### PR TITLE
feat(shell): auto-detect shell on Windows

### DIFF
--- a/.kan/boards/bugfixes/config.toml
+++ b/.kan/boards/bugfixes/config.toml
@@ -1,6 +1,6 @@
 default_column = "todo-lo"
 id = "b_sBGk8Gtk"
-kan_schema = "board/10"
+kan_schema = "board/11"
 name = "bugfixes"
 
 [card_display]

--- a/.kan/boards/main/cards/3d85TpNT.json
+++ b/.kan/boards/main/cards/3d85TpNT.json
@@ -2,12 +2,12 @@
   "_v": 2,
   "alias": "rad-9-transposing-tables",
   "alias_explicit": false,
-  "column": "low",
+  "column": "in-progress",
   "created_at_millis": 1767762148915,
   "creator": "Alexander Terp",
   "id": "3d85TpNT",
-  "position": "0K",
+  "position": "U",
   "title": "RAD-9: Transposing tables",
   "type": "feature",
-  "updated_at_millis": 1767762148915
+  "updated_at_millis": 1775785559110
 }

--- a/.kan/boards/main/cards/a_1BidxHsvp.json
+++ b/.kan/boards/main/cards/a_1BidxHsvp.json
@@ -1,0 +1,14 @@
+{
+  "_v": 2,
+  "alias": "windows-shell-macro",
+  "alias_explicit": false,
+  "column": "uncommitted",
+  "created_at_millis": 1778118725524,
+  "creator": "Alexander Terp",
+  "description": "From #123 thread: auto-detect on Windows ships now (PowerShell first, cmd.exe fallback) but creates portability variance across machines. Add a script-header macro/pragma like '@shell bash' or 'requires_shell = bash' that lets a script declare its required shell and fail-fast if unavailable. Complements (does not replace) auto-detect: macro is for 'this script needs bash', auto-detect is for 'I just want shell commands to work'. Prior art: shebangs, Go's //go:build, Python's # -*- coding -*-. Could live alongside the existing args/header block.",
+  "id": "a_1BidxHsvp",
+  "position": "wiU",
+  "title": "Windows: @shell macro for pinning shell target",
+  "type": "feature",
+  "updated_at_millis": 1778118725524
+}

--- a/.kan/boards/main/cards/a_1Bie7LvAa.json
+++ b/.kan/boards/main/cards/a_1Bie7LvAa.json
@@ -1,0 +1,14 @@
+{
+  "_v": 2,
+  "alias": "windows-docs-for",
+  "alias_explicit": false,
+  "column": "high",
+  "created_at_millis": 1778118731762,
+  "creator": "Alexander Terp",
+  "description": "From #123 thread: user couldn't 'go build' or 'go install' on Windows because tree-sitter requires CGO and gcc. They fixed it by installing MinGW (WinLibs) and putting gcc on PATH. Add a 'Building from Source on Windows' section to the docs noting: CGO_ENABLED=1 needed, gcc must be on PATH, recommend WinLibs/MinGW or MSYS2. Note that pre-built binaries (rad_windows_amd64.zip in releases) avoid this entirely - most users should use those.",
+  "id": "a_1Bie7LvAa",
+  "position": "t!U",
+  "title": "Windows: docs for building from source (CGO/MinGW)",
+  "type": "chore",
+  "updated_at_millis": 1778119792090
+}

--- a/.kan/boards/main/cards/a_1BieHfp6E.json
+++ b/.kan/boards/main/cards/a_1BieHfp6E.json
@@ -1,0 +1,14 @@
+{
+  "_v": 2,
+  "alias": "windows-uplift-cross",
+  "alias_explicit": false,
+  "column": "next",
+  "created_at_millis": 1778118738164,
+  "creator": "Alexander Terp",
+  "description": "The 'windows' branch has commits adding cross-platform testing for macOS/Windows (e085011a) and platform-normalization improvements (64227082, 5fdf8fd8). Review and uplift the relevant pieces to main so we get Windows coverage in CI. Without this, Windows fixes (like the auto-shell-detect for #123) only get verified by users hitting issues, not by automation.",
+  "id": "a_1BieHfp6E",
+  "position": "t!UU",
+  "title": "Windows: uplift cross-platform CI from windows branch",
+  "type": "excellence",
+  "updated_at_millis": 1778119788265
+}

