### PR TITLE
feat(repl): implement REPL

### DIFF
--- a/core/flags_global.go
+++ b/core/flags_global.go
@@ -21,6 +21,8 @@ const (
 	FLAG_SRC_TREE      = "src-tree"
 	FLAG_RAD_ARGS_DUMP = "rad-args-dump"
 	FLAG_MOCK_RESPONSE = "mock-response"
+	FLAG_REPL          = "repl"
+	FLAG_R             = "r"
 )
 
 var (
@@ -39,6 +41,7 @@ var (
 	FlagRadTree              BoolRadArg
 	FlagRadArgsDump          BoolRadArg
 	FlagMockResponse         StringRadArg
+	FlagRepl                 BoolRadArg
 	// ^ when adding more, update ResetGlobals function
 )
 
@@ -56,6 +59,17 @@ func CreateAndRegisterGlobalFlags() []RadArg {
 		NO_CONSTRAINTS,
 	)
 	flags = append(flags, &FlagHelp)
+
+	FlagRepl = NewBoolRadArg(
+		FLAG_REPL,
+		FLAG_R,
+		"Start interactive REPL mode.",
+		false,
+		false,
+		NO_CONSTRAINTS,
+		NO_CONSTRAINTS,
+	)
+	flags = append(flags, &FlagRepl)
 
 	FlagDebug = NewBoolRadArg(
 		FLAG_DEBUG,

--- a/core/global.go
+++ b/core/global.go
@@ -76,6 +76,7 @@ func ResetGlobals() {
 	FlagRadTree = BoolRadArg{}
 	FlagRadArgsDump = BoolRadArg{}
 	FlagMockResponse = StringRadArg{}
+	FlagRepl = BoolRadArg{}
 
 	color.NoColor = false
 }

--- a/core/repl.go
+++ b/core/repl.go
@@ -1,0 +1,69 @@
+package core
+
+import (
+	"fmt"
+	"io"
+)
+
+// CreateReplSession creates a new REPL session with default configuration
+func CreateReplSession() (ReplSession, error) {
+	// Skeleton implementation
+	interpreter := NewInterpreter(&ScriptData{
+		// Empty script data for REPL mode
+	})
+
+	interpreter.InitBuiltIns()
+
+	inputReader := NewSingleLineInputReader()
+	session := NewReplSession(interpreter, inputReader)
+
+	return session, nil
+}
+
+// RunRepl is the main entry point for REPL mode
+func RunRepl() error {
+	session, err := CreateReplSession()
+	if err != nil {
+		return fmt.Errorf("failed to create REPL session: %w", err)
+	}
+
+	defer func() {
+		if shutdownErr := session.Shutdown(); shutdownErr != nil {
+			RP.Printf("Warning: REPL shutdown error: %v\n", shutdownErr)
+		}
+	}()
+
+	return session.Run()
+}
+
+// shouldPrintResult determines if an execution result should be auto-printed
+func shouldPrintResult(result *ExecutionResult) bool {
+	if result.Error != nil {
+		return false // Errors are handled separately
+	}
+
+	if result.Value == VOID_SENTINEL {
+		return false // No value to print
+	}
+
+	// Use the ShouldPrint flag determined during execution
+	return result.ShouldPrint
+}
+
+// printWelcomeBanner prints the REPL welcome message
+func printWelcomeBanner() {
+	RP.Printf("🤙 Rad REPL %s\n", Version)
+	RP.Printf("Type 'exit()' to quit.\n\n")
+}
+
+// handleReplError handles and displays REPL-specific errors
+func handleReplError(err error) {
+	if err == io.EOF {
+		// Ctrl+D - clean exit
+		RP.Printf("\n")
+		return
+	}
+
+	// Format error message appropriately
+	RP.Printf("Error: %v\n", err)
+}

--- a/core/repl_input.go
+++ b/core/repl_input.go
@@ -1,0 +1,70 @@
+package core
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"strings"
+)
+
+// SingleLineInputReader implements InputReader for single-line input (MVP)
+// Uses RadIo abstractions for full testability
+type SingleLineInputReader struct {
+	reader             *bufio.Scanner
+	primaryPrompt      string
+	continuationPrompt string // unused in MVP, but ready for future multi-line support
+	writer             io.Writer
+}
+
+// NewSingleLineInputReader creates a new single-line input reader using RadIo
+func NewSingleLineInputReader() InputReader {
+	return &SingleLineInputReader{
+		reader:             bufio.NewScanner(RIo.StdIn.Unwrap()),
+		primaryPrompt:      "> ",
+		continuationPrompt: "... ", // ready for future use
+		writer:             RIo.StdOut,
+	}
+}
+
+// ReadStatement reads a single line of input from the user
+func (r *SingleLineInputReader) ReadStatement() (string, error) {
+	fmt.Fprint(r.writer, r.primaryPrompt)
+	if !r.reader.Scan() {
+		// Handle EOF or error
+		if err := r.reader.Err(); err != nil {
+			return "", err
+		}
+		// EOF (Ctrl+D) - return special error to signal exit
+		return "", io.EOF
+	}
+
+	line := strings.TrimSpace(r.reader.Text())
+	return line, nil
+}
+
+// SupportsMultiLine returns false for MVP (single-line only)
+func (r *SingleLineInputReader) SupportsMultiLine() bool {
+	return false
+}
+
+// SetPrompt allows customizing the prompts
+func (r *SingleLineInputReader) SetPrompt(primary, continuation string) {
+	r.primaryPrompt = primary
+	r.continuationPrompt = continuation
+}
+
+// Shutdown cleans up resources
+func (r *SingleLineInputReader) Shutdown() error {
+	return nil
+}
+
+// Future: ReadlineInputReader for enhanced input with history
+// This interface design allows us to swap in a readline-based implementation later
+type ReadlineInputReader struct {
+	// todo: Will implement with github.com/chzyer/readline
+	// todo: Command history support
+	// todo: Multi-line input support
+	// todo: Tab completion hooks
+}
+
+// todo: Implement ReadlineInputReader methods when adding enhanced features

--- a/core/repl_session.go
+++ b/core/repl_session.go
@@ -1,0 +1,139 @@
+package core
+
+import (
+	"io"
+	"strings"
+)
+
+// Core REPL contracts and interfaces following maintainability-first design
+
+// ReplSession represents the main REPL session contract
+type ReplSession interface {
+	Run() error
+	ExecuteStatement(input string) (*ExecutionResult, error)
+	GetEnvironment() *Env
+	Shutdown() error
+}
+
+// InputReader abstracts input handling (designed for future multi-line extension)
+type InputReader interface {
+	ReadStatement() (string, error)
+	SupportsMultiLine() bool
+	SetPrompt(primary, continuation string)
+	Shutdown() error
+}
+
+// ExecutionResult represents the result of executing a statement
+type ExecutionResult struct {
+	Value       RadValue
+	ShouldPrint bool
+	Error       *RadError
+}
+
+// NewExecutionResult creates a new execution result
+func NewExecutionResult(value RadValue, shouldPrint bool, err *RadError) *ExecutionResult {
+	return &ExecutionResult{
+		Value:       value,
+		ShouldPrint: shouldPrint,
+		Error:       err,
+	}
+}
+
+// DefaultReplSession implements the ReplSession interface
+type DefaultReplSession struct {
+	interpreter *Interpreter
+	inputReader InputReader
+	// todo: Add session state (history, etc.)
+}
+
+// NewReplSession creates a new REPL session with the given interpreter and input reader
+func NewReplSession(interpreter *Interpreter, inputReader InputReader) ReplSession {
+	return &DefaultReplSession{
+		interpreter: interpreter,
+		inputReader: inputReader,
+	}
+}
+
+// Run starts the main REPL loop
+func (s *DefaultReplSession) Run() error {
+	printWelcomeBanner()
+
+	// Set default prompts
+	s.inputReader.SetPrompt("> ", "... ")
+
+	// Main read-eval-print loop
+	for {
+		// Read input from user
+		input, err := s.inputReader.ReadStatement()
+		if err != nil {
+			handleReplError(err)
+			if err == io.EOF {
+				// Ctrl+D - clean exit
+				break
+			}
+			continue
+		}
+
+		// Skip empty input
+		if strings.TrimSpace(input) == "" {
+			continue
+		}
+
+		// Check for exit command
+		if strings.TrimSpace(input) == "exit()" {
+			break
+		}
+
+		// Execute the statement
+		result, err := s.ExecuteStatement(input)
+		if err != nil {
+			handleReplError(err)
+			continue
+		}
+
+		// Handle execution result
+		if result.Error != nil {
+			// result.Error is a *RadError, format it properly
+			RP.Printf("Error: %v\n", result.Error.Msg().Plain())
+		} else if shouldPrintResult(result) {
+			RP.Printf("%s\n", ToPrintable(result.Value))
+		}
+	}
+
+	return nil
+}
+
+// ExecuteStatement executes a single statement and returns the result
+func (s *DefaultReplSession) ExecuteStatement(input string) (*ExecutionResult, error) {
+	// Use the new EvaluateStatement API on our persistent interpreter
+	resultValue, err := s.interpreter.EvaluateStatement(input)
+	if err != nil {
+		// Convert Go error to RadError for consistent error handling
+		radErr := NewErrorStrf("Execution error: %v", err)
+		return NewExecutionResult(RAD_NULL_VAL, false, radErr), nil
+	}
+
+	// Determine if result should be printed
+	// For MVP: print expressions that return values, don't print assignments or print statements
+
+	shouldPrint := resultValue != VOID_SENTINEL
+
+	return NewExecutionResult(resultValue, shouldPrint, nil), nil
+}
+
+// GetEnvironment returns the current interpreter environment
+func (s *DefaultReplSession) GetEnvironment() *Env {
+	return s.interpreter.env
+}
+
+// Shutdown performs cleanup when REPL session ends
+func (s *DefaultReplSession) Shutdown() error {
+	// Clean up input reader
+	if err := s.inputReader.Shutdown(); err != nil {
+		return err
+	}
+
+	// todo: (maybe) save command history to file
+
+	return nil
+}

--- a/core/runner.go
+++ b/core/runner.go
@@ -21,6 +21,7 @@ const (
 	ScriptFile                            // existing file
 	StdinScript                           // "rad -"
 	EmbeddedCommand                       // built-in commands
+	Repl                                  // interactive REPL mode
 )
 
 type RadRunner struct {
@@ -257,6 +258,11 @@ func (r *RadRunner) parseAndExecute(invocationType InvocationType) error {
 		RExit(0)
 	}
 
+	// Handle REPL mode (but not if help is requested)
+	if FlagRepl.Value && !FlagHelp.Value {
+		return r.runRepl()
+	}
+
 	// Handle global-only invocations
 	if invocationType == NoScript {
 		unknownArgs := RRootCmd.GetUnknownArgs()
@@ -348,4 +354,9 @@ func (r *RadRunner) createAndRegisterScriptArgs() []RadArg {
 func readSource(scriptPath string) (string, error) {
 	source, err := os.ReadFile(scriptPath)
 	return string(source), err
+}
+
+// runRepl starts the interactive REPL mode
+func (r *RadRunner) runRepl() error {
+	return RunRepl()
 }

--- a/core/testing/misc_test.go
+++ b/core/testing/misc_test.go
@@ -154,6 +154,7 @@ args:
 	setupAndRunCode(t, script, "--color=never", "--help")
 	expectedGlobalFlags := `Global options:
   -h, --help            Print usage string.
+  -r, --repl            Start interactive REPL mode.
   -d                    Enables debug output. Intended for Rad script developers.
       --color mode      Control output colorization. Valid values: [auto, always, never] (default auto)
   -q, --quiet           Suppresses some output.
@@ -179,6 +180,7 @@ args:
 	setupAndRunCode(t, script, "--color=never", "--help")
 	expectedGlobalFlags := `Global options:
   -h, --help            Print usage string.
+  -r, --repl            Start interactive REPL mode.
   -d, --debug           Enables debug output. Intended for Rad script developers.
       --color mode      Control output colorization. Valid values: [auto, always, never] (default auto)
       --quiet           Suppresses some output.

--- a/core/testing/repl_test.go
+++ b/core/testing/repl_test.go
@@ -1,0 +1,222 @@
+package testing
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	"github.com/amterp/rad/core"
+	"github.com/stretchr/testify/assert"
+)
+
+// Example of how REPL testing will work once implementation is complete
+// This demonstrates the testability architecture using existing RadIo patterns
+
+func replBanner() string {
+	return fmt.Sprintf("🤙 Rad REPL %s\nType 'exit()' to quit.\n\n", core.Version)
+}
+
+func setupReplTest(t *testing.T, inputs []string) (*bytes.Buffer, *bytes.Buffer) {
+	t.Helper()
+
+	// Reset test state
+	resetTestState()
+	core.IsTest = true
+
+	// Write REPL inputs to stdin buffer
+	for _, input := range inputs {
+		stdInBuffer.WriteString(input + "\n")
+	}
+
+	// Set up args to trigger REPL mode
+	args := []string{"--repl"}
+	runner := setupRunner(t, args...)
+
+	// Run with REPL flag (will use our injected I/O)
+	err := runner.Run()
+	assert.NoError(t, err, "REPL should execute without error")
+
+	return stdOutBuffer, stdErrBuffer
+}
+
+func TestRepl_BasicSession(t *testing.T) {
+	inputs := []string{
+		`name = "alice"`,
+		`print("Hello {name}!")`,
+		`age = 25`,
+		`print(age)`,
+		`exit()`,
+	}
+
+	stdOut, stdErr := setupReplTest(t, inputs)
+
+	expected := fmt.Sprintf(`🤙 Rad REPL %s
+Type 'exit()' to quit.
+
+> > Hello alice!
+> > 25
+> `, core.Version)
+
+	assertOutput(t, stdOut, expected)
+	assert.Empty(t, stdErr.String())
+}
+
+func TestRepl_EnvironmentPersistence(t *testing.T) {
+	inputs := []string{
+		`x = 10`,
+		`y = 20`,
+		`print(x + y)`,
+		`x = x * 2`,
+		`print(x)`,
+		`exit()`,
+	}
+
+	stdOut, stdErr := setupReplTest(t, inputs)
+
+	expected := replBanner() + `> > > 30
+> > 20
+> `
+
+	assertOutput(t, stdOut, expected)
+	assert.Empty(t, stdErr.String())
+}
+
+func TestRepl_IncompleteStatementHandling(t *testing.T) {
+	inputs := []string{
+		`if x > 5:`,
+		`x = 10`,
+		`print(x)`,
+		`exit()`,
+	}
+
+	stdOut, stdErr := setupReplTest(t, inputs)
+
+	// Incomplete statements cause parse errors but REPL continues
+	expected := replBanner() + `> Error: Execution error: parse error in statement: if x > 5:
+> > 10
+> `
+
+	assertOutput(t, stdOut, expected)
+	assert.Empty(t, stdErr.String())
+}
+
+func TestRepl_ErrorRecovery(t *testing.T) {
+	inputs := []string{
+		`x = 5`,
+		`y = undefined_variable`, // This should error
+		`print(x)`,               // But this should still work
+		`exit()`,
+	}
+
+	stdOut, stdErr := setupReplTest(t, inputs)
+
+	// Check the basic REPL functionality and that x variable persists
+	output := stdOut.String()
+	assert.Contains(t, output, "🤙 Rad REPL", "Should show welcome banner")
+	assert.Contains(t, output, "5", "Should print x value after error")
+
+	// Runtime errors go to stderr in Rad, so check that stderr contains error
+	errorOutput := stdErr.String()
+	assert.Contains(t, errorOutput, "undefined_variable", "Should show undefined variable error in stderr")
+	assert.Contains(t, errorOutput, "Undefined variable", "Should show error message in stderr")
+}
+
+func TestRepl_EmptyInputHandling(t *testing.T) {
+	inputs := []string{
+		``,   // Empty line
+		`  `, // Whitespace only
+		`x = 1`,
+		`print(x)`,
+		`exit()`,
+	}
+
+	stdOut, stdErr := setupReplTest(t, inputs)
+
+	expected := replBanner() + `> > > > 1
+> `
+
+	assertOutput(t, stdOut, expected)
+	assert.Empty(t, stdErr.String())
+}
+
+// Test the key feature: expression auto-printing
+func TestRepl_ExpressionAutoPrinting(t *testing.T) {
+	inputs := []string{
+		`2 + 3`,   // Should auto-print
+		`10 * 4`,  // Should auto-print
+		`x = 100`, // Assignment - no auto-print
+		`x`,       // Variable access - should auto-print
+		`x / 2`,   // Expression with variable - should auto-print
+		`exit()`,
+	}
+
+	stdOut, stdErr := setupReplTest(t, inputs)
+
+	expected := replBanner() + `> 5
+> 40
+> > 100
+> 50
+> `
+
+	assertOutput(t, stdOut, expected)
+	assert.Empty(t, stdErr.String())
+}
+
+// Test that print statements don't double-print
+func TestRepl_PrintStatementHandling(t *testing.T) {
+	inputs := []string{
+		`x = 42`,
+		`print(x)`,      // Should print 42 but not auto-print the return value
+		`print("test")`, // Should print test but not auto-print
+		`x + 1`,         // Should auto-print 43
+		`exit()`,
+	}
+
+	stdOut, stdErr := setupReplTest(t, inputs)
+
+	expected := replBanner() + `> > 42
+> test
+> 43
+> `
+
+	assertOutput(t, stdOut, expected)
+	assert.Empty(t, stdErr.String())
+}
+
+// Test complex expressions and function calls
+func TestRepl_ComplexExpressions(t *testing.T) {
+	inputs := []string{
+		`numbers = [1, 2, 3, 4, 5]`,
+		`len(numbers)`,
+		`sum(numbers)`,
+		`numbers[2]`,         // Indexing
+		`"hello" + " world"`, // String concatenation
+		`exit()`,
+	}
+
+	stdOut, stdErr := setupReplTest(t, inputs)
+
+	expected := replBanner() + `> > 5
+> 15
+> 3
+> "hello world"
+> `
+
+	assertOutput(t, stdOut, expected)
+	assert.Empty(t, stdErr.String())
+}
+
+// Test REPL exit behavior
+func TestRepl_ExitBehavior(t *testing.T) {
+	inputs := []string{
+		`x = 42`,
+		`exit()`, // Clean exit
+	}
+
+	stdOut, stdErr := setupReplTest(t, inputs)
+
+	expected := replBanner() + `> > `
+
+	assertOutput(t, stdOut, expected)
+	assert.Empty(t, stdErr.String())
+}

--- a/core/testing/test_helpers.go
+++ b/core/testing/test_helpers.go
@@ -16,6 +16,7 @@ import (
 
 const scriptGlobalFlagHelp = `Global options:
   -h, --help            Print usage string.
+  -r, --repl            Start interactive REPL mode.
   -d, --debug           Enables debug output. Intended for Rad script developers.
       --color mode      Control output colorization. Valid values: [auto, always, never] (default auto)
   -q, --quiet           Suppresses some output.
@@ -25,6 +26,7 @@ const scriptGlobalFlagHelp = `Global options:
 
 const allGlobalFlagHelp = `Global options:
   -h, --help                Print usage string.
+  -r, --repl                Start interactive REPL mode.
   -d, --debug               Enables debug output. Intended for Rad script developers.
       --rad-debug           Enables Rad debug output. Intended for Rad developers.
       --color mode          Control output colorization. Valid values: [auto, always, never] (default auto)

--- a/core/utils.go
+++ b/core/utils.go
@@ -63,6 +63,8 @@ func ToPrintableQuoteStr(val interface{}, quoteStrings bool) string {
 		return "null"
 	case *RadError:
 		return ToPrintableQuoteStr(coerced.Msg().String(), quoteStrings)
+	case nil:
+		return "null"
 	default:
 		RP.RadErrorExit(fmt.Sprintf("Bug! Unhandled type for printable: %T", val))
 		panic(UNREACHABLE)


### PR DESCRIPTION
Rad does not have a repl mode at the moment! This commit fixes that, implementing a basic repl mode with a lot of bells and whistles *missing* e.g. history, multiline support. These things will come, though, as I see them as largely essential for a REPL mode we can be satisfied with shipping.