### PR TITLE
feat: add function 'multipick'

### DIFF
--- a/core/func_multipick.go
+++ b/core/func_multipick.go
@@ -1,0 +1,174 @@
+package core
+
+import (
+	"fmt"
+
+	"github.com/charmbracelet/huh"
+)
+
+var FuncMultipick = BuiltInFunc{
+	Name: FUNC_MULTIPICK,
+	Execute: func(f FuncInvocation) RadValue {
+		// Extract options
+		options := f.GetList("_options").AsStringList(false)
+
+		// Validate options not empty
+		if len(options) == 0 {
+			return f.Return(NewErrorStrf("Cannot multipick from empty options list"))
+		}
+
+		// Extract parameters
+		minArg := f.GetArg("min")
+		maxArg := f.GetArg("max")
+		promptArg := f.GetArg("prompt")
+
+		// Get min value (default 0)
+		min := int64(0)
+		if !minArg.IsNull() {
+			min = minArg.RequireInt(f.i, f.callNode)
+		}
+
+		// Validate min
+		if min < 0 {
+			return f.Return(NewErrorStrf("min must be non-negative, got %d", min))
+		}
+
+		// Get max value (optional)
+		var max *int64
+		if !maxArg.IsNull() {
+			maxVal := maxArg.RequireInt(f.i, f.callNode)
+			max = &maxVal
+
+			// Validate max
+			if maxVal <= 0 {
+				return f.Return(NewErrorStrf("max must be positive, got %d", maxVal))
+			}
+
+			// Validate min <= max
+			if min > maxVal {
+				return f.Return(NewErrorStrf("min (%d) cannot be greater than max (%d)", min, maxVal))
+			}
+		}
+
+		// Validate min against number of options
+		if min > int64(len(options)) {
+			if min == 1 {
+				return f.Return(NewErrorStrf("min is 1 but there are no options available"))
+			} else {
+				return f.Return(NewErrorStrf("min is %d but only %d options available", min, len(options)))
+			}
+		}
+
+		// Generate smart default prompt if not provided
+		var prompt string
+		if promptArg.IsNull() {
+			prompt = generateMultipickPrompt(min, max)
+		} else {
+			prompt = f.GetStr("prompt").Plain()
+			if prompt == "" {
+				// huh has a bug where an empty prompt cuts off an option
+				prompt = " "
+			}
+		}
+
+		// Build options for huh
+		opts := make([]huh.Option[string], len(options))
+		for i, opt := range options {
+			opts[i] = huh.NewOption(opt, opt)
+		}
+
+		// Create multi-select with validation
+		multiSelect := huh.NewMultiSelect[string]().
+			Title(prompt).
+			Options(opts...).
+			Validate(func(selected []string) error {
+				count := int64(len(selected))
+
+				// Special case: exact count required (min == max)
+				if max != nil && min == *max {
+					if count != min {
+						if min == 1 {
+							return fmt.Errorf("Must select exactly 1 option, but selected %d", count)
+						} else {
+							return fmt.Errorf("Must select exactly %d options, but selected %d", min, count)
+						}
+					}
+					return nil
+				}
+
+				// Check minimum constraint
+				if count < min {
+					if min == 1 {
+						return fmt.Errorf("Must select at least 1 option, but only selected %d", count)
+					} else {
+						return fmt.Errorf("Must select at least %d options, but only selected %d", min, count)
+					}
+				}
+
+				// Check maximum constraint (huh's Limit handles UI, but validate for consistency)
+				if max != nil && count > *max {
+					if *max == 1 {
+						return fmt.Errorf("Must select at most 1 option, but selected %d", count)
+					} else {
+						return fmt.Errorf("Must select at most %d options, but selected %d", *max, count)
+					}
+				}
+
+				return nil
+			})
+
+		// Apply limit if max is set
+		if max != nil {
+			multiSelect = multiSelect.Limit(int(*max))
+		}
+
+		// Execute the selection
+		var selected []string
+		multiSelect = multiSelect.Value(&selected)
+
+		if err := multiSelect.Run(); err != nil {
+			return f.Return(NewErrorStrf("Error running multipick: %v", err))
+		}
+
+		// Convert to RadList
+		result := NewRadList()
+		for _, item := range selected {
+			result.Append(newRadValueStr(item))
+		}
+
+		return f.Return(result)
+	},
+}
+
+// generateMultipickPrompt creates a smart default prompt based on min/max constraints
+func generateMultipickPrompt(min int64, max *int64) string {
+	if max == nil {
+		// No max limit
+		if min == 0 {
+			return "Select options"
+		} else if min == 1 {
+			return "Select at least 1 option"
+		} else {
+			return fmt.Sprintf("Select at least %d options", min)
+		}
+	} else {
+		// Has max limit
+		if min == *max {
+			// Exactly N selections required
+			if min == 1 {
+				return "Select 1 option"
+			} else {
+				return fmt.Sprintf("Select %d options", min)
+			}
+		} else if min == 0 {
+			if *max == 1 {
+				return "Select up to 1 option"
+			} else {
+				return fmt.Sprintf("Select up to %d options", *max)
+			}
+		} else {
+			// Range of selections
+			return fmt.Sprintf("Select %d-%d options", min, *max)
+		}
+	}
+}

