### PR TITLE
feat: add stdin support for Unix-style piping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ test3.rad
 resource.json
 docs-web/site
 dist
+.idea
 
 ### Go ###
 # If you prefer the allow list template instead of the deny list, see community template:
@@ -38,32 +39,6 @@ dist
 ### GoLand ###
 # Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
 # Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
-
-# User-specific stuff
-.idea/**/workspace.xml
-.idea/**/tasks.xml
-.idea/**/usage.statistics.xml
-.idea/**/dictionaries
-.idea/**/shelf
-
-# AWS User-specific
-.idea/**/aws.xml
-
-# Generated files
-.idea/**/contentModel.xml
-
-# Sensitive or high-churn files
-.idea/**/dataSources/
-.idea/**/dataSources.ids
-.idea/**/dataSources.local.xml
-.idea/**/sqlDataSources.xml
-.idea/**/dynamic.xml
-.idea/**/uiDesigner.xml
-.idea/**/dbnavigator.xml
-
-# Gradle
-.idea/**/gradle.xml
-.idea/**/libraries
 
 # Gradle and Maven with auto-import
 # When using Gradle or Maven with auto-import, you should exclude module files,

--- a/core/funcs.go
+++ b/core/funcs.go
@@ -8,6 +8,7 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"fmt"
+	"io"
 	"math"
 	"os"
 	"path/filepath"
