### PR TITLE
perf: eliminate per-eval CGo cursor allocation

### DIFF
--- a/core/func_helpers.go
+++ b/core/func_helpers.go
@@ -35,8 +35,8 @@ type namedArg struct {
 
 func (i *Interpreter) callFunction(callNode *ts.Node, ufcsArg *PosArg) RadValue {
 	funcNameNode := rl.GetChild(callNode, rl.F_FUNC)
-	argNodes := rl.GetChildren(callNode, rl.F_ARG)
-	namedArgNodes := rl.GetChildren(callNode, rl.F_NAMED_ARG)
+	argNodes := rl.GetChildren(callNode, rl.F_ARG, i.cursor)
+	namedArgNodes := rl.GetChildren(callNode, rl.F_NAMED_ARG, i.cursor)
 
 	funcName := i.GetSrcForNode(funcNameNode)
 

--- a/core/json_path.go
+++ b/core/json_path.go
@@ -30,7 +30,7 @@ type JsonPathSegmentIdx struct {
 }
 
 func NewJsonFieldVar(i *Interpreter, leftNode, jsonPathNode *ts.Node) *JsonFieldVar {
-	indexingNodes := rl.GetChildren(leftNode, rl.F_INDEXING)
+	indexingNodes := rl.GetChildren(leftNode, rl.F_INDEXING, i.cursor)
 	if len(indexingNodes) != 0 {
 		i.emitError(rl.ErrInvalidSyntax, leftNode, "Json paths must be defined to plain identifiers")
 	}
@@ -38,11 +38,11 @@ func NewJsonFieldVar(i *Interpreter, leftNode, jsonPathNode *ts.Node) *JsonField
 
 	var segments []JsonPathSegment
 
-	segmentNodes := rl.GetChildren(jsonPathNode, rl.F_SEGMENT)
+	segmentNodes := rl.GetChildren(jsonPathNode, rl.F_SEGMENT, i.cursor)
 	for _, segmentNode := range segmentNodes {
 		identifierNode := rl.GetChild(&segmentNode, rl.F_KEY)
 		identifierStr := i.GetSrcForNode(identifierNode)
-		indexNodes := rl.GetChildren(&segmentNode, rl.F_INDEX)
+		indexNodes := rl.GetChildren(&segmentNode, rl.F_INDEX, i.cursor)
 
 		var idxSegments []JsonPathSegmentIdx
 		for _, indexNode := range indexNodes {

--- a/core/rad_block.go
+++ b/core/rad_block.go
@@ -72,7 +72,7 @@ func (i *Interpreter) runRadBlock(radBlockNode *ts.Node) {
 		colToMods:        make(map[string]*radFieldMods),
 	}
 
-	radStmtNodes := rl.GetChildren(radBlockNode, rl.F_STMT)
+	radStmtNodes := rl.GetChildren(radBlockNode, rl.F_STMT, i.cursor)
 	for _, radStmtNode := range radStmtNodes {
 		ri.evalRad(&radStmtNode)
 	}
@@ -96,7 +96,7 @@ func (r *radInvocation) unsafeEvalRad(node *ts.Node) {
 	switch node.Kind() {
 	case rl.K_RAD_FIELD_STMT:
 		// todo validate no field names conflict with keywords e.g. 'asc'. Would be nice to do in static analysis tho.
-		identifierNodes := rl.GetChildren(node, rl.F_IDENTIFIER)
+		identifierNodes := rl.GetChildren(node, rl.F_IDENTIFIER, r.i.cursor)
 		for _, identifierNode := range identifierNodes {
 			r.fields = append(r.fields, &identifierNode)
 		}
@@ -105,7 +105,7 @@ func (r *radInvocation) unsafeEvalRad(node *ts.Node) {
 			r.i.emitError(rl.ErrUnsupportedOperation, node, "Only one sort statement allowed per rad block")
 		}
 
-		specifierNodes := rl.GetChildren(node, rl.F_SPECIFIER)
+		specifierNodes := rl.GetChildren(node, rl.F_SPECIFIER, r.i.cursor)
 		if len(specifierNodes) == 0 {
 			r.generalSort = &GeneralSort{
 				Node: node,
@@ -149,8 +149,8 @@ func (r *radInvocation) unsafeEvalRad(node *ts.Node) {
 			Dir:           dir,
 		})
 	case rl.K_RAD_FIELD_MODIFIER_STMT:
-		identifierNodes := rl.GetChildren(node, rl.F_IDENTIFIER)
-		stmtNodes := rl.GetChildren(node, rl.F_MOD_STMT)
+		identifierNodes := rl.GetChildren(node, rl.F_IDENTIFIER, r.i.cursor)
+		stmtNodes := rl.GetChildren(node, rl.F_MOD_STMT, r.i.cursor)
 		var fields []radField
 		for _, identifierNode := range identifierNodes {
 			identifierStr := r.i.GetSrcForNode(&identifierNode)
@@ -195,7 +195,7 @@ func (r *radInvocation) unsafeEvalRad(node *ts.Node) {
 			}
 		}
 	case rl.K_RAD_IF_STMT:
-		altNodes := rl.GetChildren(node, rl.F_ALT)
+		altNodes := rl.GetChildren(node, rl.F_ALT, r.i.cursor)
 		for _, altNode := range altNodes {
 			condNode := rl.GetChild(&altNode, rl.F_CONDITION)
 
@@ -206,7 +206,7 @@ func (r *radInvocation) unsafeEvalRad(node *ts.Node) {
 			}
 
 			if shouldExecute {
-				stmtNodes := rl.GetChildren(&altNode, rl.F_STMT)
+				stmtNodes := rl.GetChildren(&altNode, rl.F_STMT, r.i.cursor)
 				for _, stmtNode := range stmtNodes {
 					r.evalRad(&stmtNode)
 				}

--- a/core/shell.go
+++ b/core/shell.go
@@ -39,8 +39,8 @@ type ShellExecutor func(invocation ShellInvocation) (string, string, int)
 
 func (i *Interpreter) executeShellStmt(shellStmtNode *ts.Node) EvalResult {
 	// Get left-hand variables for assignment
-	leftNode := rl.GetChildren(shellStmtNode, rl.F_LEFT)
-	leftNodes := rl.GetChildren(shellStmtNode, rl.F_LEFTS)
+	leftNode := rl.GetChildren(shellStmtNode, rl.F_LEFT, i.cursor)
+	leftNodes := rl.GetChildren(shellStmtNode, rl.F_LEFTS, i.cursor)
 	leftNodes = append(leftNode, leftNodes...)
 
 	if len(leftNodes) > 3 {
@@ -76,7 +76,7 @@ func (i *Interpreter) executeShellStmt(shellStmtNode *ts.Node) EvalResult {
 		assignResults(*result)
 
 		// Run catch block statements
-		stmtNodes := rl.GetChildren(catchBlockNode, rl.F_STMT)
+		stmtNodes := rl.GetChildren(catchBlockNode, rl.F_STMT, i.cursor)
 		res := i.runBlock(stmtNodes)
 		if res.Ctrl != CtrlNormal {
 			return res // Propagate control flow (return/break/continue)
@@ -128,7 +128,7 @@ func (i *Interpreter) namedCaptureMode(leftNodes []ts.Node) (captureStdout bool,
 
 func (i *Interpreter) executeShellCmd(shellCmdNode *ts.Node, captureStdout, captureStderr bool) shellResult {
 	// Check for modifiers by inspecting all modifier nodes
-	modifierNodes := rl.GetChildren(shellCmdNode, rl.F_MODIFIER)
+	modifierNodes := rl.GetChildren(shellCmdNode, rl.F_MODIFIER, i.cursor)
 	var isQuiet, isConfirm bool
 	// todo they should be using different field names, really
 	for _, modNode := range modifierNodes {

--- a/core/type_fn.go
+++ b/core/type_fn.go
@@ -20,7 +20,7 @@ type RadFn struct {
 
 func NewFn(i *Interpreter, fnNode *ts.Node) RadFn {
 	typing := rl.NewTypingFnT(fnNode, i.GetSrc())
-	stmts := rl.GetChildren(fnNode, rl.F_STMT)
+	stmts := rl.GetChildren(fnNode, rl.F_STMT, i.cursor)
 	reprNode := fnNode
 	isBlock := rl.GetChild(fnNode, rl.F_BLOCK_COLON) != nil
 

--- a/rts/nodes_args.go
+++ b/rts/nodes_args.go
@@ -592,7 +592,8 @@ func extractString(src string, stringNode *ts.Node) string {
 
 	// todo should handle string interpolation somehow
 	var sb strings.Builder
-	contentChildren := contents.Children(contents.Walk())
+	cursor := contents.Walk()
+	contentChildren := contents.Children(cursor)
 	for i, content := range contentChildren {
 		childSrc := src[content.StartByte():content.EndByte()]
 		childFieldName := contents.FieldNameForChild(uint32(i))

--- a/rts/rl/util.go
+++ b/rts/rl/util.go
@@ -4,14 +4,83 @@ import (
 	ts "github.com/tree-sitter/go-tree-sitter"
 )
 
-func GetChildren(node *ts.Node, fieldName string) []ts.Node {
-	return node.ChildrenByFieldName(fieldName, node.Walk())
+// fieldIds caches field name -> numeric ID mappings, eliminating repeated
+// CString conversions through the CGo boundary. Initialized once via InitFieldIds.
+var fieldIds map[string]uint16
+
+// InitFieldIds pre-computes numeric field IDs for all known field names.
+// Must be called once after parsing, before any hot-path GetChildren/GetChild calls.
+// Before initialization, GetChildren/GetChild fall back to the original tree-sitter
+// string-based lookups (used during init-time signature parsing).
+func InitFieldIds(node *ts.Node) {
+	lang := node.Language()
+	fieldIds = make(map[string]uint16, len(allFieldNames))
+	for _, name := range allFieldNames {
+		fieldIds[name] = lang.FieldIdForName(name)
+	}
 }
 
+// GetChildren returns all children of node with the given field name,
+// using a reusable cursor to avoid per-call CGo cursor allocation.
+//
+// Falls back to ChildrenByFieldName if field IDs haven't been initialized
+// (e.g. during init-time signature parsing).
+func GetChildren(node *ts.Node, fieldName string, cursor *ts.TreeCursor) []ts.Node {
+	if fieldIds == nil {
+		return node.ChildrenByFieldName(fieldName, cursor)
+	}
+	fieldId := fieldIds[fieldName]
+	if fieldId == 0 {
+		return nil
+	}
+	cursor.Reset(*node)
+	if !cursor.GotoFirstChild() {
+		return nil
+	}
+	var result []ts.Node
+	for {
+		if cursor.FieldId() == fieldId {
+			n := cursor.Node()
+			result = append(result, *n)
+		}
+		if !cursor.GotoNextSibling() {
+			break
+		}
+	}
+	return result
+}
+
+// GetChild returns the first child of node with the given field name,
+// using cached field IDs to avoid CString conversion.
+//
+// Falls back to ChildByFieldName if field IDs haven't been initialized.
 func GetChild(node *ts.Node, fieldName string) *ts.Node {
-	return node.ChildByFieldName(fieldName)
+	if fieldIds == nil {
+		return node.ChildByFieldName(fieldName)
+	}
+	return node.ChildByFieldId(fieldIds[fieldName])
 }
 
 func GetSrc(node *ts.Node, src string) string {
 	return src[node.StartByte():node.EndByte()]
+}
+
+// allFieldNames lists every F_* constant for field ID pre-computation.
+var allFieldNames = []string{
+	F_LEFT, F_LEFTS, F_RIGHT, F_ROOT, F_INDEXING, F_INDEX,
+	F_LIST_ENTRY, F_FUNC, F_ARG, F_NAMED_ARG, F_OP, F_CONTENTS,
+	F_EXPR, F_FORMAT, F_THOUSANDS_SEPARATOR, F_ALIGNMENT, F_PADDING,
+	F_PRECISION, F_MAP_ENTRY, F_KEY, F_VALUE, F_ALT, F_CONDITION,
+	F_STMT, F_KEYWORD, F_START, F_END, F_SHELL_CMD, F_MODIFIER,
+	F_QUIET_MOD, F_CONFIRM_MOD, F_COMMAND, F_SEGMENT, F_SOURCE,
+	F_RAD_TYPE, F_IDENTIFIER, F_SPECIFIER, F_MOD_STMT, F_COLOR,
+	F_REGEX, F_LAMBDA, F_TRUE_BRANCH, F_FALSE_BRANCH, F_NAME,
+	F_FIRST, F_SECOND, F_DISCRIMINANT, F_CASE, F_CASE_KEY,
+	F_DEFAULT, F_YIELD_STMT, F_RETURN_STMT, F_DELEGATE, F_PARAM,
+	F_METADATA_ENTRY, F_BLOCK_COLON, F_CATCH, F_TYPE, F_RETURN_TYPE,
+	F_VARARG_MARKER, F_VARIADIC_MARKER, F_OPTIONAL, F_LEAF_TYPE,
+	F_ANY, F_ENUM, F_NAMED_ENTRY, F_KEY_NAME, F_KEY_TYPE,
+	F_VALUE_TYPE, F_LIST, F_NORMAL_PARAM, F_NAMED_ONLY_PARAM,
+	F_VARARG_PARAM, F_CALLBACK_IDENTIFIER, F_CALLBACK_LAMBDA,
+	F_DESCRIPTION, F_CALLS, F_CONTEXT,
 }


### PR DESCRIPTION
Profiling showed 80% of CPU time in tight loops was spent crossing the CGo boundary - primarily from creating a new TreeCursor on every GetChildren call (72% alone) and converting field name strings to C strings on every GetChild call.

Two optimizations:

1. Pre-compute field IDs once at startup via InitFieldIds, then use numeric ChildByFieldId instead of string-based ChildByFieldName. Eliminates repeated CString allocs.

2. Reuse a single TreeCursor stored on the Interpreter, passing it into GetChildren which now does Reset + manual child iteration by field ID. Eliminates the per-call cursor creation that dominated the profile.

Both functions fall back to the original string-based API when field IDs haven't been initialized yet, which happens during init()-time signature parsing in rts/signatures.go. The REPL lazily initializes cursor and field IDs on first EvaluateStatement since it starts with no tree.