### PR TITLE
feat(checker): add warning against undefined cmd callback references

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+docs-docusaurus
+
 # Binaries
 rad
 rls

--- a/core/testing/check_test.go
+++ b/core/testing/check_test.go
@@ -133,3 +133,22 @@ Reported 2 diagnostics.
 `
 	assertOnlyOutput(t, stdOutBuffer, expected)
 }
+
+func Test_Check_UnknownCommandCallbacks(t *testing.T) {
+	setupAndRunArgs(t, "check", "./rad_scripts/unknown_command_callbacks.rad", "--color=never")
+	expected := `L4:11: WARN
+
+     4 |     calls missing_one
+       |           ^ Function 'missing_one' may not be defined (only built-in and top-level functions are tracked)
+       |           (code: RAD40003)
+
+L7:11: WARN
+
+     7 |     calls missing_two
+       |           ^ Function 'missing_two' may not be defined (only built-in and top-level functions are tracked)
+       |           (code: RAD40003)
+
+Reported 2 diagnostics.
+`
+	assertOnlyOutput(t, stdOutBuffer, expected)
+}

--- a/core/testing/rad_scripts/unknown_command_callbacks.rad
+++ b/core/testing/rad_scripts/unknown_command_callbacks.rad
@@ -1,0 +1,14 @@
+#!/usr/bin/env rad
+
+command first:
+    calls missing_one
+
+command second:
+    calls missing_two
+
+command third:
+    calls print
+
+command fourth:
+    calls fn():
+        print("inline")

--- a/rts/check/structs.go
+++ b/rts/check/structs.go
@@ -23,7 +23,7 @@ func (s Severity) String() string {
 	case Info:
 		return "Info"
 	case Warning:
-		return "Warning"
+		return "Warn"
 	case Error:
 		return "Error"
 	default:
@@ -77,6 +77,10 @@ func NewDiagnosticError(node *ts.Node, originalSrc string, msg string, code rl.E
 
 func NewDiagnosticHint(node *ts.Node, originalSrc string, msg string, code rl.Error) Diagnostic {
 	return NewDiagnosticFromNode(node, originalSrc, Hint, msg, &code)
+}
+
+func NewDiagnosticWarn(node *ts.Node, originalSrc string, msg string, code rl.Error) Diagnostic {
+	return NewDiagnosticFromNode(node, originalSrc, Warning, msg, &code)
 }
 
 type Result struct {


### PR DESCRIPTION
Longer-term, we'll want to be smart enough in our static analysis to generically warn for all method references (and this callback is just one of them). But, deferred for now!