### PR TITLE
feat: add flat_map function

### DIFF
--- a/core/testing/func_flat_map_test.go
+++ b/core/testing/func_flat_map_test.go
@@ -1,0 +1,319 @@
+package testing
+
+import "testing"
+
+// === List without function - all elements must be lists ===
+
+func Test_Func_FlatMap_ListNoFn_NestedLists(t *testing.T) {
+	script := `
+a = [[1, 2], [3, 4]]
+a.flat_map().print()
+`
+	setupAndRunCode(t, script, "--color=never")
+	expected := `[ 1, 2, 3, 4 ]
+`
+	assertOnlyOutput(t, stdOutBuffer, expected)
+	assertNoErrors(t)
+}
+
+func Test_Func_FlatMap_ListNoFn_OneLevelOnly(t *testing.T) {
+	script := `
+a = [[[1, 2]], [[3, 4]]]
+a.flat_map().print()
+`
+	setupAndRunCode(t, script, "--color=never")
+	expected := `[ [ 1, 2 ], [ 3, 4 ] ]
+`
+	assertOnlyOutput(t, stdOutBuffer, expected)
+	assertNoErrors(t)
+}
+
+func Test_Func_FlatMap_ListNoFn_EmptyList(t *testing.T) {
+	script := `
+a = []
+a.flat_map().print()
+`
+	setupAndRunCode(t, script, "--color=never")
+	expected := `[ ]
+`
+	assertOnlyOutput(t, stdOutBuffer, expected)
+	assertNoErrors(t)
+}
+
+func Test_Func_FlatMap_ListNoFn_EmptyNestedLists(t *testing.T) {
+	script := `
+a = [[], [1], []]
+a.flat_map().print()
+`
+	setupAndRunCode(t, script, "--color=never")
+	expected := `[ 1 ]
+`
+	assertOnlyOutput(t, stdOutBuffer, expected)
+	assertNoErrors(t)
+}
+
+func Test_Func_FlatMap_ListNoFn_ListOfStringLists(t *testing.T) {
+	script := `
+a = [["a", "b"], ["c", "d"]]
+a.flat_map().print()
+`
+	setupAndRunCode(t, script, "--color=never")
+	expected := `[ "a", "b", "c", "d" ]
+`
+	assertOnlyOutput(t, stdOutBuffer, expected)
+	assertNoErrors(t)
+}
+
+// === List without function - error cases ===
+
+func Test_Func_FlatMap_ListNoFn_ErrorOnMixedElements(t *testing.T) {
+	script := `
+a = [1, [2, 3], 4]
+a.flat_map().print()
+`
+	setupAndRunCode(t, script, "--color=never")
+	expected := `Error at L3:3
+
+  a.flat_map().print()
+    ^^^^^^^^^^
+    flat_map requires all elements to be lists, but element at index 0 is int (RAD20000)
+`
+	assertError(t, 1, expected)
+}
+
+func Test_Func_FlatMap_ListNoFn_ErrorOnNonLists(t *testing.T) {
+	script := `
+a = [1, 2, 3]
+a.flat_map().print()
+`
+	setupAndRunCode(t, script, "--color=never")
+	expected := `Error at L3:3
+
+  a.flat_map().print()
+    ^^^^^^^^^^
+    flat_map requires all elements to be lists, but element at index 0 is int (RAD20000)
+`
+	assertError(t, 1, expected)
+}
+
+// === List with function - must return lists ===
+
+func Test_Func_FlatMap_ListWithFn_Split(t *testing.T) {
+	script := `
+a = ["a-b", "c-d"]
+a.flat_map(fn(e) e.split("-")).print()
+`
+	setupAndRunCode(t, script, "--color=never")
+	expected := `[ "a", "b", "c", "d" ]
+`
+	assertOnlyOutput(t, stdOutBuffer, expected)
+	assertNoErrors(t)
+}
+
+func Test_Func_FlatMap_ListWithFn_Duplicate(t *testing.T) {
+	script := `
+a = [1, 2]
+a.flat_map(fn(x) [x, x * 10]).print()
+`
+	setupAndRunCode(t, script, "--color=never")
+	expected := `[ 1, 10, 2, 20 ]
+`
+	assertOnlyOutput(t, stdOutBuffer, expected)
+	assertNoErrors(t)
+}
+
+func Test_Func_FlatMap_ListWithFn_Range(t *testing.T) {
+	script := `
+a = [1, 2, 3]
+a.flat_map(fn(x) range(x)).print()
+`
+	setupAndRunCode(t, script, "--color=never")
+	expected := `[ 0, 0, 1, 0, 1, 2 ]
+`
+	assertOnlyOutput(t, stdOutBuffer, expected)
+	assertNoErrors(t)
+}
+
+func Test_Func_FlatMap_ListWithFn_NamedFunction(t *testing.T) {
+	script := `
+a = ["a-b", "c-d"]
+splitter = fn(e) e.split("-")
+a.flat_map(splitter).print()
+`
+	setupAndRunCode(t, script, "--color=never")
+	expected := `[ "a", "b", "c", "d" ]
+`
+	assertOnlyOutput(t, stdOutBuffer, expected)
+	assertNoErrors(t)
+}
+
+func Test_Func_FlatMap_ListWithFn_EmptyListResults(t *testing.T) {
+	script := `
+a = [1, 2, 3]
+a.flat_map(fn(x) []).print()
+`
+	setupAndRunCode(t, script, "--color=never")
+	expected := `[ ]
+`
+	assertOnlyOutput(t, stdOutBuffer, expected)
+	assertNoErrors(t)
+}
+
+// === List with function - error cases ===
+
+func Test_Func_FlatMap_ListWithFn_ErrorOnNonListResult(t *testing.T) {
+	script := `
+a = [1, 2, 3]
+a.flat_map(fn(x) x * 2).print()
+`
+	setupAndRunCode(t, script, "--color=never")
+	expected := `Error at L3:3
+
+  a.flat_map(fn(x) x * 2).print()
+    ^^^^^^^^^^^^^^^^^^^^^
+    flat_map function must return a list, but returned int for element at index 0 (RAD20000)
+`
+	assertError(t, 1, expected)
+}
+
+// === Map - requires function ===
+
+func Test_Func_FlatMap_MapNoFn_RequiresFunction(t *testing.T) {
+	script := `
+a = { "a": [1, 2], "b": [3, 4] }
+a.flat_map().print()
+`
+	setupAndRunCode(t, script, "--color=never")
+	expected := `Error at L3:3
+
+  a.flat_map().print()
+    ^^^^^^^^^^ flat_map on maps requires a function argument (RAD20000)
+`
+	assertError(t, 1, expected)
+}
+
+func Test_Func_FlatMap_MapWithFn_ExtractValues(t *testing.T) {
+	script := `
+a = { "a": [1, 2], "b": [3, 4] }
+a.flat_map(fn(k, v) v).print()
+`
+	setupAndRunCode(t, script, "--color=never")
+	expected := `[ 1, 2, 3, 4 ]
+`
+	assertOnlyOutput(t, stdOutBuffer, expected)
+	assertNoErrors(t)
+}
+
+func Test_Func_FlatMap_MapWithFn_CreatePairs(t *testing.T) {
+	script := `
+a = { "a": 1, "b": 2 }
+a.flat_map(fn(k, v) [k, v]).print()
+`
+	setupAndRunCode(t, script, "--color=never")
+	expected := `[ "a", 1, "b", 2 ]
+`
+	assertOnlyOutput(t, stdOutBuffer, expected)
+	assertNoErrors(t)
+}
+
+func Test_Func_FlatMap_MapWithFn_TransformThenFlatten(t *testing.T) {
+	script := `
+a = { "a": "x-y", "b": "z-w" }
+a.flat_map(fn(k, v) v.split("-")).print()
+`
+	setupAndRunCode(t, script, "--color=never")
+	expected := `[ "x", "y", "z", "w" ]
+`
+	assertOnlyOutput(t, stdOutBuffer, expected)
+	assertNoErrors(t)
+}
+
+// === Map with function - error cases ===
+
+func Test_Func_FlatMap_MapWithFn_ErrorOnNonListResult(t *testing.T) {
+	script := `
+a = { "a": 1, "b": 2 }
+a.flat_map(fn(k, v) v * 2).print()
+`
+	setupAndRunCode(t, script, "--color=never")
+	expected := `Error at L3:3
+
+  a.flat_map(fn(k, v) v * 2).print()
+    ^^^^^^^^^^^^^^^^^^^^^^^^
+    flat_map function must return a list, but returned int for key a (RAD20000)
+`
+	assertError(t, 1, expected)
+}
+
+// === Chaining ===
+
+func Test_Func_FlatMap_ChainWithFilter(t *testing.T) {
+	script := `
+a = [[1, 2], [3, 4]]
+a.flat_map().filter(fn(x) x > 2).print()
+`
+	setupAndRunCode(t, script, "--color=never")
+	expected := `[ 3, 4 ]
+`
+	assertOnlyOutput(t, stdOutBuffer, expected)
+	assertNoErrors(t)
+}
+
+func Test_Func_FlatMap_ChainWithMap(t *testing.T) {
+	script := `
+a = [[1, 2], [3, 4]]
+a.flat_map().map(fn(x) x * 2).print()
+`
+	setupAndRunCode(t, script, "--color=never")
+	expected := `[ 2, 4, 6, 8 ]
+`
+	assertOnlyOutput(t, stdOutBuffer, expected)
+	assertNoErrors(t)
+}
+
+func Test_Func_FlatMap_ChainMultiple(t *testing.T) {
+	script := `
+a = ["a-b", "c-d"]
+a.flat_map(fn(e) e.split("-")).map(fn(x) x.upper()).print()
+`
+	setupAndRunCode(t, script, "--color=never")
+	expected := `[ "A", "B", "C", "D" ]
+`
+	assertOnlyOutput(t, stdOutBuffer, expected)
+	assertNoErrors(t)
+}
+
+// === Method vs Function syntax ===
+
+func Test_Func_FlatMap_MethodSyntax(t *testing.T) {
+	script := `
+[[1], [2]].flat_map().print()
+`
+	setupAndRunCode(t, script, "--color=never")
+	expected := `[ 1, 2 ]
+`
+	assertOnlyOutput(t, stdOutBuffer, expected)
+	assertNoErrors(t)
+}
+
+func Test_Func_FlatMap_FunctionSyntax(t *testing.T) {
+	script := `
+flat_map([[1], [2]]).print()
+`
+	setupAndRunCode(t, script, "--color=never")
+	expected := `[ 1, 2 ]
+`
+	assertOnlyOutput(t, stdOutBuffer, expected)
+	assertNoErrors(t)
+}
+
+func Test_Func_FlatMap_FunctionSyntaxWithFn(t *testing.T) {
+	script := `
+flat_map([1, 2], fn(x) [x, x * 10]).print()
+`
+	setupAndRunCode(t, script, "--color=never")
+	expected := `[ 1, 10, 2, 20 ]
+`
+	assertOnlyOutput(t, stdOutBuffer, expected)
+	assertNoErrors(t)
+}