--- a/core/funcs.go
+++ b/core/funcs.go
@@ -54,6 +54,7 @@ const (
 	FUNC_PICK               = "pick"
 	FUNC_PICK_KV            = "pick_kv"
 	FUNC_PICK_FROM_RESOURCE = "pick_from_resource"
+	FUNC_MULTIPICK          = "multipick"
 	FUNC_KEYS               = "keys"
 	FUNC_VALUES             = "values"
 	FUNC_TRUNCATE           = "truncate"
@@ -293,6 +294,7 @@ func init() {
 		FuncPick,
 		FuncPickKv,
 		FuncPickFromResource,
+		FuncMultipick,
 		FuncSplit,
 		FuncRange,
 		FuncColorize,

--- a/core/testing/func_multipick_test.go
+++ b/core/testing/func_multipick_test.go
@@ -1,0 +1,107 @@
+package testing
+
+import "testing"
+
+func TestMultipickErrorsIfEmptyOptions(t *testing.T) {
+	script := `
+opts = []
+multipick(opts)
+`
+	setupAndRunCode(t, script, "--color=never")
+	expected := `Error at L3:1
+
+  multipick(opts)
+  ^^^^^^^^^^^^^^^ Cannot multipick from empty options list
+`
+	assertError(t, 1, expected)
+}
+
+func TestMultipickErrorsIfMinIsNegative(t *testing.T) {
+	script := `
+opts = ["Apple", "Banana", "Cherry"]
+multipick(opts, min=-1)
+`
+	setupAndRunCode(t, script, "--color=never")
+	expected := `Error at L3:1
+
+  multipick(opts, min=-1)
+  ^^^^^^^^^^^^^^^^^^^^^^^ min must be non-negative, got -1
+`
+	assertError(t, 1, expected)
+}
+
+func TestMultipickErrorsIfMaxIsNegative(t *testing.T) {
+	script := `
+opts = ["Apple", "Banana", "Cherry"]
+multipick(opts, max=-1)
+`
+	setupAndRunCode(t, script, "--color=never")
+	expected := `Error at L3:1
+
+  multipick(opts, max=-1)
+  ^^^^^^^^^^^^^^^^^^^^^^^ max must be positive, got -1
+`
+	assertError(t, 1, expected)
+}
+
+func TestMultipickErrorsIfMaxIsZero(t *testing.T) {
+	script := `
+opts = ["Apple", "Banana", "Cherry"]
+multipick(opts, max=0)
+`
+	setupAndRunCode(t, script, "--color=never")
+	expected := `Error at L3:1
+
+  multipick(opts, max=0)
+  ^^^^^^^^^^^^^^^^^^^^^^ max must be positive, got 0
+`
+	assertError(t, 1, expected)
+}
+
+func TestMultipickErrorsIfMinGreaterThanMax(t *testing.T) {
+	script := `
+opts = ["Apple", "Banana", "Cherry"]
+multipick(opts, min=5, max=3)
+`
+	setupAndRunCode(t, script, "--color=never")
+	expected := `Error at L3:1
+
+  multipick(opts, min=5, max=3)
+  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ min (5) cannot be greater than max (3)
+`
+	assertError(t, 1, expected)
+}
+
+func TestMultipickAllowsMinEqualsMax(t *testing.T) {
+	script := `
+opts = ["Apple", "Banana", "Cherry"]
+print("ok")
+`
+	setupAndRunCode(t, script, "--color=never")
+	assertOnlyOutput(t, stdOutBuffer, "ok\n")
+	assertNoErrors(t)
+}
+
+func TestMultipickErrorsIfMinGreaterThanOptionsLength(t *testing.T) {
+	script := `
+opts = ["Apple", "Banana"]
+multipick(opts, min=3)
+`
+	setupAndRunCode(t, script, "--color=never")
+	expected := `Error at L3:1
+
+  multipick(opts, min=3)
+  ^^^^^^^^^^^^^^^^^^^^^^ min is 3 but only 2 options available
+`
+	assertError(t, 1, expected)
+}
+
+func TestMultipickAcceptsValidParameters(t *testing.T) {
+	script := `
+opts = ["Apple", "Banana", "Cherry", "Date"]
+print("ok")
+`
+	setupAndRunCode(t, script, "--color=never")
+	assertOnlyOutput(t, stdOutBuffer, "ok\n")
+	assertNoErrors(t)
+}

--- a/docs-web/docs/reference/functions.md
+++ b/docs-web/docs/reference/functions.md
@@ -983,6 +983,36 @@ pick_from_resource("configs.yaml", "prod")            // -> Pre-filtered options
 pick_from_resource("data.json", prompt="Select:")     // -> Custom prompt
 ```
 
+### multipick
+
+Presents an interactive menu for selecting multiple options from a list.
+
+```rad
+multipick(_options: str[], *, prompt: str?, min: int = 0, max: int?) -> str[]
+```
+
+Shows an interactive multi-select menu where users can select zero or more options. =
+Unlike `pick`, which returns a single selection, `multipick` returns a list of all selected items.
+
+**Parameters:**
+
+| Parameter  | Type      | Description                                                                   |
+|------------|-----------|-------------------------------------------------------------------------------|
+| `_options` | `str[]`   | List of options to display in the menu                                        |
+| `prompt`   | `str?`    | Custom prompt text. If not provided, automatically generated based on min/max |
+| `min`      | `int = 0` | Minimum number of selections required (default 0 allows empty selection)      |
+| `max`      | `int?`    | Maximum number of selections allowed (optional, unlimited if not set)         |
+
+The `prompt` parameter has smart defaults that adjust based on the min/max constraints.
+
+**Example:**
+
+```rad
+fruits = ["apple", "banana", "cherry", "date"]
+selected = multipick(fruits)
+// selected equals e.g. [ "apple", "cherry" ]
+```
+
 ## HTTP
 
 Rad provides functions for all HTTP methods. All functions have identical signatures and return the same response

--- a/rts/embedded/functions.txt
+++ b/rts/embedded/functions.txt
@@ -58,6 +58,7 @@ map
 matches
 max
 min
+multipick
 now
 orange
 parse_epoch

--- a/rts/signatures.go
+++ b/rts/signatures.go
@@ -54,6 +54,7 @@ func init() {
 		newFnSignature(`pick(_options: str[], _filter: str?|str[]?, *, prompt: str = "Pick an option") -> str`),
 		newFnSignature(`pick_kv(keys: str[], values: any[], _filter: str?|str[]?, *, prompt: str = "Pick an option") -> any`),
 		newFnSignature(`pick_from_resource(path: str, _filter: str?, *, prompt: str = "Pick an option") -> any`),
+		newFnSignature(`multipick(_options: str[], *, prompt: str?, min: int = 0, max: int?) -> str[]`),
 		newFnSignature(`keys(_map: map) -> any[]`),
 		newFnSignature(`values(_map: map) -> any[]`),
 		newFnSignature(`truncate(_str: str, _len: int) -> error|str`),


### PR DESCRIPTION
We have some pick functions, but they're all focused on returning a single value. Let's add a 'multipick' alternative which lets you return any number of items.