--- a/.kan/boards/main/cards/a_1BiySevmD.json
+++ b/.kan/boards/main/cards/a_1BiySevmD.json
@@ -1,0 +1,14 @@
+{
+  "_v": 2,
+  "alias": "fix-vet-warnings-in",
+  "alias_explicit": false,
+  "column": "next",
+  "created_at_millis": 1778119513772,
+  "creator": "Alexander Terp",
+  "description": "Found while working on #123 fix: 'make test' currently only runs ./core/testing/... not ./core/..., so unit tests in core/ (fuzzy_test.go, shell_test.go) don't run in ./dev --validate. Switching to ./core/... exposes pre-existing vet warnings - 'non-constant format string in call to NewErrorStrf' in core/funcs.go and core/func_parse_date.go (16 instances). Fix these (likely just s/NewErrorStrf/NewErrorStr/ where the arg is already-formatted) then expand the Makefile test target to ./core/... so unit tests are actually exercised by validate.",
+  "id": "a_1BiySevmD",
+  "position": "t!U",
+  "title": "Fix vet warnings in core, expand make test to ./core/...",
+  "type": "excellence",
+  "updated_at_millis": 1778119773514
+}

--- a/.kan/boards/main/cards/a_1BjqOvRU8.json
+++ b/.kan/boards/main/cards/a_1BjqOvRU8.json
@@ -1,0 +1,14 @@
+{
+  "_v": 2,
+  "alias": "surface-shell",
+  "alias_explicit": false,
+  "column": "low",
+  "created_at_millis": 1778121587222,
+  "creator": "Alexander Terp",
+  "description": "Found in code review of #123 fix: when shell resolution panics (e.g. 'Cannot run shell cmd as no shell found' at core/shell.go:208, or 'Failed to run command' at :186) it propagates as a string panic, not *RadPanic. handlePanicRecovery treats string panics as internal bugs and tells the user 'This is a bug in Rad. Please report it at: https://github.com/amterp/rad/issues. Panic: \u003cmessage\u003e'. The user-actionable text gets buried inside a 'this is our fault' template. This predates the Windows fix but became more visible now that Windows users can hit shell errors. Convert these to proper RadErrors / *RadPanics so they surface as clean user-facing errors instead.",
+  "id": "a_1BjqOvRU8",
+  "position": "xRUU",
+  "title": "Surface shell-resolution panics as user errors, not 'bug in Rad'",
+  "type": "bug",
+  "updated_at_millis": 1778121587222
+}

--- a/.kan/boards/main/config.toml
+++ b/.kan/boards/main/config.toml
@@ -1,6 +1,6 @@
 default_column = "uncommitted"
 id = "3d0a0ABE"
-kan_schema = "board/10"
+kan_schema = "board/11"
 name = "main"
 
 [card_display]

--- a/core/shell.go
+++ b/core/shell.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"strings"
 
 	"github.com/amterp/rad/rts/rl"
 )
@@ -197,33 +198,84 @@ func realShellExecutor(invocation ShellInvocation) (string, string, int) {
 	return stdout, stderr, exitCode
 }
 