@@ -90,6 +91,8 @@ const (
 	FUNC_TRIM_SUFFIX        = "trim_suffix"
 	FUNC_READ_FILE          = "read_file"
 	FUNC_WRITE_FILE         = "write_file"
+	FUNC_READ_STDIN         = "read_stdin"
+	FUNC_HAS_STDIN          = "has_stdin"
 	FUNC_ROUND              = "round"
 	FUNC_CEIL               = "ceil"
 	FUNC_FLOOR              = "floor"
@@ -1067,6 +1070,29 @@ func init() {
 				} else {
 					return f.Return(NewErrorStrf(err.Error()).SetCode(rl.ErrFileWrite))
 				}
+			},
+		},
+		{
+			Name: FUNC_READ_STDIN,
+			Execute: func(f FuncInvocation) RadValue {
+				// Check if stdin has content (is piped)
+				if !RIo.StdIn.HasContent() {
+					return f.Return(RAD_NULL_VAL)
+				}
+
+				// Read all stdin content
+				data, err := io.ReadAll(RIo.StdIn)
+				if err != nil {
+					return f.Return(NewErrorStrf("Failed to read from stdin: %v", err).SetCode(rl.ErrStdinRead))
+				}
+
+				return f.Return(string(data))
+			},
+		},
+		{
+			Name: FUNC_HAS_STDIN,
+			Execute: func(f FuncInvocation) RadValue {
+				return f.Return(RIo.StdIn.HasContent())
 			},
 		},
 		{

--- a/core/io.go
+++ b/core/io.go
@@ -44,7 +44,8 @@ func NewFileReader(file *os.File) CheckableReader {
 }
 
 type BufferReader struct {
-	buffer *bytes.Buffer
+	buffer  *bytes.Buffer
+	isPiped bool
 }
 
 func (br *BufferReader) Read(p []byte) (n int, err error) {
@@ -52,13 +53,19 @@ func (br *BufferReader) Read(p []byte) (n int, err error) {
 }
 
 func (br *BufferReader) HasContent() bool {
-	return br.buffer.Len() > 0
+	// Return true if buffer has content OR if explicitly marked as piped
+	// This matches FileReader behavior where empty piped stdin returns true
+	return br.buffer.Len() > 0 || br.isPiped
 }
 
 func (br *BufferReader) Unwrap() io.Reader {
 	return br.buffer
 }
 
+func (br *BufferReader) SetPiped(piped bool) {
+	br.isPiped = piped
+}
+
 func NewBufferReader(buffer *bytes.Buffer) CheckableReader {
-	return &BufferReader{buffer: buffer}
+	return &BufferReader{buffer: buffer, isPiped: false}
 }

--- a/core/testing/data/wc_input.txt
+++ b/core/testing/data/wc_input.txt
@@ -1,0 +1,3 @@
+The quick brown fox
+jumps over the lazy dog.
+Hello world!

--- a/core/testing/func_has_stdin_test.go
+++ b/core/testing/func_has_stdin_test.go
@@ -1,0 +1,91 @@
+package testing
+
+import (
+	"testing"
+)
+
+func Test_Func_HasStdin_True(t *testing.T) {
+	script := `
+if has_stdin():
+    print("has stdin")
+else:
+    print("no stdin")
+`
+	tp := NewTestParams(script, "--color=never").StdinInput("some data")
+	setupAndRun(t, tp)
+	assertOnlyOutput(t, stdOutBuffer, "has stdin\n")
+	assertNoErrors(t)
+}
+
+func Test_Func_HasStdin_False(t *testing.T) {
+	script := `
+if has_stdin():
+    print("has stdin")
+else:
+    print("no stdin")
+`
+	setupAndRunCode(t, script, "--color=never")
+	assertOnlyOutput(t, stdOutBuffer, "no stdin\n")
+	assertNoErrors(t)
+}
+
+func Test_Func_HasStdin_EmptyStdin(t *testing.T) {
+	script := `
+if has_stdin():
+    print("has stdin")
+else:
+    print("no stdin")
+`
+	tp := NewTestParams(script, "--color=never").StdinInput("")
+	setupAndRun(t, tp)
+	assertOnlyOutput(t, stdOutBuffer, "has stdin\n")
+	assertNoErrors(t)
+}
+
+func Test_Func_HasStdin_CheckBeforeRead(t *testing.T) {
+	script := `
+if has_stdin():
+    content = read_stdin()
+    print("Content: {content}")
+else:
+    print("No stdin to read")
+`
+	tp := NewTestParams(script, "--color=never").StdinInput("hello")
+	setupAndRun(t, tp)
+	assertOnlyOutput(t, stdOutBuffer, "Content: hello\n")
+	assertNoErrors(t)
+}
+
+func Test_Func_HasStdin_CheckBeforeReadNoData(t *testing.T) {
+	script := `
+if has_stdin():
+    content = read_stdin()
+    print("Content: {content}")
+else:
+    print("No stdin to read")
+`
+	setupAndRunCode(t, script, "--color=never")
+	assertOnlyOutput(t, stdOutBuffer, "No stdin to read\n")
+	assertNoErrors(t)
+}
+
+func Test_Func_HasStdin_Assignment(t *testing.T) {
+	script := `
+has_data = has_stdin()
+print("Has stdin: {has_data}")
+`
+	tp := NewTestParams(script, "--color=never").StdinInput("data")
+	setupAndRun(t, tp)
+	assertOnlyOutput(t, stdOutBuffer, "Has stdin: true\n")
+	assertNoErrors(t)
+}
+
+func Test_Func_HasStdin_AssignmentNoData(t *testing.T) {
+	script := `
+has_data = has_stdin()
+print("Has stdin: {has_data}")
+`
+	setupAndRunCode(t, script, "--color=never")
+	assertOnlyOutput(t, stdOutBuffer, "Has stdin: false\n")
+	assertNoErrors(t)
+}

--- a/core/testing/func_read_stdin_test.go
+++ b/core/testing/func_read_stdin_test.go
@@ -1,0 +1,146 @@
+package testing
+
+import (
+	"testing"
+)
+
+func Test_Func_ReadStdin_Basic(t *testing.T) {
+	script := `
+content = read_stdin()
+print(content)
+`
+	tp := NewTestParams(script, "--color=never").StdinInput("hello from stdin")
+	setupAndRun(t, tp)
+	assertOnlyOutput(t, stdOutBuffer, "hello from stdin\n")
+	assertNoErrors(t)
+}
+
+func Test_Func_ReadStdin_MultiLine(t *testing.T) {
+	script := `
+content = read_stdin()
+print(content)
+`
+	tp := NewTestParams(script, "--color=never").StdinInput("line1\nline2\nline3")
+	setupAndRun(t, tp)
+	assertOnlyOutput(t, stdOutBuffer, "line1\nline2\nline3\n")
+	assertNoErrors(t)
+}
+
+func Test_Func_ReadStdin_Empty(t *testing.T) {
+	script := `
+content = read_stdin()
+if content == null:
+    print("content: null")
+else:
+    print("content: '{content}'")
+`
+	tp := NewTestParams(script, "--color=never").StdinInput("")
+	setupAndRun(t, tp)
+	assertOnlyOutput(t, stdOutBuffer, "content: ''\n")
+	assertNoErrors(t)
+}
+
+func Test_Func_ReadStdin_NoStdin(t *testing.T) {
+	script := `
+content = read_stdin()
+print("content: {content}")
+`
+	setupAndRunCode(t, script, "--color=never")
+	assertOnlyOutput(t, stdOutBuffer, "content: null\n")
+	assertNoErrors(t)
+}
+
+func Test_Func_ReadStdin_WithSpecialChars(t *testing.T) {
+	script := `
+content = read_stdin()
+print(content)
+`
+	tp := NewTestParams(script, "--color=never").StdinInput("hello\tworld\n!@#$%^&*()")
+	setupAndRun(t, tp)
+	assertOnlyOutput(t, stdOutBuffer, "hello\tworld\n!@#$%^&*()\n")
+	assertNoErrors(t)
+}
+
+func Test_Func_ReadStdin_CanCheckNull(t *testing.T) {
+	script := `
+content = read_stdin()
+if content == null:
+    print("no stdin")
+else:
+    print("got stdin: {content}")
+`
+	setupAndRunCode(t, script, "--color=never")
+	assertOnlyOutput(t, stdOutBuffer, "no stdin\n")
+	assertNoErrors(t)
+}
+
+func Test_Func_ReadStdin_CanCheckNullWithData(t *testing.T) {
+	script := `
+content = read_stdin()
+if content == null:
+    print("no stdin")
+else:
+    print("got stdin: {content}")
+`
+	tp := NewTestParams(script, "--color=never").StdinInput("data here")
+	setupAndRun(t, tp)
+	assertOnlyOutput(t, stdOutBuffer, "got stdin: data here\n")
+	assertNoErrors(t)
+}
+
+func Test_Func_ReadStdin_LongInput(t *testing.T) {
+	script := `
+content = read_stdin()
+print(len(content))
+`
+	longInput := ""
+	for i := 0; i < 1000; i++ {
+		longInput += "abcdefghij"
+	}
+	tp := NewTestParams(script, "--color=never").StdinInput(longInput)
+	setupAndRun(t, tp)
+	assertOnlyOutput(t, stdOutBuffer, "10000\n")
+	assertNoErrors(t)
+}
+
+func Test_Func_ReadStdin_ProcessLines(t *testing.T) {
+	script := `
+content = read_stdin()
+if content == null:
+    exit(1)
+
+lines = split(content, "\n")
+for line in lines:
+    if line != "":
+        print("Line: {line}")
+`
+	tp := NewTestParams(script, "--color=never").StdinInput("first\nsecond\nthird")
+	setupAndRun(t, tp)
+	expected := `Line: first
+Line: second
+Line: third
+`
+	assertOnlyOutput(t, stdOutBuffer, expected)
+	assertNoErrors(t)
+}
+
+func Test_Func_ReadStdin_MultipleReads(t *testing.T) {
+	script := `
+first = read_stdin()
+second = read_stdin()
+
+print("first: '{first}'")
+print("second: '{second}'")
+print("first is null: {first == null}")
+print("second is null: {second == null}")
+`
+	tp := NewTestParams(script, "--color=never").StdinInput("test data")
+	setupAndRun(t, tp)
+	expected := `first: 'test data'
+second: ''
+first is null: false
+second is null: false
+`
+	assertOnlyOutput(t, stdOutBuffer, expected)
+	assertNoErrors(t)
+}

--- a/core/testing/func_stdin_integration_test.go
+++ b/core/testing/func_stdin_integration_test.go
@@ -1,0 +1,74 @@
+package testing
+
+import (
+	"os"
+	"testing"
+)
+
+func Test_Stdin_Integration_WC_Basic(t *testing.T) {
+	// Read the test input file
+	inputData, err := os.ReadFile("data/wc_input.txt")
+	if err != nil {
+		t.Fatalf("Failed to read test input: %v", err)
+	}
+
+	// Create test params with script file and stdin input
+	tp := NewTestParams("", "./rad_scripts/wc.rad", "--color=never").StdinInput(string(inputData))
+	setupAndRun(t, tp)
+
+	// The wc_input.txt file has:
+	// - 3 lines
+	// - 11 words
+	// - 57 characters (including newlines)
+	assertOnlyOutput(t, stdOutBuffer, "3 11 57\n")
+	assertNoErrors(t)
+}
+
+func Test_Stdin_Integration_WC_LinesOnly(t *testing.T) {
+	// Read the test input file
+	inputData, err := os.ReadFile("data/wc_input.txt")
+	if err != nil {
+		t.Fatalf("Failed to read test input: %v", err)
+	}
+
+	// Test with -l flag
+	tp := NewTestParams("", "./rad_scripts/wc.rad", "--color=never", "-l").StdinInput(string(inputData))
+	setupAndRun(t, tp)
+
+	assertOnlyOutput(t, stdOutBuffer, "3\n")
+	assertNoErrors(t)
+}
+
+func Test_Stdin_Integration_WC_LinesOnlyLongFlag(t *testing.T) {
+	// Read the test input file
+	inputData, err := os.ReadFile("data/wc_input.txt")
+	if err != nil {
+		t.Fatalf("Failed to read test input: %v", err)
+	}
+
+	// Test with --lines flag
+	tp := NewTestParams("", "./rad_scripts/wc.rad", "--color=never", "--lines").StdinInput(string(inputData))
+	setupAndRun(t, tp)
+
+	assertOnlyOutput(t, stdOutBuffer, "3\n")
+	assertNoErrors(t)
+}
+
+func Test_Stdin_Integration_WC_NoStdin(t *testing.T) {
+	// Test error when no stdin provided
+	tp := NewTestParams("", "./rad_scripts/wc.rad", "--color=never")
+	setupAndRun(t, tp)
+
+	assertOutput(t, stdErrBuffer, "wc: no input\n")
+	assertExitCode(t, 1)
+}
+
+func Test_Stdin_Integration_WC_EmptyStdin(t *testing.T) {
+	// Test with empty stdin
+	tp := NewTestParams("", "./rad_scripts/wc.rad", "--color=never").StdinInput("")
+	setupAndRun(t, tp)
+
+	// Empty input should give 1 empty line, 0 words, 0 chars
+	assertOnlyOutput(t, stdOutBuffer, "1 0 0\n")
+	assertNoErrors(t)
+}

--- a/core/testing/rad_scripts/wc.rad
+++ b/core/testing/rad_scripts/wc.rad
@@ -1,0 +1,34 @@
+#!/usr/bin/env rad
+---
+Count lines, words, and characters from stdin
+---
+args:
+    lines l bool
+
+if not has_stdin():
+    print_err("wc: no input")
+    exit(1)
+
+content = read_stdin()
+
+// Count lines
+line_list = content.split("\n")
+line_count = len(line_list)
+
+// If -l flag, only print line count
+if lines:
+    print(line_count)
+    exit(0)
+
+// Count words
+word_count = 0
+for line in line_list:
+    trimmed = line.trim()
+    if trimmed != "":
+        words = trimmed.split(" ")
+        word_count += len(words)
+
+// Character count (includes newlines)
+char_count = len(content)
+
+print("{line_count} {word_count} {char_count}")

--- a/docs-web/docs/reference/functions.md
+++ b/docs-web/docs/reference/functions.md
@@ -1417,6 +1417,37 @@ if err:
     print("Write failed:", err.msg)
 ```
 
+### read_stdin
+
+Reads all data from stdin.
+
+```rad
+read_stdin() -> str?|error
+```
+
+```rad
+read_stdin()                  // -> "piped content" (if piped)
+read_stdin()                  // -> null (if not piped)
+read_stdin()                  // -> Error 20026 if read fails
+content = read_stdin()
+lines = content.split("\n")   // Process stdin line-by-line
+```
+
+### has_stdin
+
+Checks if stdin is piped to the script.
+
+```rad
+has_stdin() -> bool
+```
+
+```rad
+has_stdin()                     // -> true (if piped)
+has_stdin()                     // -> false (if not piped)
+if has_stdin():
+  content = read_stdin()        // Conditional read
+```
+
 ### get_path
 
 Gets information about a file or directory path.

--- a/lsp-server/com/embedded/functions.txt
+++ b/lsp-server/com/embedded/functions.txt
@@ -30,6 +30,7 @@ get_path
 get_rad_home
 get_stash_dir
 green
+has_stdin
 hash
 http_connect
 http_delete
@@ -76,6 +77,7 @@ rand
 rand_int
 range
 read_file
+read_stdin
 red
 replace
 reverse

--- a/rts/rl/errors.go
+++ b/rts/rl/errors.go
@@ -40,6 +40,7 @@ const (
 	ErrSleepStr                   = "20023"
 	ErrInvalidRegex               = "20024"
 	ErrColorizeValNotInEnum       = "20025"
+	ErrStdinRead                  = "20026"
 
 	// 3xxxx Type Errors?
 

--- a/rts/signatures.go
+++ b/rts/signatures.go
@@ -81,6 +81,8 @@ func init() {
 		newFnSignature(`trim_suffix(_subject: str, _to_trim: str = " \t\n") -> str`),
 		newFnSignature(`read_file(_path: str, *, mode: ["text", "bytes"] = "text") -> error|{ "size_bytes": int, "content": str|[int] }`),
 		newFnSignature(`write_file(_path: str, _content: str, *, append: bool = false) -> error|{ "bytes_written": int, "path": str }`),
+		newFnSignature(`read_stdin() -> str?|error`),
+		newFnSignature(`has_stdin() -> bool`),
 		newFnSignature(`round(_num: float, _decimals: int = 0) -> error|int|float`),
 		newFnSignature(`ceil(_num: float) -> int`),
 		newFnSignature(`floor(_num: float) -> int`),


### PR DESCRIPTION
Adds read_stdin() and has_stdin() built-in functions to enable Rad scripts to work with stdin, making them composable with Unix pipes.

This lets you do things like `cat file.txt | rad script.rad` or build filters that process piped input.

We defer the creation of streaming stdin functions like reading them line-by-line, as this will need the introduction of iterators into Rad, which we definitely want, but is a bit more involved.

==  Functions  ==

`read_stdin() -> str?|error`: Reads all stdin content. Returns null if nothing piped, empty string if piped but empty, or error on read failure.

`has_stdin() -> bool`: Checks if stdin is piped. Good practice to check before reading.

The null vs empty string distinction lets scripts detect whether they're in a pipeline vs standalone. Second call to read_stdin() returns empty string since stdin can only be read once (standard Unix behavior).

Added dedicated error code ErrStdinRead (20026) instead of reusing ErrFileRead for semantic clarity.

==  Testing  ==

Enhanced test infrastructure to properly simulate piped stdin:
- Added isPiped flag to BufferReader to distinguish "no stdin" from "empty stdin" in tests
- Test helpers now handle both "script from stdin" (rad -) and "data piped to script" scenarios