### PR TITLE
ci: add cross-platform testing for macOS and Windows

### DIFF
--- a/.github/workflows/cross-platform-tests.yml
+++ b/.github/workflows/cross-platform-tests.yml
@@ -1,0 +1,80 @@
+# Manual workflow for quick cross-platform testing during development.
+# Useful when iterating on platform-specific fixes without running the full PR pipeline.
+#
+# Trigger via GitHub UI or CLI:
+#   gh workflow run "Cross-Platform Tests" --ref your-branch
+
+name: Cross-Platform Tests
+
+on:
+  workflow_dispatch:
+    inputs:
+      platforms:
+        description: 'Platforms to test'
+        required: true
+        default: 'all'
+        type: choice
+        options:
+          - all
+          - windows
+          - macos
+          - linux
+
+jobs:
+  determine-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - id: set-matrix
+        run: |
+          if [ "${{ inputs.platforms }}" == "all" ]; then
+            echo 'matrix=["ubuntu-latest", "macos-latest", "windows-latest"]' >> $GITHUB_OUTPUT
+          elif [ "${{ inputs.platforms }}" == "windows" ]; then
+            echo 'matrix=["windows-latest"]' >> $GITHUB_OUTPUT
+          elif [ "${{ inputs.platforms }}" == "macos" ]; then
+            echo 'matrix=["macos-latest"]' >> $GITHUB_OUTPUT
+          elif [ "${{ inputs.platforms }}" == "linux" ]; then
+            echo 'matrix=["ubuntu-latest"]' >> $GITHUB_OUTPUT
+          fi
+
+  test:
+    name: Test (${{ matrix.os }})
+    needs: determine-matrix
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ${{ fromJson(needs.determine-matrix.outputs.matrix) }}
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.21'
+          cache: true
+
+      - name: Build Rad
+        run: go build -o rad .
+
+      - name: Run Go tests
+        run: go test -v ./core/testing/... ./rts/...
+
+      - name: Test basic Rad execution (Unix)
+        if: runner.os != 'Windows'
+        run: |
+          echo 'print("Hello from Rad!")' | ./rad -
+
+      - name: Test basic Rad execution (Windows PowerShell)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          echo 'print("Hello from Rad!")' | ./rad.exe -
+
+      - name: Test basic Rad execution (Windows cmd)
+        if: runner.os == 'Windows'
+        shell: cmd
+        run: |
+          echo print("Hello from Rad!") | rad.exe -

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   tests:
-    name: Run Tests
+    name: Tests (ubuntu-latest)
     runs-on: ubuntu-latest
     outputs:
       tests-passed: ${{ steps.tests.outcome == 'success' }}
@@ -38,6 +38,26 @@ jobs:
       - name: Run tests
         id: tests
         run: rad ci/test-runner.rad