+// resolveCmdSimple resolves the shell to use for the given command string and
+// returns a prepared *exec.Cmd. Panics with a user-facing message if no shell
+// can be found.
 func resolveCmdSimple(cmdStr string) *exec.Cmd {
-	if shell := os.Getenv("SHELL"); shell != "" {
-		return buildCmd(shell, cmdStr)
+	path, flag, err := resolveShell(os.Getenv, exec.LookPath, IsWindows())
+	if err != nil {
+		panic(err.Error())
 	}
-
-	if _, err := exec.LookPath("/bin/sh"); err == nil {
-		return buildCmd("/bin/sh", cmdStr)
-	}
-
-	panic("Cannot run shell cmd as no shell found. Please set the SHELL environment variable.")
+	return buildCmd(path, flag, cmdStr)
 }
 
-func resolveCmd(i *Interpreter, shellNode rl.Node, cmdStr string) *exec.Cmd {
-	if shell := os.Getenv("SHELL"); shell != "" {
-		return buildCmd(shell, cmdStr)
+// resolveShell picks a shell to use for executing a command string. It is a
+// pure function: all platform/env dependencies are passed in so it is testable
+// without mutating global state.
+//
+// Resolution order:
+//  1. SHELL env var if set, but on Windows only if it actually resolves to an
+//     executable. Git Bash / MSYS2 / Cygwin set SHELL to a Unix-style path
+//     (e.g. /usr/bin/bash) that native Win32 exec can't find, so on Windows
+//     we fall through to the candidate chain in that case rather than crash.
+//  2. Windows: pwsh.exe -> powershell.exe -> cmd.exe
+//  3. Other:   /bin/sh
+//
+// Returns the resolved shell path and the flag to use for command-string
+// invocation (e.g. "-c" for POSIX shells and PowerShell, "/c" for cmd.exe).
+func resolveShell(
+	getEnv func(string) string,
+	lookPath func(string) (string, error),
+	isWindows bool,
+) (path, flag string, err error) {
+	if shell := strings.TrimSpace(getEnv("SHELL")); shell != "" {
+		if !isWindows {
+			return shell, shellExecFlag(shell), nil
+		}
+		// On Windows, only honor SHELL if it actually resolves - otherwise
+		// fall through. This rescues the common Git Bash case where SHELL is
+		// set to /usr/bin/bash but the native Win32 binary can't see it.
+		if resolved, lookErr := lookPath(shell); lookErr == nil {
+			return resolved, shellExecFlag(resolved), nil
+		}
 	}
 
-	if _, err := exec.LookPath("/bin/sh"); err == nil {
-		return buildCmd("/bin/sh", cmdStr)
+	var candidates []string
+	if isWindows {
+		candidates = []string{"pwsh.exe", "powershell.exe", "cmd.exe"}
+	} else {
+		candidates = []string{"/bin/sh"}
 	}
 
-	i.emitError(rl.ErrGenericRuntime, shellNode, "Cannot run shell cmd as no shell found. Please set the SHELL environment variable")
-	panic(UNREACHABLE)
+	for _, c := range candidates {
+		if resolved, lookErr := lookPath(c); lookErr == nil {
+			return resolved, shellExecFlag(resolved), nil
+		}
+	}
+
+	return "", "", errors.New("Cannot run shell cmd as no shell found. Please set the SHELL environment variable")
 }
 
-func buildCmd(shellStr string, cmdStr string) *exec.Cmd {
-	cmd := exec.Command(shellStr, "-c", cmdStr)
+// shellExecFlag returns the flag a given shell expects for invoking a command
+// string. Defaults to "-c" (POSIX shells, bash/zsh, and PowerShell which
+// accepts "-c" as a short form of "-Command"). Only cmd.exe needs "/c".
+//
+// We don't use filepath.Base because its separator handling is GOOS-specific
+// (only "/" on Unix), which would mis-handle Windows-style paths that may
+// arrive via env vars or mixed environments.
+func shellExecFlag(shellPath string) string {
+	if i := strings.LastIndexAny(shellPath, `/\`); i >= 0 {
+		shellPath = shellPath[i+1:]
+	}
+	base := strings.TrimSuffix(strings.ToLower(shellPath), ".exe")
+	if base == "cmd" {
+		return "/c"
+	}
+	return "-c"
+}
+
+func buildCmd(shellStr string, flag string, cmdStr string) *exec.Cmd {
+	cmd := exec.Command(shellStr, flag, cmdStr)
 	cmd.Stdin = RIo.StdIn.Unwrap()
 	return cmd
 }

--- a/core/shell_test.go
+++ b/core/shell_test.go
@@ -1,0 +1,202 @@
+package core
+
+import (
+	"errors"
+	"os/exec"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// fakeLookPath returns a lookPath function that succeeds for any name in
+// the available set and fails otherwise.
+func fakeLookPath(available ...string) func(string) (string, error) {
+	set := make(map[string]bool, len(available))
+	for _, a := range available {
+		set[a] = true
+	}
+	return func(name string) (string, error) {
+		if set[name] {
+			return name, nil
+		}
+		return "", exec.ErrNotFound
+	}
+}
+
+// fakeGetEnv returns a getEnv function backed by the given map.
+func fakeGetEnv(env map[string]string) func(string) string {
+	return func(key string) string { return env[key] }
+}
+
+func TestResolveShell_SHELL_set_wins_on_unix(t *testing.T) {
+	// On Unix, SHELL is trusted as-is - no LookPath validation - because the
+	// user's explicit choice takes precedence and a missing path failing
+	// loudly is the right behavior for genuine misconfiguration.
+	path, flag, err := resolveShell(
+		fakeGetEnv(map[string]string{"SHELL": "/usr/local/bin/zsh"}),
+		fakeLookPath(), // empty - should not be consulted
+		false,
+	)
+	assert.NoError(t, err)
+	assert.Equal(t, "/usr/local/bin/zsh", path)
+	assert.Equal(t, "-c", flag)
+}
+
+func TestResolveShell_SHELL_set_wins_on_windows_when_resolvable(t *testing.T) {
+	path, flag, err := resolveShell(
+		fakeGetEnv(map[string]string{"SHELL": "pwsh.exe"}),
+		fakeLookPath("pwsh.exe"),
+		true,
+	)
+	assert.NoError(t, err)
+	assert.Equal(t, "pwsh.exe", path)
+	assert.Equal(t, "-c", flag)
+}
+
+func TestResolveShell_Windows_GitBash_SHELL_falls_through(t *testing.T) {
+	// Git Bash / MSYS2 / Cygwin auto-set SHELL to a Unix-style path that
+	// native Win32 exec can't see. We should fall through to the Windows
+	// candidate chain rather than handing back an unusable path.
+	path, flag, err := resolveShell(
+		fakeGetEnv(map[string]string{"SHELL": "/usr/bin/bash"}),
+		fakeLookPath("powershell.exe", "cmd.exe"), // /usr/bin/bash NOT in PATH
+		true,
+	)
+	assert.NoError(t, err)
+	assert.Equal(t, "powershell.exe", path)
+	assert.Equal(t, "-c", flag)
+}
+
+func TestResolveShell_whitespace_only_SHELL_treated_as_unset(t *testing.T) {
+	for _, isWindows := range []bool{false, true} {
+		fallback := "/bin/sh"
+		if isWindows {
+			fallback = "cmd.exe"
+		}
+		path, _, err := resolveShell(
+			fakeGetEnv(map[string]string{"SHELL": "   "}),
+			fakeLookPath(fallback),
+			isWindows,
+		)
+		assert.NoError(t, err)
+		assert.Equal(t, fallback, path)
+	}
+}
+
+func TestResolveShell_SHELL_set_to_cmd_uses_slash_c(t *testing.T) {
+	cmdPath := `C:\Windows\System32\cmd.exe`
+	path, flag, err := resolveShell(
+		fakeGetEnv(map[string]string{"SHELL": cmdPath}),
+		fakeLookPath(cmdPath),
+		true,
+	)
+	assert.NoError(t, err)
+	assert.Equal(t, cmdPath, path)
+	assert.Equal(t, "/c", flag)
+}
+
+func TestResolveShell_Windows_prefers_pwsh(t *testing.T) {
+	path, flag, err := resolveShell(
+		fakeGetEnv(nil),
+		fakeLookPath("pwsh.exe", "powershell.exe", "cmd.exe"),
+		true,
+	)
+	assert.NoError(t, err)
+	assert.Equal(t, "pwsh.exe", path)
+	assert.Equal(t, "-c", flag)
+}
+
+func TestResolveShell_Windows_falls_back_to_powershell(t *testing.T) {
+	path, flag, err := resolveShell(
+		fakeGetEnv(nil),
+		fakeLookPath("powershell.exe", "cmd.exe"),
+		true,
+	)
+	assert.NoError(t, err)
+	assert.Equal(t, "powershell.exe", path)
+	assert.Equal(t, "-c", flag)
+}
+
+func TestResolveShell_Windows_falls_back_to_cmd(t *testing.T) {
+	path, flag, err := resolveShell(
+		fakeGetEnv(nil),
+		fakeLookPath("cmd.exe"),
+		true,
+	)
+	assert.NoError(t, err)
+	assert.Equal(t, "cmd.exe", path)
+	assert.Equal(t, "/c", flag)
+}
+
+func TestResolveShell_Unix_uses_bin_sh(t *testing.T) {
+	path, flag, err := resolveShell(
+		fakeGetEnv(nil),
+		fakeLookPath("/bin/sh"),
+		false,
+	)
+	assert.NoError(t, err)
+	assert.Equal(t, "/bin/sh", path)
+	assert.Equal(t, "-c", flag)
+}
+
+func TestResolveShell_no_shell_available_returns_error(t *testing.T) {
+	for _, isWindows := range []bool{false, true} {
+		_, _, err := resolveShell(
+			fakeGetEnv(nil),
+			fakeLookPath(), // nothing available
+			isWindows,
+		)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "SHELL environment variable")
+	}
+}
+
+func TestResolveShell_lookPath_other_error_treated_as_not_found(t *testing.T) {
+	// Some lookPath implementations may return errors other than ErrNotFound
+	// (e.g., permission errors). We should still skip the candidate and
+	// continue down the chain.
+	calls := 0
+	lookPath := func(name string) (string, error) {
+		calls++
+		if name == "pwsh.exe" {
+			return "", errors.New("permission denied")
+		}
+		if name == "powershell.exe" {
+			return name, nil
+		}
+		return "", exec.ErrNotFound
+	}
+	path, flag, err := resolveShell(fakeGetEnv(nil), lookPath, true)
+	assert.NoError(t, err)
+	assert.Equal(t, "powershell.exe", path)
+	assert.Equal(t, "-c", flag)
+	assert.Equal(t, 2, calls)
+}
+
+func TestShellExecFlag(t *testing.T) {
+	tests := []struct {
+		shellPath string
+		want      string
+	}{
+		// POSIX shells -> -c
+		{"/bin/sh", "-c"},
+		{"/bin/bash", "-c"},
+		{"/usr/bin/zsh", "-c"},
+		{"/usr/local/bin/fish", "-c"},
+		// PowerShell -> -c (accepted as short form of -Command)
+		{"pwsh", "-c"},
+		{"pwsh.exe", "-c"},
+		{"powershell.exe", "-c"},
+		{`C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe`, "-c"},
+		// cmd.exe -> /c, case- and extension-insensitive
+		{"cmd", "/c"},
+		{"cmd.exe", "/c"},
+		{"CMD.EXE", "/c"},
+		{`C:\Windows\System32\cmd.exe`, "/c"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.shellPath, func(t *testing.T) {
+			assert.Equal(t, tt.want, shellExecFlag(tt.shellPath))
+		})
+	}
+}

--- a/docs-web/docs/guide/shell-commands.md
+++ b/docs-web/docs/guide/shell-commands.md
@@ -30,6 +30,14 @@ By default, the stdout/stderr will be printed directly to the user's terminal as
     Shell commands often use 'single' and "double" quotes, so backticks minimize delimiter conflicts.
     However, you can use any string delimiter.
 
+## Which Shell Runs My Command?
+
+Rad picks a shell to run your command in this order:
+
+1. **`SHELL` env var** if it's set - this is the user's explicit choice and always wins.
+2. **On Windows** (when `SHELL` is unset): `pwsh.exe` (PowerShell 7+), then `powershell.exe` (Windows PowerShell, ships with every Win10+), then `cmd.exe` as a last resort.
+3. **On Linux/macOS** (when `SHELL` is unset): `/bin/sh`.
+
 ## Capturing Output
 
 Shell commands return three values: **exit code**, **stdout**, and **stderr**. You can capture anywhere from zero to all three of these values, depending on what you need.


### PR DESCRIPTION
Shell commands ($"...") hard-failed on a clean Windows install because rad's resolver only knew about the SHELL env var (a Unix convention) and /bin/sh (which doesn't exist on Windows). Closes #123.

Resolution chain when SHELL is unset:
- Windows: pwsh.exe -> powershell.exe -> cmd.exe
- Other:   /bin/sh

PowerShell is preferred over cmd.exe because it ships with Unix-like aliases (ls, cat, pwd), so common rad shell idioms work without modification. Validated by the issue reporter.

On Windows we also LookPath the SHELL value when it IS set, falling through to the candidate chain if it doesn't resolve. This rescues the common Git Bash / MSYS2 / Cygwin case where SHELL is set to /usr/bin/bash - a virtual path the native Win32 binary can't see. On Unix, SHELL is trusted as-is; explicit misconfiguration there should fail loudly.

resolveShell is extracted as a pure function (deps injected) so the fallback logic is unit-testable without mutating the host environment. Also handles whitespace-only SHELL (treated as unset), case-insensitive cmd.exe detection, and Windows-style paths.

shellExecFlag picks "-c" (POSIX shells, PowerShell) or "/c" (cmd.exe) based on the shell's basename, with separator-agnostic detection (handles both / and \\) so it doesn't depend on filepath.Base's GOOS-specific behavior.

Cross-machine portability variance from auto-detect is real but no worse than the existing /bin/bash vs /bin/zsh variance on Unix; a follow-up @shell script-header macro will let scripts pin a shell explicitly. Filed as kan card a_1BidxHsvp.

Removed the dead resolveCmd duplicate while we were in there.