### PR TITLE
Support underscores & exponentials in ints/floats

### DIFF
--- a/core/args.go
+++ b/core/args.go
@@ -593,7 +593,7 @@ func (f *IntArrRslArg) SetValue(arg string) {
 	split := strings.Split(arg, ",")
 	ints := make([]int64, len(split))
 	for i, v := range split {
-		parsed, err := strconv.ParseInt(v, 10, 64)
+		parsed, err := rts.ParseInt(v)
 		if err != nil {
 			RP.CtxErrorExit(NewCtxFromRtsNode(&f.scriptArg.Decl, fmt.Sprintf("Expected int, but could not parse: %v\n", arg)))
 		}
@@ -652,7 +652,7 @@ func (f *FloatRslArg) Register() {
 
 func (f *FloatRslArg) SetValue(arg string) {
 	f.BaseRslArg.SetValue(arg)
-	parsed, err := strconv.ParseFloat(arg, 64)
+	parsed, err := rts.ParseFloat(arg)
 	if err != nil {
 		RP.CtxErrorExit(NewCtxFromRtsNode(&f.scriptArg.Decl, fmt.Sprintf("Expected float, but could not parse: %v\n", arg)))
 	}
@@ -728,7 +728,7 @@ func (f *FloatArrRslArg) SetValue(arg string) {
 	split := strings.Split(arg, ",")
 	floats := make([]float64, len(split))
 	for i, v := range split {
-		parsed, err := strconv.ParseFloat(v, 64)
+		parsed, err := rts.ParseFloat(v)
 		if err != nil {
 			RP.CtxErrorExit(NewCtxFromRtsNode(&f.scriptArg.Decl, fmt.Sprintf("Expected float, but could not parse: %v\n", arg)))
 		}

--- a/core/funcs.go
+++ b/core/funcs.go
@@ -2,12 +2,12 @@ package core
 
 import (
 	"fmt"
+	"github.com/amterp/rts"
 	"math"
 	"os"
 	"path/filepath"
 	com "rad/core/common"
 	"sort"
-	"strconv"
 	"strings"
 
 	"github.com/samber/lo"
@@ -449,7 +449,7 @@ func init() {
 				arg := f.args[0]
 
 				str := arg.value.RequireStr(f.i, arg.node).Plain()
-				parsed, err := strconv.ParseInt(str, 10, 64)
+				parsed, err := rts.ParseInt(str)
 
 				if err == nil {
 					if f.numExpectedOutputs == 1 {
@@ -479,7 +479,7 @@ func init() {
 				arg := f.args[0]
 
 				str := arg.value.RequireStr(f.i, arg.node).Plain()
-				parsed, err := strconv.ParseFloat(str, 64)
+				parsed, err := rts.ParseFloat(str)
 
 				if err == nil {
 					if f.numExpectedOutputs == 1 {

--- a/core/interpreter.go
+++ b/core/interpreter.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"fmt"
+	rts "github.com/amterp/rts"
 	com "rad/core/common"
 	"runtime/debug"
 	"strconv"
@@ -309,12 +310,12 @@ func (i *Interpreter) unsafeEval(node *ts.Node, numExpectedOutputs int) []RslVal
 	case K_INT:
 		i.assertExpectedNumOutputs(node, numExpectedOutputs, 1)
 		asStr := i.sd.Src[node.StartByte():node.EndByte()]
-		asInt, _ := strconv.ParseInt(asStr, 10, 64) // todo unhandled err
+		asInt, _ := rts.ParseInt(asStr) // todo unhandled err
 		return newRslValues(i, node, asInt)
 	case K_FLOAT:
 		i.assertExpectedNumOutputs(node, numExpectedOutputs, 1)
 		asStr := i.sd.Src[node.StartByte():node.EndByte()]
-		asFloat, _ := strconv.ParseFloat(asStr, 64) // todo unhandled err
+		asFloat, _ := rts.ParseFloat(asStr) // todo unhandled err
 		return newRslValues(i, node, asFloat)
 	case K_STRING:
 		i.assertExpectedNumOutputs(node, numExpectedOutputs, 1)

--- a/core/rsl_func_sleep.go
+++ b/core/rsl_func_sleep.go
@@ -1,7 +1,7 @@
 package core
 
 import (
-	"strconv"
+	"github.com/amterp/rts"
 	"strings"
 	"time"
 
@@ -28,7 +28,7 @@ var FuncSleep = Func{
 		case RslString:
 			durStr := strings.Replace(coerced.Plain(), " ", "", -1)
 
-			floatVal, err := strconv.ParseFloat(durStr, 64)
+			floatVal, err := rts.ParseFloat(durStr)
 			if err == nil {
 				sleep(f.i, arg.node, time.Duration(floatVal*1000)*time.Millisecond, f.namedArgs)
 				return EMPTY

--- a/core/testing/exponential_nums_test.go
+++ b/core/testing/exponential_nums_test.go
@@ -1,0 +1,43 @@
+package testing
+
+import "testing"
+
+func Test_NumExponential_CanWrite(t *testing.T) {
+	rsl := `
+print(1.0e9)
+print(1e9)
+print(1E1_8)
+print(1.2e9)
+print(12.3e9)
+print(12.3e1_8)
+print(1.23e-1_8)
+print(12.3e-1_9)
+`
+	setupAndRunCode(t, rsl, "--color=never")
+	expected := `1000000000
+1000000000
+1000000000000000000
+1200000000
+12300000000
+12300000000000000000
+0.00000000000000000123
+0.00000000000000000123
+`
+	assertOnlyOutput(t, stdOutBuffer, expected)
+	assertNoErrors(t)
+}
+
+func Test_NumExponential_CanUseInArgs(t *testing.T) {
+	rsl := `
+args:
+    a float = 2e3
+    a range [1e3, 3e3]
+`
+	setupAndRunCode(t, rsl, "4000", "--color=never")
+	expected := `Error at L3:5
+
+      a float = 2e3
+      ^^^^^^^^^^^^^ 'a' value 4000 is > maximum 3000
+`
+	assertError(t, 1, expected)
+}

--- a/core/testing/underscore_nums_test.go
+++ b/core/testing/underscore_nums_test.go
@@ -1,0 +1,54 @@
+package testing
+
+import "testing"
+
+func Test_NumUnderscores_CanWrite(t *testing.T) {
+	rsl := `
+print(1_234)
+print(0.123_456)
+print(12_34.56_78)
+`
+	setupAndRunCode(t, rsl, "--color=never")
+	expected := `1234
+0.123456
+1234.5678
+`
+	assertOnlyOutput(t, stdOutBuffer, expected)
+	assertNoErrors(t)
+}
+
+func Test_NumUnderscores_CanUseInArgs(t *testing.T) {
+	rsl := `
+args:
+  a int = 1_234
+  b float = 0.123_456
+
+  a range [1_000, 2_000]
+
+print(a, b)
+`
+	setupAndRunCode(t, rsl, "--color=never")
+	expected := `1234 0.123456
+`
+	assertOnlyOutput(t, stdOutBuffer, expected)
+	assertNoErrors(t)
+}
+
+func Test_NumUnderscores_CanUseInArgs_Range(t *testing.T) {
+	rsl := `
+args:
+  a int = 1_234
+  b float = 0.123_456
+
+  a range [1_000, 2_000]
+
+print(a, b)
+`
+	setupAndRunCode(t, rsl, "3000", "--color=never")
+	expected := `Error at L3:3
+
+    a int = 1_234
+    ^^^^^^^^^^^^^ 'a' value 3000 is > maximum 2000
+`
+	assertError(t, 1, expected)
+}

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ toolchain go1.24.1
 
 require (
 	github.com/amterp/go-tbl v0.9.0
-	github.com/amterp/rts v0.0.18
+	github.com/amterp/rts v0.0.19
 	github.com/charmbracelet/huh v0.6.0
 	github.com/dustin/go-humanize v1.0.1
 	github.com/fatih/color v1.18.0
@@ -23,7 +23,7 @@ require (
 )
 
 require (
-	github.com/amterp/tree-sitter-rsl v0.0.23 // indirect
+	github.com/amterp/tree-sitter-rsl v0.0.24 // indirect
 	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/catppuccin/go v0.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,10 +2,10 @@ github.com/MakeNowJust/heredoc v1.0.0 h1:cXCdzVdstXyiTqTvfqk9SDHpKNjxuom+DOlyEeQ
 github.com/MakeNowJust/heredoc v1.0.0/go.mod h1:mG5amYoWBHf8vpLOuehzbGGw0EHxpZZ6lCpQ4fNJ8LE=
 github.com/amterp/go-tbl v0.9.0 h1:eh5bE1RbVKK6tN/FOjsotBNCF4+wvJSsH3HHw2t+Cb4=
 github.com/amterp/go-tbl v0.9.0/go.mod h1:py0viOYEcyfO0Po/EdCW8Tgg7/LXecf6nBlqQFlrOZ8=
-github.com/amterp/rts v0.0.18 h1:QSO/HbP7JwGdGb/V2ULBOHFP+71jQsRvf2EK+8l6A+c=
-github.com/amterp/rts v0.0.18/go.mod h1:Rmw5aHYKwYynrnsBuWwOumEldlCzkWIJMT2Rhrh9JYQ=
-github.com/amterp/tree-sitter-rsl v0.0.23 h1:9m6aL0Y5Rd3mrynlIJQVcYVUAkyS3aWt/No58nLN3+g=
-github.com/amterp/tree-sitter-rsl v0.0.23/go.mod h1:mI2TUxkQL+7CCjrMdU5TA5xy6W1LB6mpCmyy7sDUFCY=
+github.com/amterp/rts v0.0.19 h1:VZ1j9+McR8Ph6Cd2K4h2vnhjF2srXotGGnPnqyFr2Zs=
+github.com/amterp/rts v0.0.19/go.mod h1:vDtT5G2MjPMm2LsFIhApLCWv3fBGZF8UAceNMYKzRhg=
+github.com/amterp/tree-sitter-rsl v0.0.24 h1:AwVoocmD4CHBxLHb5Ny30Ffk9H4tITmvxT4ZQV9RL/8=
+github.com/amterp/tree-sitter-rsl v0.0.24/go.mod h1:mI2TUxkQL+7CCjrMdU5TA5xy6W1LB6mpCmyy7sDUFCY=
 github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z4=
 github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=


### PR DESCRIPTION
Pretty common in languages, makes writing and reading larger numbers easier.

Examples: 1_234, 1e9, 1.23e9_8

Closes #16, #17.

Most of the changes are made in the RTS and Tree Sitter repos.