### PR TITLE
ci: treat all platforms as equal first-class citizens

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -10,12 +10,11 @@ permissions:
   pull-requests: write
 
 jobs:
-  tests:
-    name: Tests (ubuntu-latest)
+  tests-linux:
+    name: Tests (Linux)
     runs-on: ubuntu-latest
     outputs:
-      tests-passed: ${{ steps.tests.outcome == 'success' }}
-      tests-job-url: ${{ steps.job-url.outputs.url }}
+      passed: ${{ steps.tests.outcome == 'success' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -31,21 +30,15 @@ jobs:
       - name: Install Rad
         run: ./ci/install-rad.sh
 
-      - name: Generate job URL
-        id: job-url
-        run: echo "url=${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" >> $GITHUB_OUTPUT
-
       - name: Run tests
         id: tests
         run: rad ci/test-runner.rad
 
-  cross-platform-tests:
-    name: Tests (${{ matrix.os }})
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [macos-latest, windows-latest]
-    runs-on: ${{ matrix.os }}
+  tests-macos:
+    name: Tests (macOS)
+    runs-on: macos-latest
+    outputs:
+      passed: ${{ steps.tests.outcome == 'success' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -57,6 +50,26 @@ jobs:
           cache: true
 
       - name: Run Go tests
+        id: tests
+        run: go test ./core/testing/... ./rts/...
+
+  tests-windows:
+    name: Tests (Windows)
+    runs-on: windows-latest
+    outputs:
+      passed: ${{ steps.tests.outcome == 'success' }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.21'
+          cache: true
+
+      - name: Run Go tests
+        id: tests
         run: go test ./core/testing/... ./rts/...
 
   binary-size:
@@ -138,7 +151,7 @@ jobs:
   comment:
     name: Post PR Comment
     runs-on: ubuntu-latest
-    needs: [tests, cross-platform-tests, binary-size, benchmarks]
+    needs: [tests-linux, tests-macos, tests-windows, binary-size, benchmarks]
     if: always()
     steps:
       - name: Checkout code
@@ -161,9 +174,10 @@ jobs:
 
       - name: Generate PR comment
         env:
-          TESTS_PASSED: ${{ needs.tests.outputs.tests-passed }}
-          TESTS_JOB_URL: ${{ needs.tests.outputs.tests-job-url }}
-          CROSS_PLATFORM_PASSED: ${{ needs.cross-platform-tests.result == 'success' }}
+          LINUX_PASSED: ${{ needs.tests-linux.outputs.passed }}
+          MACOS_PASSED: ${{ needs.tests-macos.outputs.passed }}
+          WINDOWS_PASSED: ${{ needs.tests-windows.outputs.passed }}
+          TESTS_JOB_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           BINARY_JOB_URL: ${{ needs.binary-size.outputs.binary-job-url }}
           BENCHMARK_JOB_URL: ${{ needs.benchmarks.outputs.benchmark-job-url }}
           GITHUB_SHA: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/quick-platform-tests.yml
+++ b/.github/workflows/quick-platform-tests.yml
@@ -1,10 +1,10 @@
-# Manual workflow for quick cross-platform testing during development.
+# Manual workflow for quick platform testing during development.
 # Useful when iterating on platform-specific fixes without running the full PR pipeline.
 #
 # Trigger via GitHub UI or CLI:
-#   gh workflow run "Cross-Platform Tests" --ref your-branch
+#   gh workflow run "Quick Platform Tests" --ref your-branch
 
-name: Cross-Platform Tests
+name: Quick Platform Tests
 
 on:
   workflow_dispatch:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,21 +65,21 @@ Or use the dev script for a more comprehensive validation (includes formatting, 
 ./dev --validate
 ```
 
-#### Cross-Platform Testing
+#### Quick Platform Testing
 
 Rad supports Linux, macOS, and Windows. PR checks automatically run Go tests on all three platforms.
 
-If you're working on a platform-specific fix and want faster feedback than the full PR pipeline, you can manually trigger cross-platform tests on your branch:
+If you're working on a platform-specific fix and want faster feedback than the full PR pipeline, you can manually trigger quick platform tests on your branch:
 
 ```shell
 # Test on all platforms
-gh workflow run "Cross-Platform Tests" --ref your-branch
+gh workflow run "Quick Platform Tests" --ref your-branch
 
 # Test only on Windows
-gh workflow run "Cross-Platform Tests" --ref your-branch -f platforms=windows
+gh workflow run "Quick Platform Tests" --ref your-branch -f platforms=windows
 
 # Test only on macOS
-gh workflow run "Cross-Platform Tests" --ref your-branch -f platforms=macos
+gh workflow run "Quick Platform Tests" --ref your-branch -f platforms=macos
 ```
 
 This is particularly useful when debugging issues that only reproduce on specific platforms.

--- a/ci/pr-comment.rad
+++ b/ci/pr-comment.rad
@@ -7,9 +7,10 @@ Reads data from GitHub Actions environment and temp files.
 print("💬 Generating PR comment...")
 
 // Read test results from GitHub Actions environment
-tests_passed = get_env("TESTS_PASSED") == "true"
+linux_passed = get_env("LINUX_PASSED") == "true"
+macos_passed = get_env("MACOS_PASSED") == "true"
+windows_passed = get_env("WINDOWS_PASSED") == "true"
 tests_job_url = get_env("TESTS_JOB_URL")
-cross_platform_passed = get_env("CROSS_PLATFORM_PASSED") == "true"
 binary_job_url = get_env("BINARY_JOB_URL")
 benchmark_job_url = get_env("BENCHMARK_JOB_URL")
 
@@ -43,14 +44,15 @@ if type_of(benchmark_file) != "error":
         print("⚠️ Could not parse benchmark data: {benchmark_data}")
         benchmark_data = null
 
-// Determine test status icon and message
-test_icon = tests_passed ? "✅" : "❌"
-test_message = tests_passed ? "All tests passed" : "Tests failed"
-test_link = tests_job_url ? " ([view logs]({tests_job_url}))" : ""
+// Determine platform test status icons
+linux_icon = linux_passed ? "✅" : "❌"
+macos_icon = macos_passed ? "✅" : "❌"
+windows_icon = windows_passed ? "✅" : "❌"
 
-// Determine cross-platform test status
-cross_platform_icon = cross_platform_passed ? "✅" : "❌"
-cross_platform_message = cross_platform_passed ? "macOS & Windows tests passed" : "Cross-platform tests failed"
+// Determine overall test status
+all_tests_passed = linux_passed and macos_passed and windows_passed
+tests_header_icon = all_tests_passed ? "✅" : "❌"
+test_link = tests_job_url ? " ([view logs]({tests_job_url}))" : ""
 
 // Determine binary size change significance for rad
 rad_size_change_icon = get_size_change_icon(binary_data.rad.diff_percent)
@@ -93,11 +95,12 @@ radls_change_text = binary_data.radls.diff_percent != null ? "{radls_size_change
 comment = """
 ## 🔍 PR Checks Summary
 
-### {test_icon} Tests (Linux)
-{test_message}{test_link}
-
-### {cross_platform_icon} Cross-Platform Tests
-{cross_platform_message}
+### {tests_header_icon} Platform Tests{test_link}
+| Platform | Status |
+|----------|--------|
+| Linux    | {linux_icon}     |
+| macOS    | {macos_icon}     |
+| Windows  | {windows_icon}     |
 
 ### 📊 Binary Size Impact (linux/amd64)
 | Binary | Base ({base_commit_short}) | PR ({pr_commit_short}) | Change |


### PR DESCRIPTION
Previously, Linux was the "main" test target with macOS/Windows grouped under "cross-platform tests". This framing implied secondary status for non-Linux platforms.

Changes:
- Split tests into three equal jobs: tests-linux, tests-macos, tests-windows
- PR comment now shows unified platform table with individual status for each
- Renamed manual workflow from "Cross-Platform Tests" to "Quick Platform Tests"

The PR comment now displays:
| Platform | Status |
|----------|--------|
| Linux    | ✅     |
| macOS    | ✅     |
| Windows  | ✅     |