--- a/docs-web/docs/guide/functions.md
+++ b/docs-web/docs/guide/functions.md
@@ -316,7 +316,7 @@ print(calculate(5))  // 20
 [//]: # (TODO closures behave poorly, fix and write here i.e. they should statically capture values!)
 
 Lambdas are particularly useful for defining once-off operations and passing them as arguments.
-For example, with [`map`](../reference/functions.md#map) and [`filter`](../reference/functions.md#filter):
+For example, with [`map`](../reference/functions.md#map), [`filter`](../reference/functions.md#filter), and [`flat_map`](../reference/functions.md#flat_map):
 
 ```rad
 numbers = [1, 2, 3, 4, 5]
@@ -325,6 +325,11 @@ print(doubled)  // [2, 4, 6, 8, 10]
 
 evens = numbers.filter(fn(x) x % 2 == 0)
 print(evens)  // [2, 4]
+
+// flat_map is useful for transformations that produce lists
+words = ["hello world", "foo bar"]
+all_words = words.flat_map(fn(s) s.split(" "))
+print(all_words)  // ["hello", "world", "foo", "bar"]
 ```
 
 !!! tip "Named Functions vs Lambdas"
@@ -352,7 +357,7 @@ There are a lot of built-in functions. If you want to see what's available and h
     - Are **hoisted** at the root of scripts (can be called before definition)
     - Can have optional **type annotations**
 - **Lambdas** are anonymous functions: `double = fn(x) x * 2`
-    - Useful for one-off operations and callbacks - functions like `map()` and `filter()`
+    - Useful for one-off operations and callbacks - functions like `map()`, `filter()`, and `flat_map()`
 
 ## Next
 

--- a/docs-web/docs/reference/functions.md
+++ b/docs-web/docs/reference/functions.md
@@ -391,6 +391,44 @@ filter([1, 2, 3, 4], fn(x) x % 2 == 0)      // -> [2, 4]
 filter({"a": 1, "b": 2}, fn(k, v) v > 1)    // -> {"b": 2}
 ```
 
+### flat_map
+
+Flattens a list of lists, or applies a mapping function that returns lists and flattens the results.
+
+```rad
+flat_map(_coll: list|map, _fn: any?) -> list
+```
+
+**For lists without function:** All elements must be lists. Flattens one level.
+
+**With function:** The function must return a list. Results are flattened.
+
+For lists, function receives `fn(value)`. For maps, function receives `fn(key, value)` and is required.
+
+**Examples:**
+
+```rad
+// Flatten list of lists (all elements must be lists)
+[[1, 2], [3, 4]].flat_map()              // -> [1, 2, 3, 4]
+[[], [1], []].flat_map()                 // -> [1]
+
+// Only one level
+[[[1]], [[2]]].flat_map()                // -> [[1], [2]]
+
+// Map then flatten (function must return a list)
+["a-b", "c-d"].flat_map(fn(e) e.split("-"))  // -> ["a", "b", "c", "d"]
+[1, 2].flat_map(fn(x) [x, x * 10])           // -> [1, 10, 2, 20]
+[1, 2].flat_map(fn(x) range(x))              // -> [0, 0, 1]
+
+// Map collection - function required, must return list
+{"a": [1, 2], "b": [3, 4]}.flat_map(fn(k, v) v)  // -> [1, 2, 3, 4]
+{"a": 1, "b": 2}.flat_map(fn(k, v) [k, v])       // -> ["a", 1, "b", 2]
+
+// Errors:
+// [1, [2], 3].flat_map()           // Error: element 0 is not a list
+// [1, 2].flat_map(fn(x) x * 2)     // Error: function must return a list
+```
+
 ### load
 
 Loads a value into a map using lazy evaluation. If key exists, returns cached value; otherwise runs loader function.

--- a/rts/embedded/functions.txt
+++ b/rts/embedded/functions.txt
@@ -20,6 +20,7 @@ error
 exit
 filter
 find_paths
+flat_map
 float
 floor
 gen_fid

--- a/rts/signatures.go
+++ b/rts/signatures.go
@@ -109,6 +109,7 @@ func init() {
 		newFnSignature(`decode_base16(_content: str) -> error|str`),
 		newFnSignature(`map(_coll: map|list, _fn: fn(any) -> any | fn(any, any) -> any) -> map|list`),
 		newFnSignature(`filter(_coll: map|list, _fn: fn(any) -> bool | fn(any, any) -> bool) -> map|list`),
+		newFnSignature(`flat_map(_coll: map|list, _fn: any?) -> list`),
 		newFnSignature(`get_default(_map: map, key: any, default: any) -> any`),
 		newFnSignature(`get_rad_home() -> str`),
 		newFnSignature(`load(_map: map, _key: any, _loader: fn() -> any, *, reload: bool = false, override: any?) -> error|any`),


### PR DESCRIPTION
Spawned from discussion in #71 I realized we're missing a flattening function, which is quite often handy to have.

We call it flat_map() and make it operate on lists or maps. If used on lists, then providing an actual mapping function isn't required. Instead, identify will be assumed i.e. you don't need to write

  my_list.flat_map(fn(e) e)

as you do in other languages like Java.

However, for *do* require the function to be defined inputting map types, because we can't assume identity in a way that makes sense (given key-value pairs).