### PR TITLE
fix: preserve text attributes in trim, reverse, slice

### DIFF
--- a/core/interpreter.go
+++ b/core/interpreter.go
@@ -1302,7 +1302,7 @@ func (i *Interpreter) evalSlice(contextNode rl.Node, seg rl.PathSegment, val Rad
 	case RadString:
 		length := coerced.Len()
 		start, end := i.resolveSliceBounds(seg, length)
-		return newRadValues(i, contextNode, NewRadString(string(coerced.Runes()[start:end])))
+		return newRadValues(i, contextNode, coerced.SubSlice(start, end))
 	case *RadList:
 		length := coerced.Len()
 		start, end := i.resolveSliceBounds(seg, length)

--- a/core/testing/snapshots/functions/reverse.snap
+++ b/core/testing/snapshots/functions/reverse.snap
@@ -83,3 +83,21 @@ print(reverse("a😀b"))
 ### STDOUT ###
 b😀a
 
+### TITLE ###
+Preserves color attributes
+### INPUT ###
+print(reverse(red("hello")))
+### ARGS ###
+--color=always
+### STDOUT ###
+[31molleh[0m
+
+### TITLE ###
+Preserves color across segments
+### INPUT ###
+print(reverse(red("he") + blue("llo")))
+### ARGS ###
+--color=always
+### STDOUT ###
+[34moll[0m[31meh[0m
+

--- a/core/testing/snapshots/functions/trim.snap
+++ b/core/testing/snapshots/functions/trim.snap
@@ -22,3 +22,23 @@ print(trim(a, "!,"))
 ### STDOUT ###
 hello
 
+### TITLE ###
+Preserves color attributes
+### INPUT ###
+a = "  " + red("hello") + "  "
+print(trim(a))
+### ARGS ###
+--color=always
+### STDOUT ###
+[31mhello[0m
+
+### TITLE ###
+Preserves color across segment boundary
+### INPUT ###
+a = ", " + red("he") + blue("llo") + " ,"
+print(trim(a, " ,"))
+### ARGS ###
+--color=always
+### STDOUT ###
+[31mhe[0m[34mllo[0m
+

--- a/core/testing/snapshots/functions/trim_left.snap
+++ b/core/testing/snapshots/functions/trim_left.snap
@@ -19,3 +19,13 @@ print(trim_left("  hello  "))
 ### STDOUT ###
 hello  
 
+### TITLE ###
+Preserves color attributes
+### INPUT ###
+a = "  " + red("hello") + "  "
+print(trim_left(a))
+### ARGS ###
+--color=always
+### STDOUT ###
+[31mhello[0m  
+

--- a/core/testing/snapshots/functions/trim_prefix.snap
+++ b/core/testing/snapshots/functions/trim_prefix.snap
@@ -40,3 +40,23 @@ print(trim_prefix("hello", ""))
 ### STDOUT ###
 hello
 
+### TITLE ###
+Preserves color attributes
+### INPUT ###
+a = "xx" + red("hello")
+print(trim_prefix(a, "xx"))
+### ARGS ###
+--color=always
+### STDOUT ###
+[31mhello[0m
+
+### TITLE ###
+Preserves color across segment boundary
+### INPUT ###
+a = red("xx") + blue("hello")
+print(trim_prefix(a, "xx"))
+### ARGS ###
+--color=always
+### STDOUT ###
+[34mhello[0m
+

--- a/core/testing/snapshots/functions/trim_right.snap
+++ b/core/testing/snapshots/functions/trim_right.snap
@@ -19,3 +19,13 @@ print(trim_right("  hello  "))
 ### STDOUT ###
   hello
 
+### TITLE ###
+Preserves color attributes
+### INPUT ###
+a = "  " + red("hello") + "  "
+print(trim_right(a))
+### ARGS ###
+--color=always
+### STDOUT ###
+  [31mhello[0m
+

--- a/core/testing/snapshots/functions/trim_suffix.snap
+++ b/core/testing/snapshots/functions/trim_suffix.snap
@@ -40,3 +40,23 @@ print(trim_suffix("hello", ""))
 ### STDOUT ###
 hello
 
+### TITLE ###
+Preserves color attributes
+### INPUT ###
+a = red("hello") + "xx"
+print(trim_suffix(a, "xx"))
+### ARGS ###
+--color=always
+### STDOUT ###
+[31mhello[0m
+
+### TITLE ###
+Preserves color across segment boundary
+### INPUT ###
+a = red("hello") + blue("xx")
+print(trim_suffix(a, "xx"))
+### ARGS ###
+--color=always
+### STDOUT ###
+[31mhello[0m
+

--- a/core/testing/snapshots/operators/slice_string.snap
+++ b/core/testing/snapshots/operators/slice_string.snap
@@ -114,3 +114,23 @@ a
 b
 a😀b
 
+### TITLE ###
+Slice string preserves color
+### INPUT ###
+a = red("hello")
+print(a[1:4])
+### ARGS ###
+--color=always
+### STDOUT ###
+[31mell[0m
+
+### TITLE ###
+Slice string preserves color across segments
+### INPUT ###
+a = red("he") + blue("llo")
+print(a[1:4])
+### ARGS ###
+--color=always
+### STDOUT ###
+[31me[0m[34mll[0m
+

--- a/core/testing/snapshots/types/color.snap
+++ b/core/testing/snapshots/types/color.snap
@@ -7,13 +7,13 @@ Alice
 
 ### TITLE ###
 Can slice colored string
-### DESCRIPTION ###
-TODO: this *should* be red
 ### INPUT ###
 a = upper(red("Alice"))
 print(a[2:4])
+### ARGS ###
+--color=always
 ### STDOUT ###
-IC
+[31mIC[0m
 
 ### TITLE ###
 Color equality

--- a/docs-web/docs/guide/strings-advanced.md
+++ b/docs-web/docs/guide/strings-advanced.md
@@ -264,10 +264,8 @@ and the `hyperlink` function for creating clickable terminal links. See the [fun
 
 !!! info "When Attributes Are Preserved"
 
-    - **Preserved**: Interpolation, concatenation, and index lookup maintain attributes
-    - **Not preserved**: Most string functions like `replace()`, `split()`, `upper()`, and `lower()` return plain strings
-
-    We intend to preserve attributes in more situations in future versions of Rad.
+    - **Preserved**: Interpolation, concatenation, index lookup, slicing, `upper()`, `lower()`, `trim()`, `trim_prefix()`, `trim_suffix()`, `trim_left()`, `trim_right()`, and `reverse()`
+    - **Not preserved**: `replace()`, `split()`
 
 !!! tip "String Manipulation Functions"
 

--- a/docs-web/docs/reference/functions.md
+++ b/docs-web/docs/reference/functions.md
@@ -683,7 +683,7 @@ count("test", "xyz")          // -> 0
 
 ### trim
 
-Strips all matching characters from both ends of a string.
+Strips all matching characters from both ends of a string. Preserves color attributes.
 
 ```rad
 trim(_subject: str, _chars: str = " \t\n") -> str
@@ -697,7 +697,7 @@ trim("abcHELLOabc", "abc")   // -> "HELLO"
 
 ### trim_left
 
-Strips all matching characters from the start of a string.
+Strips all matching characters from the start of a string. Preserves color attributes.
 
 ```rad
 trim_left(_subject: str, _chars: str = " \t\n") -> str
@@ -711,7 +711,7 @@ trim_left("aaabbb", "a")        // -> "bbb"
 
 ### trim_right
 
-Strips all matching characters from the end of a string.
+Strips all matching characters from the end of a string. Preserves color attributes.
 
 ```rad
 trim_right(_subject: str, _chars: str = " \t\n") -> str
@@ -725,7 +725,7 @@ trim_right("aaabbb", "b")       // -> "aaa"
 
 ### trim_prefix
 
-Removes a literal prefix from the start of a string (once).
+Removes a literal prefix from the start of a string (once). Preserves color attributes.
 
 ```rad
 trim_prefix(_subject: str, _prefix: str) -> str
@@ -739,7 +739,7 @@ trim_prefix("test", "x")              // -> "test" (no match)
 
 ### trim_suffix
 
-Removes a literal suffix from the end of a string (once).
+Removes a literal suffix from the end of a string (once). Preserves color attributes.
 
 ```rad
 trim_suffix(_subject: str, _suffix: str) -> str
@@ -753,7 +753,7 @@ trim_suffix("test", "x")              // -> "test" (no match)
 
 ### reverse
 
-Reverses a string or list.
+Reverses a string or list. Preserves color attributes for strings.
 
 ```rad
 reverse(_val: str|list) -> str|list


### PR DESCRIPTION
These operations were discarding RadString segment attributes (colors, styles, hyperlinks, RGB) by flattening to .Plain() before operating. Now they work on segments directly.

Add SubSlice(start, end) as the core primitive for extracting a rune range while preserving per-segment attributes. Rewrite all six trim functions to compute rune offsets and delegate to SubSlice. Rewrite Reverse to reverse both segment order and runes within each segment. Fix the slice operator (a[start:end]) to use SubSlice instead of reconstructing a plain string.

Also fix a pre-existing shallow-copy bug in DeepCopy and the new methods: segment Attributes slices and Rgb pointers were aliased between original and copy. Added a deepCopy helper on radStringSegment to properly isolate copied segments.