+
+  cross-platform-tests:
+    name: Tests (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.21'
+          cache: true
+
+      - name: Run Go tests
+        run: go test ./core/testing/... ./rts/...
 
   binary-size:
     name: Binary Size Comparison
@@ -118,7 +138,7 @@ jobs:
   comment:
     name: Post PR Comment
     runs-on: ubuntu-latest
-    needs: [tests, binary-size, benchmarks]
+    needs: [tests, cross-platform-tests, binary-size, benchmarks]
     if: always()
     steps:
       - name: Checkout code
@@ -143,6 +163,7 @@ jobs:
         env:
           TESTS_PASSED: ${{ needs.tests.outputs.tests-passed }}
           TESTS_JOB_URL: ${{ needs.tests.outputs.tests-job-url }}
+          CROSS_PLATFORM_PASSED: ${{ needs.cross-platform-tests.result == 'success' }}
           BINARY_JOB_URL: ${{ needs.binary-size.outputs.binary-job-url }}
           BENCHMARK_JOB_URL: ${{ needs.benchmarks.outputs.benchmark-job-url }}
           GITHUB_SHA: ${{ github.event.pull_request.head.sha }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,6 +51,39 @@ If you're using GoLand, the repo includes a few run configurations that may be h
 - **Tests**: Runs all the tests.
 - **make all**: Runs make all from the IDE.
 
+### Testing
+
+Run the full test suite locally with:
+
+```shell
+make test
+```
+
+Or use the dev script for a more comprehensive validation (includes formatting, building, and tests):
+
+```shell
+./dev --validate
+```
+
+#### Cross-Platform Testing
+
+Rad supports Linux, macOS, and Windows. PR checks automatically run Go tests on all three platforms.
+
+If you're working on a platform-specific fix and want faster feedback than the full PR pipeline, you can manually trigger cross-platform tests on your branch:
+
+```shell
+# Test on all platforms
+gh workflow run "Cross-Platform Tests" --ref your-branch
+
+# Test only on Windows
+gh workflow run "Cross-Platform Tests" --ref your-branch -f platforms=windows
+
+# Test only on macOS
+gh workflow run "Cross-Platform Tests" --ref your-branch -f platforms=macos
+```
+
+This is particularly useful when debugging issues that only reproduce on specific platforms.
+
 ### Submitting PRs
 
 1. Fork the repo, create a feature branch, and commit your changes.

--- a/Makefile
+++ b/Makefile
@@ -25,4 +25,4 @@ build:
 
 test:
 	@echo "⚙️ Running tests..."
-	go test ./core/testing ./rts
+	go test ./core/testing/... ./rts/...

--- a/ci/pr-comment.rad
+++ b/ci/pr-comment.rad
@@ -9,6 +9,7 @@ print("💬 Generating PR comment...")
 // Read test results from GitHub Actions environment
 tests_passed = get_env("TESTS_PASSED") == "true"
 tests_job_url = get_env("TESTS_JOB_URL")
+cross_platform_passed = get_env("CROSS_PLATFORM_PASSED") == "true"
 binary_job_url = get_env("BINARY_JOB_URL")
 benchmark_job_url = get_env("BENCHMARK_JOB_URL")
 
@@ -46,6 +47,10 @@ if type_of(benchmark_file) != "error":
 test_icon = tests_passed ? "✅" : "❌"
 test_message = tests_passed ? "All tests passed" : "Tests failed"
 test_link = tests_job_url ? " ([view logs]({tests_job_url}))" : ""
+
+// Determine cross-platform test status
+cross_platform_icon = cross_platform_passed ? "✅" : "❌"
+cross_platform_message = cross_platform_passed ? "macOS & Windows tests passed" : "Cross-platform tests failed"
 
 // Determine binary size change significance for rad
 rad_size_change_icon = get_size_change_icon(binary_data.rad.diff_percent)
@@ -88,8 +93,11 @@ radls_change_text = binary_data.radls.diff_percent != null ? "{radls_size_change
 comment = """
 ## 🔍 PR Checks Summary
 
-### {test_icon} Tests
+### {test_icon} Tests (Linux)
 {test_message}{test_link}
+
+### {cross_platform_icon} Cross-Platform Tests
+{cross_platform_message}
 
 ### 📊 Binary Size Impact (linux/amd64)
 | Binary | Base ({base_commit_short}) | PR ({pr_commit_short}) | Change |

--- a/core/cmds.go
+++ b/core/cmds.go
@@ -81,7 +81,7 @@ func getFileHeaderLine(fileName string) string {
 	if !ok {
 		panic(fmt.Sprintf("Failed to find file header in embedded file %s", fileName))
 	}
-	firstLine := strings.Split(fh.Contents, "\n")[0]
+	firstLine := strings.TrimSpace(strings.Split(fh.Contents, "\n")[0])
 	if !strings.HasSuffix(firstLine, ".") {
 		// Heuristic for the first line being a decent standalone description, for usage in rad help message.
 		panic(

--- a/rts/test/dumps/test_dumps.rad
+++ b/rts/test/dumps/test_dumps.rad
@@ -14,14 +14,14 @@ actuals = ["actual/{d}" for d in dumps]
 
 results = []
 fails = 0
-for i, d in dumps:
-    actual = actuals[i]
+for d in dumps with loop:
+    actual = actuals[loop.idx]
     diffs = compare_files("./cases/{d}", actual)
     result = green("SUCCESS")
     if diffs:
         result = red("FAIL")
         fails++
-    summary = "{i + 1:3}. {d} - " + result
+    summary = "{loop.idx + 1:3}. {d} - " + result
     print(summary)
     results += [summary]
 

--- a/rts/test/rts_test.go
+++ b/rts/test/rts_test.go
@@ -26,7 +26,7 @@ func Test_Tree_Sexp(t *testing.T) {
 
 	tree := radParser.Parse("a = 2\nprint(a)")
 
-	expected := "(source_file (assign left: (var_path) right: (expr (ternary_expr delegate: (or_expr delegate: (and_expr delegate: (compare_expr delegate: (add_expr delegate: (mult_expr delegate: (unary_expr delegate: (indexed_expr root: (primary_expr (literal (int))))))))))))) (expr (ternary_expr delegate: (or_expr delegate: (and_expr delegate: (compare_expr delegate: (add_expr delegate: (mult_expr delegate: (unary_expr delegate: (indexed_expr root: (primary_expr (call arg: (expr (ternary_expr delegate: (or_expr delegate: (and_expr delegate: (compare_expr delegate: (add_expr delegate: (mult_expr delegate: (unary_expr delegate: (var_path)))))))))))))))))))))"
+	expected := "(source_file (assign left: (var_path) right: (expr delegate: (ternary_expr delegate: (or_expr delegate: (and_expr delegate: (compare_expr delegate: (add_expr delegate: (mult_expr delegate: (unary_expr delegate: (fallback_expr delegate: (indexed_expr root: (primary_expr (literal (int)))))))))))))) (expr_stmt expr: (expr delegate: (ternary_expr delegate: (or_expr delegate: (and_expr delegate: (compare_expr delegate: (add_expr delegate: (mult_expr delegate: (unary_expr delegate: (fallback_expr delegate: (indexed_expr root: (primary_expr (call arg: (expr delegate: (ternary_expr delegate: (or_expr delegate: (and_expr delegate: (compare_expr delegate: (add_expr delegate: (mult_expr delegate: (unary_expr delegate: (fallback_expr delegate: (var_path))))))))))))))))))))))))"
 	if tree.Sexp() != expected {
 		t.Fatalf("Sexp failed: %v", tree.Sexp())
 	}


### PR DESCRIPTION
## Summary

- Add cross-platform Go tests to PR checks (macOS + Windows matrix)
- Create manual-trigger workflow for quick iteration on platform-specific fixes
- Update PR comment to show cross-platform test status

## Context

Addresses the broader issue raised by #77 - we were shipping Windows binaries without ever running tests on Windows. This change ensures Go tests run on all three platforms for every PR.

The manual workflow (`cross-platform-tests.yml`) allows quick iteration when debugging platform-specific issues:
```bash
gh workflow run "Cross-Platform Tests" --ref branch-name -f platforms=windows
```

## Test plan

- [ ] PR checks should now show separate jobs for macOS and Windows
- [ ] PR comment should show cross-platform test status
- [ ] After merge, verify manual workflow can be triggered