### PR TITLE
fix: returning from fn in for loop

### DIFF
--- a/core/interpreter.go
+++ b/core/interpreter.go
@@ -285,7 +285,7 @@ func (i *Interpreter) eval(node *ts.Node) (out EvalResult) {
 			i.forWhileLoopLevel--
 		}()
 		stmts := rl.GetChildren(node, rl.F_STMT)
-		i.executeForLoop(node, func() EvalResult { return i.runBlock(stmts) })
+		return i.executeForLoop(node, func() EvalResult { return i.runBlock(stmts) })
 	case rl.K_WHILE_LOOP:
 		i.forWhileLoopLevel++
 		defer func() {

--- a/core/testing/fn_return_yield_in_loop_test.go
+++ b/core/testing/fn_return_yield_in_loop_test.go
@@ -1,0 +1,81 @@
+package testing
+
+import "testing"
+
+func Test_Fn_ReturnInForLoop(t *testing.T) {
+	script := `
+fn foo():
+    for i in range(5):
+        return 5
+
+a = foo()
+print(":{a}:")
+`
+	setupAndRunCode(t, script, "--color=never")
+	assertOnlyOutput(t, stdOutBuffer, ":5:\n")
+	assertNoErrors(t)
+}
+
+func Test_Fn_ReturnInWhileLoop(t *testing.T) {
+	script := `
+fn bar():
+    i = 0
+    while i < 5:
+        return 10
+        i = i + 1
+
+b = bar()
+print(":{b}:")
+`
+	setupAndRunCode(t, script, "--color=never")
+	assertOnlyOutput(t, stdOutBuffer, ":10:\n")
+	assertNoErrors(t)
+}
+
+func Test_Fn_ReturnDirectly_ShouldWork(t *testing.T) {
+	script := `
+fn direct():
+    return 42
+
+c = direct()
+print(":{c}:")
+`
+	setupAndRunCode(t, script, "--color=never")
+	assertOnlyOutput(t, stdOutBuffer, ":42:\n")
+	assertNoErrors(t)
+}
+
+func Test_Fn_YieldInForLoopInSwitch(t *testing.T) {
+	script := `
+result = switch "test":
+    case "test":
+        for i in range(5):
+            if i == 2:
+                yield 42
+    default:
+        yield -1
+
+print(":{result}:")
+`
+	setupAndRunCode(t, script, "--color=never")
+	assertOnlyOutput(t, stdOutBuffer, ":42:\n")
+	assertNoErrors(t)
+}
+
+func Test_Fn_YieldInNestedLoops(t *testing.T) {
+	script := `
+result = switch "nested":
+    case "nested":
+        for i in range(3):
+            for j in range(3):
+                if i == 1 and j == 1:
+                    yield "success"
+    default:
+        yield "fail"
+
+print(":{result}:")
+`
+	setupAndRunCode(t, script, "--color=never")
+	assertOnlyOutput(t, stdOutBuffer, ":success:\n")
+	assertNoErrors(t)
+}


### PR DESCRIPTION
These was a bug whereby you could not return within a for loop in a fn:

  fn foo():
      for i in range(5):
          return 5
  a = foo()

This would error because we can't assign void to 'a'... But obviously that's not what's we're trying to do, it's a bug.

Fix is simple, we were just failing to pass on the eval result from for loops.

We also test yield stmts while here.