### PR TITLE
feat: add limit param to split()

### DIFF
--- a/core/testing/snapshots/functions/split.snap
+++ b/core/testing/snapshots/functions/split.snap
@@ -35,3 +35,71 @@ print(tags)
 ### STDOUT ###
 [ [ "0", "0", "1" ], [ "0", "2", "1" ], [ "0", "0", "3" ] ]
 
+### TITLE ###
+Limit of 1 splits once
+### INPUT ###
+print(split("a,b,c", ",", limit=1))
+### STDOUT ###
+[ "a", "b,c" ]
+
+### TITLE ###
+Limit of 2 splits twice
+### INPUT ###
+print(split("a,b,c", ",", limit=2))
+### STDOUT ###
+[ "a", "b", "c" ]
+
+### TITLE ###
+Limit exceeding separators returns all
+### INPUT ###
+print(split("a,b,c", ",", limit=10))
+### STDOUT ###
+[ "a", "b", "c" ]
+
+### TITLE ###
+Regex with limit
+### INPUT ###
+print(split("a b c d", " +", limit=1))
+### STDOUT ###
+[ "a", "b c d" ]
+
+### TITLE ###
+Literal fallback with limit
+### INPUT ###
+print(split("a[b[c", "[", limit=1))
+### STDOUT ###
+[ "a", "b[c" ]
+
+### TITLE ###
+Limit of zero errors
+### INPUT ###
+split("a,b,c", ",", limit=0)
+### STDERR ###
+error[RAD20000]: limit must be at least 1, got 0
+  --> <script>:1:1
+  |
+1 | split("a,b,c", ",", limit=0)
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+   = info: rad explain RAD20000
+
+
+### EXIT ###
+1
+
+### TITLE ###
+Negative limit errors
+### INPUT ###
+split("a,b,c", ",", limit=-1)
+### STDERR ###
+error[RAD20000]: limit must be at least 1, got -1
+  --> <script>:1:1
+  |
+1 | split("a,b,c", ",", limit=-1)
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+   = info: rad explain RAD20000
+
+
+### EXIT ###
+1

--- a/docs-web/docs/reference/functions.md
+++ b/docs-web/docs/reference/functions.md
@@ -657,15 +657,20 @@ truncate("test", 0)          // -> Error: Requires at least 1
 Splits a string using regex pattern as delimiter. Does not preserve string color attributes.
 
 ```rad
-split(_val: str, _sep: str) -> list[str]
+split(_val: str, _sep: str, *, limit: int?) -> str[]
 ```
 
 The `_sep` parameter is treated as a regex pattern if valid, otherwise as literal string.
 
+When `limit` is provided, it caps the number of splits performed. The final element contains
+the unsplit remainder. `limit` must be >= 1.
+
 ```rad
-split("a,b,c", ",")            // -> ["a", "b", "c"]
-split("word1 word2", "\\s+")   // -> ["word1", "word2"]
-split("abc123def", "\\d+")     // -> ["abc", "def"]
+split("a,b,c", ",")               // -> ["a", "b", "c"]
+split("word1 word2", "\\s+")      // -> ["word1", "word2"]
+split("abc123def", "\\d+")        // -> ["abc", "def"]
+split("key=val=ue", "=", limit=1) // -> ["key", "val=ue"]
+split("a,b,c,d", ",", limit=2)    // -> ["a", "b", "c,d"]
 ```
 
 ### split_lines

--- a/rts/signatures.go
+++ b/rts/signatures.go
@@ -46,7 +46,7 @@ func init() {
 		newFnSignature(`type_of(_var: any) -> ["int", "str", "list", "map", "float"]`),
 		newFnSignature(`range(_arg1: float|int, _arg2: float?|int?, _step: float|int = 1) -> float[]|int[]`),
 		newFnSignature(`join(_list: list, sep: str = "", prefix: str = "", suffix: str = "") -> str`),
-		newFnSignature(`split(_val: str, _sep: str) -> str[]`),
+		newFnSignature(`split(_val: str, _sep: str, *, limit: int?) -> str[]`),
 		newFnSignature(`split_lines(_val: str) -> str[]`),
 		newFnSignature(`lower(_val: str) -> str`),
 		newFnSignature(`upper(_val: str) -> str`),


### PR DESCRIPTION
The limit counts split operations, not output parts, so limit=1 means "split once" and returns 2 parts. This matches Python's maxsplit semantics, which is the most intuitive model for the common case of splitting on the first occurrence (e.g. parsing "key=val=ue" on "=").

Internally we pass limit+1 to Go's SplitN since Go counts output parts rather than splits.