### PR TITLE
feat(check,radls): diagnose unknown typed-map keys + key completion

### DIFF
--- a/core/error_docs/40014.md
+++ b/core/error_docs/40014.md
@@ -1,0 +1,48 @@
+# RAD40014: Unknown Map Key
+
+A map access reads a key that the map's *type* doesn't declare. The
+access is guaranteed to fail at runtime ([RAD20041](20041.md),
+key not found), so the analyzer flags it statically.
+
+This fires only when the receiver has a closed map shape the
+analyzer can enumerate - typically a builtin's typed-map return
+value (e.g. `get_path`) or an explicitly annotated struct-typed
+map. Untyped `map` values have no declared keys, so the check
+stays silent for them.
+
+## Example
+
+```rad
+gp = get_path("README.md")
+print(gp.full_path)   // ok: 'full_path' is a declared key
+print(gp.fjull_path)  // RAD40014: typo - no such key
+```
+
+## Fix
+
+Use a declared key:
+
+```rad
+gp = get_path("README.md")
+print(gp.full_path)
+```
+
+If the key you want is optional (marked `?` in the type, e.g.
+`get_path`'s `size_bytes?`), it's a valid key and won't fire this -
+but it may be absent at runtime. Guard the access so a missing key
+doesn't error ([RAD20041](20041.md)).
+
+## When the check fires
+
+Only reads are checked. Writing a key that isn't declared
+(`gp.extra = 1`) is allowed - it adds the key at runtime - so it
+does not fire.
+
+Both dot access (`gp.full_path`) and string-literal index access
+(`gp["full_path"]`) are checked. Dynamic keys (`gp[k]`) and keys
+built from interpolation can't be resolved statically, so they're
+left alone.
+
+Optional keys (declared with `?`, e.g. `get_path`'s `size_bytes?`)
+are considered valid keys: accessing one resolves its type and does
+not fire here, even though the key may be absent at runtime.

--- a/core/testing/docs_snippet_tolerances.go
+++ b/core/testing/docs_snippet_tolerances.go
@@ -150,6 +150,11 @@ var docSnippetTolerances = map[string]Tolerance{
 		Reason:        "demo: case key 'wat' not in the closed enum discriminant ['a', 'b', 'c'].",
 	},
 
+	"core/error_docs/40014.md#35566bd3": {
+		ExpectedCodes: []string{"RAD40014"},
+		Reason:        "demo: typo'd map key 'fjull_path' not in get_path's typed-map return shape.",
+	},
+
 	"core/error_docs/20028.md#a34c5fb8": {
 		ExpectedCodes: []string{"RAD20028"},
 		Reason:        "demo: typo'd identifier ('usernme' vs 'username').",

--- a/radls/analysis/completion.go
+++ b/radls/analysis/completion.go
@@ -35,9 +35,9 @@ const (
 //
 // Order discipline (the LSP client honours SortText before Label):
 //
-//   1. enclosing-fn params + earlier locals (tier "0")
-//   2. file-scope: args, cmd-args, top-level fns + vars (tier "1")
-//   3. builtins (tier "2")
+//  1. enclosing-fn params + earlier locals (tier "0")
+//  2. file-scope: args, cmd-args, top-level fns + vars (tier "1")
+//  3. builtins (tier "2")
 //
 // The popup the user sees has their local names at the top,
 // file-scope next, builtins last - which matches what people

--- a/radls/analysis/completion.go
+++ b/radls/analysis/completion.go
@@ -22,7 +22,14 @@ import (
 // file-scope but before plain builtins). Everything else stays
 // at "2".
 const (
-	sortTierLocal           = "0"
+	sortTierLocal = "0"
+	// sortTierMember is for keys of a typed map surfaced at
+	// `recv.<prefix>`. It deliberately shares the local tier: a
+	// member access rarely collides with an in-scope local name, and
+	// when it does the alphabetical Label tiebreak is fine. Members
+	// are added last so dedupe (last-add-wins) keeps the member on
+	// collision.
+	sortTierMember          = sortTierLocal
 	sortTierFile            = "1"
 	sortTierBuiltinRelevant = "1z"
 	sortTierBuiltin         = "2"
@@ -68,6 +75,9 @@ func buildCompletions(items *[]lsp.CompletionItem, snap *DocumentVersion, bytePo
 		addFileScopeCompletions(items, snap, bytePos)
 		addEnclosingFnCompletions(items, snap, bytePos)
 	}
+	// Added last so dedupe (last-add-wins) keeps the member entry
+	// when a key shares a name with an in-scope local or builtin.
+	addStructKeyCompletions(items, receiverType)
 	dedupCompletionsInPlace(items)
 	// Sort runs unconditionally - including on the nil-AST path,
 	// where without it the popup order would be whatever
@@ -132,6 +142,41 @@ func firstParamAccepts(sig rts.FnSignature, receiverType rl.TypingT) bool {
 	return (*first.Type).IsAssignableFrom(receiverType)
 }
 
+// addStructKeyCompletions offers the declared keys of a typed map
+// (TypingStructT) when the cursor sits at `recv.<prefix>` and recv
+// resolves to such a shape - e.g. a `get_path` result. These are
+// the most likely completion at a member access, so they get the
+// member tier and lead the popup. Optional keys are marked with a
+// trailing `?` in the detail.
+func addStructKeyCompletions(items *[]lsp.CompletionItem, receiverType rl.TypingT) {
+	structT, ok := receiverType.(*rl.TypingStructT)
+	if !ok {
+		return
+	}
+	for key, fieldT := range structT.Fields() {
+		detail := ""
+		if fieldT != nil {
+			detail = fieldT.Name()
+		}
+		// Disambiguate the `?` suffix: in Rad it means the key may be
+		// absent from the map, not that the value is nullable. The
+		// detail alone reads like a nullable type to most editors, so
+		// the Doc spells out the runtime implication.
+		doc := ""
+		if key.IsOptional {
+			detail += "?"
+			doc = "Optional key - may be absent at runtime; accessing it without a guard errors if missing."
+		}
+		*items = append(*items, lsp.CompletionItem{
+			Label:    key.Name,
+			Kind:     lsp.CompletionKindField,
+			Detail:   detail,
+			Doc:      doc,
+			SortText: sortTierMember,
+		})
+	}
+}
+
 // receiverTypeAtCursor inspects the source immediately before the
 // cursor for a UFCS access pattern (`<ident>.<prefix>`). On a
 // match, it looks up the receiver identifier and synthesises its
@@ -183,7 +228,7 @@ func receiverTypeAtCursor(snap *DocumentVersion, pos lsp.Pos) rl.TypingT {
 	if indexes == nil {
 		return nil
 	}
-	sym := indexes.resolved.File.Lookup(name)
+	sym := resolveReceiverSymbol(indexes, name, pos)
 	if sym == nil {
 		return nil
 	}
@@ -194,6 +239,56 @@ func receiverTypeAtCursor(snap *DocumentVersion, pos lsp.Pos) rl.TypingT {
 		return sym.Declared
 	}
 	return nil
+}
+
+// resolveReceiverSymbol resolves a receiver name to its Symbol using
+// the same scope discipline as buildCompletions: the enclosing
+// function's params and earlier body-locals first, then file scope.
+// Without the enclosing-function tier, a receiver declared as a
+// function local (the common `gp = get_path(...)` inside a fn)
+// wouldn't resolve and the feature would only work at top level.
+//
+// Positions are interpreted against indexes.ast - which may be the
+// last-good snapshot, one keystroke stale. The receiver's enclosing
+// function rarely shifts within a single keystroke, and a miss falls
+// through to the position-independent file-scope lookup, so a stale
+// AST degrades gracefully rather than misresolving.
+func resolveReceiverSymbol(indexes *DocumentVersion, name string, pos lsp.Pos) *check.Symbol {
+	if indexes.ast != nil {
+		if owner, _ := enclosingCallable(indexes.ast, pos); owner != nil {
+			for _, ps := range indexes.resolved.ParamSymbols[owner] {
+				if ps != nil && ps.Name == name {
+					return ps
+				}
+			}
+			// Walk the whole function body (not just top-level
+			// statements) so locals declared inside if/for/switch
+			// blocks resolve too - Rad doesn't open a scope for those,
+			// so the binding lives in the function's scope. The
+			// Scope.Owner == owner guard keeps us from picking up a
+			// same-named local from a *nested* fn/lambda, which does
+			// open its own scope and isn't visible at the cursor.
+			var local *check.Symbol
+			rl.Walk(owner, func(n rl.Node) {
+				assign, ok := n.(*rl.Assign)
+				if !ok || !spanBefore(assign.Span(), pos) {
+					return
+				}
+				for _, target := range assign.Targets {
+					if id, ok := target.(*rl.Identifier); ok && id.Name == name {
+						if s := lookupSymbolForIdent(id, indexes.resolved); s != nil &&
+							s.Scope != nil && s.Scope.Owner == owner {
+							local = s
+						}
+					}
+				}
+			})
+			if local != nil {
+				return local
+			}
+		}
+	}
+	return indexes.resolved.File.Lookup(name)
 }
 
 // pickResolvedSnapshot returns whichever of (snap, snap.lastGood)

--- a/radls/analysis/diagnostics_test.go
+++ b/radls/analysis/diagnostics_test.go
@@ -79,9 +79,9 @@ type stubChecker struct {
 	result check.Result
 }
 
-func (s *stubChecker) UpdateSrc(string)                             {}
-func (s *stubChecker) Update(*rts.RadTree, string, *rl.SourceFile)  {}
-func (s *stubChecker) Check() (check.Result, error)                 { return s.result, nil }
+func (s *stubChecker) UpdateSrc(string)                            {}
+func (s *stubChecker) Update(*rts.RadTree, string, *rl.SourceFile) {}
+func (s *stubChecker) Check() (check.Result, error)                { return s.result, nil }
 
 // Compile-time interface check. lsp import keeps the file honest if
 // the test ever drops its only lsp reference.

--- a/radls/analysis/state.go
+++ b/radls/analysis/state.go
@@ -28,9 +28,9 @@ type State struct {
 	encoding PositionEncoding
 	idAlloc  fileIDAllocator
 
-	mu        sync.RWMutex
-	docs      map[string]*Document
-	idToDoc   map[FileID]*Document
+	mu      sync.RWMutex
+	docs    map[string]*Document
+	idToDoc map[FileID]*Document
 
 	// parserMu serializes calls into the tree-sitter parser. Tree-sitter
 	// parsers are NOT safe to share across goroutines; until/unless we

--- a/radls/lsp/text_doc.go
+++ b/radls/lsp/text_doc.go
@@ -265,6 +265,7 @@ type CompletionItemKind int
 const (
 	CompletionKindText     CompletionItemKind = 1
 	CompletionKindFunction CompletionItemKind = 3
+	CompletionKindField    CompletionItemKind = 5
 	CompletionKindVariable CompletionItemKind = 6
 	CompletionKindKeyword  CompletionItemKind = 14
 	CompletionKindSnippet  CompletionItemKind = 15

--- a/radls/lstesting/snapshots/map_key_completion.snap
+++ b/radls/lstesting/snapshots/map_key_completion.snap
@@ -1,0 +1,2379 @@
+### TITLE ###
+MapKeysAfterDotFileScope
+### DOCUMENT ###
+gp = get_path("f")
+print(gp.exists)
+### COMPLETION 1:9 ###
+### STDOUT ###
+{
+  "jsonrpc": "2.0",
+  "method": "textDocument/publishDiagnostics",
+  "params": {
+    "diagnostics": [],
+    "uri": "file:///test.rad"
+  }
+}
+
+{
+  "id": 1,
+  "jsonrpc": "2.0",
+  "result": [
+    {
+      "detail": "int?",
+      "documentation": "Optional key - may be absent at runtime; accessing it without a guard errors if missing.",
+      "kind": 5,
+      "label": "accessed_millis",
+      "sortText": "0"
+    },
+    {
+      "detail": "str?",
+      "documentation": "Optional key - may be absent at runtime; accessing it without a guard errors if missing.",
+      "kind": 5,
+      "label": "base_name",
+      "sortText": "0"
+    },
+    {
+      "detail": "bool",
+      "kind": 5,
+      "label": "exists",
+      "sortText": "0"
+    },
+    {
+      "detail": "str",
+      "kind": 5,
+      "label": "full_path",
+      "sortText": "0"
+    },
+    {
+      "detail": "int?",
+      "documentation": "Optional key - may be absent at runtime; accessing it without a guard errors if missing.",
+      "kind": 5,
+      "label": "modified_millis",
+      "sortText": "0"
+    },
+    {
+      "detail": "str?",
+      "documentation": "Optional key - may be absent at runtime; accessing it without a guard errors if missing.",
+      "kind": 5,
+      "label": "permissions",
+      "sortText": "0"
+    },
+    {
+      "detail": "int?",
+      "documentation": "Optional key - may be absent at runtime; accessing it without a guard errors if missing.",
+      "kind": 5,
+      "label": "size_bytes",
+      "sortText": "0"
+    },
+    {
+      "detail": "str?",
+      "documentation": "Optional key - may be absent at runtime; accessing it without a guard errors if missing.",
+      "kind": 5,
+      "label": "type",
+      "sortText": "0"
+    },
+    {
+      "detail": "{ \"accessed_millis\"?: int, \"base_name\"?: str, \"exists\": bool, \"full_path\": str, \"modified_millis\"?: int, \"permissions\"?: str, \"size_bytes\"?: int, \"type\"?: str }",
+      "kind": 6,
+      "label": "gp",
+      "sortText": "1"
+    },
+    {
+      "detail": "black(_item: any) -\u003e str",
+      "kind": 3,
+      "label": "black",
+      "sortText": "1z"
+    },
+    {
+      "detail": "blue(_item: any) -\u003e str",
+      "kind": 3,
+      "label": "blue",
+      "sortText": "1z"
+    },
+    {
+      "detail": "bold(_item: any) -\u003e str",
+      "kind": 3,
+      "label": "bold",
+      "sortText": "1z"
+    },
+    {
+      "detail": "color_rgb(_val: any, red: int, green: int, blue: int) -\u003e error|str",
+      "kind": 3,
+      "label": "color_rgb",
+      "sortText": "1z"
+    },
+    {
+      "detail": "colorize(_val: any, _enum: any[], *, skip_if_single: bool = false) -\u003e str",
+      "kind": 3,
+      "label": "colorize",
+      "sortText": "1z"
+    },
+    {
+      "detail": "cyan(_item: any) -\u003e str",
+      "kind": 3,
+      "label": "cyan",
+      "sortText": "1z"
+    },
+    {
+      "detail": "debug(*_items: any, *, sep: str = \" \", end: str = \"\\n\") -\u003e void",
+      "kind": 3,
+      "label": "debug",
+      "sortText": "1z"
+    },
+    {
+      "detail": "dim(_item: any) -\u003e str",
+      "kind": 3,
+      "label": "dim",
+      "sortText": "1z"
+    },
+    {
+      "detail": "filter(_coll: map|list, _fn: fn(any) -\u003e bool | fn(any, any) -\u003e bool) -\u003e map|list",
+      "kind": 3,
+      "label": "filter",
+      "sortText": "1z"
+    },
+    {
+      "detail": "flat_map(_coll: map|list, _fn: any?) -\u003e list",
+      "kind": 3,
+      "label": "flat_map",
+      "sortText": "1z"
+    },
+    {
+      "detail": "float(_var: any) -\u003e float|error",
+      "kind": 3,
+      "label": "float",
+      "sortText": "1z"
+    },
+    {
+      "detail": "green(_item: any) -\u003e str",
+      "kind": 3,
+      "label": "green",
+      "sortText": "1z"
+    },
+    {
+      "detail": "hyperlink(_val: any, _link: str) -\u003e str",
+      "kind": 3,
+      "label": "hyperlink",
+      "sortText": "1z"
+    },
+    {
+      "detail": "int(_var: any) -\u003e int|error",
+      "kind": 3,
+      "label": "int",
+      "sortText": "1z"
+    },
+    {
+      "detail": "italic(_item: any) -\u003e str",
+      "kind": 3,
+      "label": "italic",
+      "sortText": "1z"
+    },
+    {
+      "detail": "keys(_map: map) -\u003e any[]",
+      "kind": 3,
+      "label": "keys",
+      "sortText": "1z"
+    },
+    {
+      "detail": "len(_val: str|list|map) -\u003e int",
+      "kind": 3,
+      "label": "len",
+      "sortText": "1z"
+    },
+    {
+      "detail": "load(_map: map, _key: any, _loader: fn() -\u003e any, *, reload: bool = false, override: any?) -\u003e error|any",
+      "kind": 3,
+      "label": "load",
+      "sortText": "1z"
+    },
+    {
+      "detail": "magenta(_item: any) -\u003e str",
+      "kind": 3,
+      "label": "magenta",
+      "sortText": "1z"
+    },
+    {
+      "detail": "map(_coll: map|list, _fn: fn(any) -\u003e any | fn(any, any) -\u003e any) -\u003e map|list",
+      "kind": 3,
+      "label": "map",
+      "sortText": "1z"
+    },
+    {
+      "detail": "orange(_item: any) -\u003e str",
+      "kind": 3,
+      "label": "orange",
+      "sortText": "1z"
+    },
+    {
+      "detail": "pink(_item: any) -\u003e str",
+      "kind": 3,
+      "label": "pink",
+      "sortText": "1z"
+    },
+    {
+      "detail": "plain(_item: any) -\u003e str",
+      "kind": 3,
+      "label": "plain",
+      "sortText": "1z"
+    },
+    {
+      "detail": "pprint(_item: any?) -\u003e void",
+      "kind": 3,
+      "label": "pprint",
+      "sortText": "1z"
+    },
+    {
+      "detail": "print(*_items: any, *, sep: str = \" \", end: str = \"\\n\") -\u003e void",
+      "kind": 3,
+      "label": "print",
+      "sortText": "1z"
+    },
+    {
+      "detail": "print_err(*_items: any, *, sep: str = \" \", end: str = \"\\n\") -\u003e void",
+      "kind": 3,
+      "label": "print_err",
+      "sortText": "1z"
+    },
+    {
+      "detail": "red(_item: any) -\u003e str",
+      "kind": 3,
+      "label": "red",
+      "sortText": "1z"
+    },
+    {
+      "detail": "save_state(_state: map) -\u003e error?",
+      "kind": 3,
+      "label": "save_state",
+      "sortText": "1z"
+    },
+    {
+      "detail": "str(_var: any) -\u003e str",
+      "kind": 3,
+      "label": "str",
+      "sortText": "1z"
+    },
+    {
+      "detail": "strikethrough(_item: any) -\u003e str",
+      "kind": 3,
+      "label": "strikethrough",
+      "sortText": "1z"
+    },
+    {
+      "detail": "type_of(_var: any) -\u003e [\"int\", \"str\", \"list\", \"map\", \"float\", \"bool\", \"null\", \"error\", \"function\"]",
+      "kind": 3,
+      "label": "type_of",
+      "sortText": "1z"
+    },
+    {
+      "detail": "underline(_item: any) -\u003e str",
+      "kind": 3,
+      "label": "underline",
+      "sortText": "1z"
+    },
+    {
+      "detail": "values(_map: map) -\u003e any[]",
+      "kind": 3,
+      "label": "values",
+      "sortText": "1z"
+    },
+    {
+      "detail": "white(_item: any) -\u003e str",
+      "kind": 3,
+      "label": "white",
+      "sortText": "1z"
+    },
+    {
+      "detail": "yellow(_item: any) -\u003e str",
+      "kind": 3,
+      "label": "yellow",
+      "sortText": "1z"
+    },
+    {
+      "detail": "abs(_num: int|float) -\u003e int|float",
+      "kind": 3,
+      "label": "abs",
+      "sortText": "2"
+    },
+    {
+      "detail": "ceil(_num: float) -\u003e int",
+      "kind": 3,
+      "label": "ceil",
+      "sortText": "2"
+    },
+    {
+      "detail": "clamp(val: int|float, min: int|float, max: int|float) -\u003e error|int|float",
+      "kind": 3,
+      "label": "clamp",
+      "sortText": "2"
+    },
+    {
+      "detail": "confirm(prompt: str = \"Confirm? [Y/n] \u003e \") -\u003e error|bool",
+      "kind": 3,
+      "label": "confirm",
+      "sortText": "2"
+    },
+    {
+      "detail": "convert_duration(_value: int|float, _unit: [\"nanos\", \"micros\", \"millis\", \"seconds\", \"minutes\", \"hours\", \"days\"]) -\u003e error|{ \"nanos\": int, \"micros\": float, \"millis\": float, \"seconds\": float, \"minutes\": float, \"hours\": float, \"days\": float }",
+      "kind": 3,
+      "label": "convert_duration",
+      "sortText": "2"
+    },
+    {
+      "detail": "count(_str: str, _substr: str) -\u003e int",
+      "kind": 3,
+      "label": "count",
+      "sortText": "2"
+    },
+    {
+      "detail": "decode_base16(_content: str) -\u003e error|str",
+      "kind": 3,
+      "label": "decode_base16",
+      "sortText": "2"
+    },
+    {
+      "detail": "decode_base64(_content: str, *, url_safe: bool = false, padding: bool = true) -\u003e error|str",
+      "kind": 3,
+      "label": "decode_base64",
+      "sortText": "2"
+    },
+    {
+      "detail": "delete_path(_path: str) -\u003e bool",
+      "kind": 3,
+      "label": "delete_path",
+      "sortText": "2"
+    },
+    {
+      "detail": "encode_base16(_content: str) -\u003e str",
+      "kind": 3,
+      "label": "encode_base16",
+      "sortText": "2"
+    },
+    {
+      "detail": "encode_base64(_content: str, *, url_safe: bool = false, padding: bool = true) -\u003e str",
+      "kind": 3,
+      "label": "encode_base64",
+      "sortText": "2"
+    },
+    {
+      "detail": "ends_with(_val: str, _end: str) -\u003e bool",
+      "kind": 3,
+      "label": "ends_with",
+      "sortText": "2"
+    },
+    {
+      "detail": "error(_msg: str) -\u003e error",
+      "kind": 3,
+      "label": "error",
+      "sortText": "2"
+    },
+    {
+      "detail": "exit(_code: int|bool = 0) -\u003e void",
+      "kind": 3,
+      "label": "exit",
+      "sortText": "2"
+    },
+    {
+      "detail": "find_paths(_path: str, *, depth: int = -1, relative: [\"target\", \"cwd\", \"absolute\"] = \"target\") -\u003e error|str[]",
+      "kind": 3,
+      "label": "find_paths",
+      "sortText": "2"
+    },
+    {
+      "detail": "floor(_num: float) -\u003e int",
+      "kind": 3,
+      "label": "floor",
+      "sortText": "2"
+    },
+    {
+      "detail": "gen_fid(*, alphabet: str?, tick_size_ms: int?, num_random_chars: int?) -\u003e error|str",
+      "kind": 3,
+      "label": "gen_fid",
+      "sortText": "2"
+    },
+    {
+      "detail": "get_args() -\u003e str[]",
+      "kind": 3,
+      "label": "get_args",
+      "sortText": "2"
+    },
+    {
+      "detail": "get_env(_var: str) -\u003e str",
+      "kind": 3,
+      "label": "get_env",
+      "sortText": "2"
+    },
+    {
+      "detail": "get_path(_path: str) -\u003e { \"exists\": bool, \"full_path\": str, \"base_name\"?: str, \"permissions\"?: str, \"type\"?: str, \"size_bytes\"?: int, \"modified_millis\"?: int, \"accessed_millis\"?: int }",
+      "kind": 3,
+      "label": "get_path",
+      "sortText": "2"
+    },
+    {
+      "detail": "get_rad_home() -\u003e str",
+      "kind": 3,
+      "label": "get_rad_home",
+      "sortText": "2"
+    },
+    {
+      "detail": "get_stash_path(_sub_path: str = \"\") -\u003e error|str",
+      "kind": 3,
+      "label": "get_stash_path",
+      "sortText": "2"
+    },
+    {
+      "detail": "has_stdin() -\u003e bool",
+      "kind": 3,
+      "label": "has_stdin",
+      "sortText": "2"
+    },
+    {
+      "detail": "hash(_val: str, algo: [\"sha1\", \"sha256\", \"sha512\", \"md5\"] = \"sha1\") -\u003e str",
+      "kind": 3,
+      "label": "hash",
+      "sortText": "2"
+    },
+    {
+      "detail": "http_connect(url: str, *, body: any?, json: any?, headers: map?, insecure: bool = false) -\u003e { \"success\": bool, \"status_code\"?: int, \"headers\": map, \"body\"?: any, \"error\"?: str, \"duration_seconds\": float }",
+      "kind": 3,
+      "label": "http_connect",
+      "sortText": "2"
+    },
+    {
+      "detail": "http_delete(url: str, *, body: any?, json: any?, headers: map?, insecure: bool = false) -\u003e { \"success\": bool, \"status_code\"?: int, \"headers\": map, \"body\"?: any, \"error\"?: str, \"duration_seconds\": float }",
+      "kind": 3,
+      "label": "http_delete",
+      "sortText": "2"
+    },
+    {
+      "detail": "http_get(url: str, *, body: any?, json: any?, headers: map?, insecure: bool = false) -\u003e { \"success\": bool, \"status_code\"?: int, \"headers\": map, \"body\"?: any, \"error\"?: str, \"duration_seconds\": float }",
+      "kind": 3,
+      "label": "http_get",
+      "sortText": "2"
+    },
+    {
+      "detail": "http_head(url: str, *, body: any?, json: any?, headers: map?, insecure: bool = false) -\u003e { \"success\": bool, \"status_code\"?: int, \"headers\": map, \"body\"?: any, \"error\"?: str, \"duration_seconds\": float }",
+      "kind": 3,
+      "label": "http_head",
+      "sortText": "2"
+    },
+    {
+      "detail": "http_options(url: str, *, body: any?, json: any?, headers: map?, insecure: bool = false) -\u003e { \"success\": bool, \"status_code\"?: int, \"headers\": map, \"body\"?: any, \"error\"?: str, \"duration_seconds\": float }",
+      "kind": 3,
+      "label": "http_options",
+      "sortText": "2"
+    },
+    {
+      "detail": "http_patch(url: str, *, body: any?, json: any?, headers: map?, insecure: bool = false) -\u003e { \"success\": bool, \"status_code\"?: int, \"headers\": map, \"body\"?: any, \"error\"?: str, \"duration_seconds\": float }",
+      "kind": 3,
+      "label": "http_patch",
+      "sortText": "2"
+    },
+    {
+      "detail": "http_post(url: str, *, body: any?, json: any?, headers: map?, insecure: bool = false) -\u003e { \"success\": bool, \"status_code\"?: int, \"headers\": map, \"body\"?: any, \"error\"?: str, \"duration_seconds\": float }",
+      "kind": 3,
+      "label": "http_post",
+      "sortText": "2"
+    },
+    {
+      "detail": "http_put(url: str, *, body: any?, json: any?, headers: map?, insecure: bool = false) -\u003e { \"success\": bool, \"status_code\"?: int, \"headers\": map, \"body\"?: any, \"error\"?: str, \"duration_seconds\": float }",
+      "kind": 3,
+      "label": "http_put",
+      "sortText": "2"
+    },
+    {
+      "detail": "http_trace(url: str, *, body: any?, json: any?, headers: map?, insecure: bool = false) -\u003e { \"success\": bool, \"status_code\"?: int, \"headers\": map, \"body\"?: any, \"error\"?: str, \"duration_seconds\": float }",
+      "kind": 3,
+      "label": "http_trace",
+      "sortText": "2"
+    },
+    {
+      "detail": "index_of(_subject: str|list, _target: any, *, n: int = 0, start: int = 0) -\u003e int?",
+      "kind": 3,
+      "label": "index_of",
+      "sortText": "2"
+    },
+    {
+      "detail": "input(prompt: str = \"\u003e \", *, hint: str = \"\", default: str = \"\", secret: bool = false) -\u003e error|str",
+      "kind": 3,
+      "label": "input",
+      "sortText": "2"
+    },
+    {
+      "detail": "is_defined(_var: str) -\u003e bool",
+      "kind": 3,
+      "label": "is_defined",
+      "sortText": "2"
+    },
+    {
+      "detail": "join(_list: list, sep: str = \"\", prefix: str = \"\", suffix: str = \"\") -\u003e str",
+      "kind": 3,
+      "label": "join",
+      "sortText": "2"
+    },
+    {
+      "detail": "load_stash_file(_path: str, _default: str = \"\") -\u003e error|{ \"full_path\": str, \"created\": bool, \"content\"?: str }",
+      "kind": 3,
+      "label": "load_stash_file",
+      "sortText": "2"
+    },
+    {
+      "detail": "load_state() -\u003e error|map",
+      "kind": 3,
+      "label": "load_state",
+      "sortText": "2"
+    },
+    {
+      "detail": "lower(_val: str) -\u003e str",
+      "kind": 3,
+      "label": "lower",
+      "sortText": "2"
+    },
+    {
+      "detail": "matches(_str: str, _pattern: str, *, partial: bool = false) -\u003e bool|error",
+      "kind": 3,
+      "label": "matches",
+      "sortText": "2"
+    },
+    {
+      "detail": "max(*_nums: float|float[]) -\u003e int|float|error",
+      "kind": 3,
+      "label": "max",
+      "sortText": "2"
+    },
+    {
+      "detail": "min(*_nums: float|float[]) -\u003e int|float|error",
+      "kind": 3,
+      "label": "min",
+      "sortText": "2"
+    },
+    {
+      "detail": "multipick(_options: str[], *, prompt: str?, min: int = 0, max: int?) -\u003e str[]",
+      "kind": 3,
+      "label": "multipick",
+      "sortText": "2"
+    },
+    {
+      "detail": "now(*, tz: str = \"local\") -\u003e error|{ \"date\": str, \"year\": int, \"month\": int, \"day\": int, \"hour\": int, \"minute\": int, \"second\": int, \"time\": str, \"epoch\": { \"seconds\": int, \"millis\": int, \"nanos\": int } }",
+      "kind": 3,
+      "label": "now",
+      "sortText": "2"
+    },
+    {
+      "detail": "parse_date(_date: str, *, format: str?, tz: str = \"local\") -\u003e error|{ \"date\": str, \"year\": int, \"month\": int, \"day\": int, \"hour\": int, \"minute\": int, \"second\": int, \"time\": str, \"epoch\": { \"seconds\": int, \"millis\": int, \"nanos\": int } }",
+      "kind": 3,
+      "label": "parse_date",
+      "sortText": "2"
+    },
+    {
+      "detail": "parse_duration(_duration: str) -\u003e error|{ \"nanos\": int, \"micros\": float, \"millis\": float, \"seconds\": float, \"minutes\": float, \"hours\": float, \"days\": float }",
+      "kind": 3,
+      "label": "parse_duration",
+      "sortText": "2"
+    },
+    {
+      "detail": "parse_epoch(_epoch: int|float, *, tz: str = \"local\", unit: [\"auto\", \"seconds\", \"millis\", \"micros\", \"nanos\", \"milliseconds\", \"microseconds\", \"nanoseconds\"] = \"auto\") -\u003e error|{ \"date\": str, \"year\": int, \"month\": int, \"day\": int, \"hour\": int, \"minute\": int, \"second\": int, \"time\": str, \"epoch\": { \"seconds\": int, \"millis\": int, \"nanos\": int } }",
+      "kind": 3,
+      "label": "parse_epoch",
+      "sortText": "2"
+    },
+    {
+      "detail": "parse_float(_str: str) -\u003e float|error",
+      "kind": 3,
+      "label": "parse_float",
+      "sortText": "2"
+    },
+    {
+      "detail": "parse_int(_str: str) -\u003e int|error",
+      "kind": 3,
+      "label": "parse_int",
+      "sortText": "2"
+    },
+    {
+      "detail": "parse_json(_str: str) -\u003e any|error",
+      "kind": 3,
+      "label": "parse_json",
+      "sortText": "2"
+    },
+    {
+      "detail": "pick(_options: str[], _filter: (str|str[])?, *, prompt: str = \"Pick an option\", prefer_exact: bool = false) -\u003e str",
+      "kind": 3,
+      "label": "pick",
+      "sortText": "2"
+    },
+    {
+      "detail": "pick_from_resource(path: str, _filter: str?, *, prompt: str = \"Pick an option\", prefer_exact: bool = true) -\u003e any",
+      "kind": 3,
+      "label": "pick_from_resource",
+      "sortText": "2"
+    },
+    {
+      "detail": "pick_kv(keys: str[], values: any[], _filter: (str|str[])?, *, prompt: str = \"Pick an option\", prefer_exact: bool = false) -\u003e any",
+      "kind": 3,
+      "label": "pick_kv",
+      "sortText": "2"
+    },
+    {
+      "detail": "pow(_base: float, _exponent: float) -\u003e float",
+      "kind": 3,
+      "label": "pow",
+      "sortText": "2"
+    },
+    {
+      "detail": "rand() -\u003e float",
+      "kind": 3,
+      "label": "rand",
+      "sortText": "2"
+    },
+    {
+      "detail": "rand_int(_arg1: int = 9223372036854775807, _arg2: int?) -\u003e int",
+      "kind": 3,
+      "label": "rand_int",
+      "sortText": "2"
+    },
+    {
+      "detail": "range(_arg1: float|int, _arg2: (float|int)?, _step: float|int = 1) -\u003e float[]|int[]",
+      "kind": 3,
+      "label": "range",
+      "sortText": "2"
+    },
+    {
+      "detail": "read_file(_path: str, *, mode: [\"text\", \"bytes\"] = \"text\") -\u003e error|{ \"size_bytes\": int, \"content\": str|int[] }",
+      "kind": 3,
+      "label": "read_file",
+      "sortText": "2"
+    },
+    {
+      "detail": "read_stdin() -\u003e str?|error",
+      "kind": 3,
+      "label": "read_stdin",
+      "sortText": "2"
+    },
+    {
+      "detail": "replace(_original: str, _find: str, _replace: str) -\u003e str",
+      "kind": 3,
+      "label": "replace",
+      "sortText": "2"
+    },
+    {
+      "detail": "reverse(_val: str|list) -\u003e str|list",
+      "kind": 3,
+      "label": "reverse",
+      "sortText": "2"
+    },
+    {
+      "detail": "round(_num: float, _decimals: int = 0) -\u003e error|int|float",
+      "kind": 3,
+      "label": "round",
+      "sortText": "2"
+    },
+    {
+      "detail": "seed_random(_seed: int) -\u003e void",
+      "kind": 3,
+      "label": "seed_random",
+      "sortText": "2"
+    },
+    {
+      "detail": "sleep(_duration: int|float|str, *, title: str?) -\u003e void",
+      "kind": 3,
+      "label": "sleep",
+      "sortText": "2"
+    },
+    {
+      "detail": "sort(_primary: list|str, *_others: list|str, *, reverse: bool = false) -\u003e list|str",
+      "kind": 3,
+      "label": "sort",
+      "sortText": "2"
+    },
+    {
+      "detail": "split(_val: str, _sep: str, *, limit: int?) -\u003e str[]",
+      "kind": 3,
+      "label": "split",
+      "sortText": "2"
+    },
+    {
+      "detail": "split_lines(_val: str) -\u003e str[]",
+      "kind": 3,
+      "label": "split_lines",
+      "sortText": "2"
+    },
+    {
+      "detail": "starts_with(_val: str, _start: str) -\u003e bool",
+      "kind": 3,
+      "label": "starts_with",
+      "sortText": "2"
+    },
+    {
+      "detail": "sum(_nums: float[]) -\u003e error|int|float",
+      "kind": 3,
+      "label": "sum",
+      "sortText": "2"
+    },
+    {
+      "detail": "trim(_subject: str, _chars: str = \" \\t\\n\") -\u003e str",
+      "kind": 3,
+      "label": "trim",
+      "sortText": "2"
+    },
+    {
+      "detail": "trim_left(_subject: str, _chars: str = \" \\t\\n\") -\u003e str",
+      "kind": 3,
+      "label": "trim_left",
+      "sortText": "2"
+    },
+    {
+      "detail": "trim_prefix(_subject: str, _prefix: str) -\u003e str",
+      "kind": 3,
+      "label": "trim_prefix",
+      "sortText": "2"
+    },
+    {
+      "detail": "trim_right(_subject: str, _chars: str = \" \\t\\n\") -\u003e str",
+      "kind": 3,
+      "label": "trim_right",
+      "sortText": "2"
+    },
+    {
+      "detail": "trim_suffix(_subject: str, _suffix: str) -\u003e str",
+      "kind": 3,
+      "label": "trim_suffix",
+      "sortText": "2"
+    },
+    {
+      "detail": "truncate(_str: str, _len: int) -\u003e error|str",
+      "kind": 3,
+      "label": "truncate",
+      "sortText": "2"
+    },
+    {
+      "detail": "unique(_list: any[]) -\u003e any[]",
+      "kind": 3,
+      "label": "unique",
+      "sortText": "2"
+    },
+    {
+      "detail": "upper(_val: str) -\u003e str",
+      "kind": 3,
+      "label": "upper",
+      "sortText": "2"
+    },
+    {
+      "detail": "uuid_v4() -\u003e str",
+      "kind": 3,
+      "label": "uuid_v4",
+      "sortText": "2"
+    },
+    {
+      "detail": "uuid_v7() -\u003e str",
+      "kind": 3,
+      "label": "uuid_v7",
+      "sortText": "2"
+    },
+    {
+      "detail": "write_file(_path: str, _content: str, *, append: bool = false) -\u003e error|{ \"bytes_written\": int, \"path\": str }",
+      "kind": 3,
+      "label": "write_file",
+      "sortText": "2"
+    },
+    {
+      "detail": "write_stash_file(_path: str, _content: str) -\u003e error?",
+      "kind": 3,
+      "label": "write_stash_file",
+      "sortText": "2"
+    },
+    {
+      "detail": "zip(*_lists: list, *, fill: any?, strict: bool = false) -\u003e error|list[]",
+      "kind": 3,
+      "label": "zip",
+      "sortText": "2"
+    }
+  ]
+}
+### TITLE ###
+MapKeysAfterDotFunctionLocal
+### DOCUMENT ###
+fn f():
+    gp = get_path("x")
+    print(gp.exists)
+### COMPLETION 2:13 ###
+### STDOUT ###
+{
+  "jsonrpc": "2.0",
+  "method": "textDocument/publishDiagnostics",
+  "params": {
+    "diagnostics": [],
+    "uri": "file:///test.rad"
+  }
+}
+
+{
+  "id": 1,
+  "jsonrpc": "2.0",
+  "result": [
+    {
+      "detail": "int?",
+      "documentation": "Optional key - may be absent at runtime; accessing it without a guard errors if missing.",
+      "kind": 5,
+      "label": "accessed_millis",
+      "sortText": "0"
+    },
+    {
+      "detail": "str?",
+      "documentation": "Optional key - may be absent at runtime; accessing it without a guard errors if missing.",
+      "kind": 5,
+      "label": "base_name",
+      "sortText": "0"
+    },
+    {
+      "detail": "bool",
+      "kind": 5,
+      "label": "exists",
+      "sortText": "0"
+    },
+    {
+      "detail": "str",
+      "kind": 5,
+      "label": "full_path",
+      "sortText": "0"
+    },
+    {
+      "detail": "{ \"accessed_millis\"?: int, \"base_name\"?: str, \"exists\": bool, \"full_path\": str, \"modified_millis\"?: int, \"permissions\"?: str, \"size_bytes\"?: int, \"type\"?: str }",
+      "kind": 6,
+      "label": "gp",
+      "sortText": "0"
+    },
+    {
+      "detail": "int?",
+      "documentation": "Optional key - may be absent at runtime; accessing it without a guard errors if missing.",
+      "kind": 5,
+      "label": "modified_millis",
+      "sortText": "0"
+    },
+    {
+      "detail": "str?",
+      "documentation": "Optional key - may be absent at runtime; accessing it without a guard errors if missing.",
+      "kind": 5,
+      "label": "permissions",
+      "sortText": "0"
+    },
+    {
+      "detail": "int?",
+      "documentation": "Optional key - may be absent at runtime; accessing it without a guard errors if missing.",
+      "kind": 5,
+      "label": "size_bytes",
+      "sortText": "0"
+    },
+    {
+      "detail": "str?",
+      "documentation": "Optional key - may be absent at runtime; accessing it without a guard errors if missing.",
+      "kind": 5,
+      "label": "type",
+      "sortText": "0"
+    },
+    {
+      "detail": "fn()",
+      "kind": 3,
+      "label": "f",
+      "sortText": "1"
+    },
+    {
+      "detail": "black(_item: any) -\u003e str",
+      "kind": 3,
+      "label": "black",
+      "sortText": "1z"
+    },
+    {
+      "detail": "blue(_item: any) -\u003e str",
+      "kind": 3,
+      "label": "blue",
+      "sortText": "1z"
+    },
+    {
+      "detail": "bold(_item: any) -\u003e str",
+      "kind": 3,
+      "label": "bold",
+      "sortText": "1z"
+    },
+    {
+      "detail": "color_rgb(_val: any, red: int, green: int, blue: int) -\u003e error|str",
+      "kind": 3,
+      "label": "color_rgb",
+      "sortText": "1z"
+    },
+    {
+      "detail": "colorize(_val: any, _enum: any[], *, skip_if_single: bool = false) -\u003e str",
+      "kind": 3,
+      "label": "colorize",
+      "sortText": "1z"
+    },
+    {
+      "detail": "cyan(_item: any) -\u003e str",
+      "kind": 3,
+      "label": "cyan",
+      "sortText": "1z"
+    },
+    {
+      "detail": "debug(*_items: any, *, sep: str = \" \", end: str = \"\\n\") -\u003e void",
+      "kind": 3,
+      "label": "debug",
+      "sortText": "1z"
+    },
+    {
+      "detail": "dim(_item: any) -\u003e str",
+      "kind": 3,
+      "label": "dim",
+      "sortText": "1z"
+    },
+    {
+      "detail": "filter(_coll: map|list, _fn: fn(any) -\u003e bool | fn(any, any) -\u003e bool) -\u003e map|list",
+      "kind": 3,
+      "label": "filter",
+      "sortText": "1z"
+    },
+    {
+      "detail": "flat_map(_coll: map|list, _fn: any?) -\u003e list",
+      "kind": 3,
+      "label": "flat_map",
+      "sortText": "1z"
+    },
+    {
+      "detail": "float(_var: any) -\u003e float|error",
+      "kind": 3,
+      "label": "float",
+      "sortText": "1z"
+    },
+    {
+      "detail": "green(_item: any) -\u003e str",
+      "kind": 3,
+      "label": "green",
+      "sortText": "1z"
+    },
+    {
+      "detail": "hyperlink(_val: any, _link: str) -\u003e str",
+      "kind": 3,
+      "label": "hyperlink",
+      "sortText": "1z"
+    },
+    {
+      "detail": "int(_var: any) -\u003e int|error",
+      "kind": 3,
+      "label": "int",
+      "sortText": "1z"
+    },
+    {
+      "detail": "italic(_item: any) -\u003e str",
+      "kind": 3,
+      "label": "italic",
+      "sortText": "1z"
+    },
+    {
+      "detail": "keys(_map: map) -\u003e any[]",
+      "kind": 3,
+      "label": "keys",
+      "sortText": "1z"
+    },
+    {
+      "detail": "len(_val: str|list|map) -\u003e int",
+      "kind": 3,
+      "label": "len",
+      "sortText": "1z"
+    },
+    {
+      "detail": "load(_map: map, _key: any, _loader: fn() -\u003e any, *, reload: bool = false, override: any?) -\u003e error|any",
+      "kind": 3,
+      "label": "load",
+      "sortText": "1z"
+    },
+    {
+      "detail": "magenta(_item: any) -\u003e str",
+      "kind": 3,
+      "label": "magenta",
+      "sortText": "1z"
+    },
+    {
+      "detail": "map(_coll: map|list, _fn: fn(any) -\u003e any | fn(any, any) -\u003e any) -\u003e map|list",
+      "kind": 3,
+      "label": "map",
+      "sortText": "1z"
+    },
+    {
+      "detail": "orange(_item: any) -\u003e str",
+      "kind": 3,
+      "label": "orange",
+      "sortText": "1z"
+    },
+    {
+      "detail": "pink(_item: any) -\u003e str",
+      "kind": 3,
+      "label": "pink",
+      "sortText": "1z"
+    },
+    {
+      "detail": "plain(_item: any) -\u003e str",
+      "kind": 3,
+      "label": "plain",
+      "sortText": "1z"
+    },
+    {
+      "detail": "pprint(_item: any?) -\u003e void",
+      "kind": 3,
+      "label": "pprint",
+      "sortText": "1z"
+    },
+    {
+      "detail": "print(*_items: any, *, sep: str = \" \", end: str = \"\\n\") -\u003e void",
+      "kind": 3,
+      "label": "print",
+      "sortText": "1z"
+    },
+    {
+      "detail": "print_err(*_items: any, *, sep: str = \" \", end: str = \"\\n\") -\u003e void",
+      "kind": 3,
+      "label": "print_err",
+      "sortText": "1z"
+    },
+    {
+      "detail": "red(_item: any) -\u003e str",
+      "kind": 3,
+      "label": "red",
+      "sortText": "1z"
+    },
+    {
+      "detail": "save_state(_state: map) -\u003e error?",
+      "kind": 3,
+      "label": "save_state",
+      "sortText": "1z"
+    },
+    {
+      "detail": "str(_var: any) -\u003e str",
+      "kind": 3,
+      "label": "str",
+      "sortText": "1z"
+    },
+    {
+      "detail": "strikethrough(_item: any) -\u003e str",
+      "kind": 3,
+      "label": "strikethrough",
+      "sortText": "1z"
+    },
+    {
+      "detail": "type_of(_var: any) -\u003e [\"int\", \"str\", \"list\", \"map\", \"float\", \"bool\", \"null\", \"error\", \"function\"]",
+      "kind": 3,
+      "label": "type_of",
+      "sortText": "1z"
+    },
+    {
+      "detail": "underline(_item: any) -\u003e str",
+      "kind": 3,
+      "label": "underline",
+      "sortText": "1z"
+    },
+    {
+      "detail": "values(_map: map) -\u003e any[]",
+      "kind": 3,
+      "label": "values",
+      "sortText": "1z"
+    },
+    {
+      "detail": "white(_item: any) -\u003e str",
+      "kind": 3,
+      "label": "white",
+      "sortText": "1z"
+    },
+    {
+      "detail": "yellow(_item: any) -\u003e str",
+      "kind": 3,
+      "label": "yellow",
+      "sortText": "1z"
+    },
+    {
+      "detail": "abs(_num: int|float) -\u003e int|float",
+      "kind": 3,
+      "label": "abs",
+      "sortText": "2"
+    },
+    {
+      "detail": "ceil(_num: float) -\u003e int",
+      "kind": 3,
+      "label": "ceil",
+      "sortText": "2"
+    },
+    {
+      "detail": "clamp(val: int|float, min: int|float, max: int|float) -\u003e error|int|float",
+      "kind": 3,
+      "label": "clamp",
+      "sortText": "2"
+    },
+    {
+      "detail": "confirm(prompt: str = \"Confirm? [Y/n] \u003e \") -\u003e error|bool",
+      "kind": 3,
+      "label": "confirm",
+      "sortText": "2"
+    },
+    {
+      "detail": "convert_duration(_value: int|float, _unit: [\"nanos\", \"micros\", \"millis\", \"seconds\", \"minutes\", \"hours\", \"days\"]) -\u003e error|{ \"nanos\": int, \"micros\": float, \"millis\": float, \"seconds\": float, \"minutes\": float, \"hours\": float, \"days\": float }",
+      "kind": 3,
+      "label": "convert_duration",
+      "sortText": "2"
+    },
+    {
+      "detail": "count(_str: str, _substr: str) -\u003e int",
+      "kind": 3,
+      "label": "count",
+      "sortText": "2"
+    },
+    {
+      "detail": "decode_base16(_content: str) -\u003e error|str",
+      "kind": 3,
+      "label": "decode_base16",
+      "sortText": "2"
+    },
+    {
+      "detail": "decode_base64(_content: str, *, url_safe: bool = false, padding: bool = true) -\u003e error|str",
+      "kind": 3,
+      "label": "decode_base64",
+      "sortText": "2"
+    },
+    {
+      "detail": "delete_path(_path: str) -\u003e bool",
+      "kind": 3,
+      "label": "delete_path",
+      "sortText": "2"
+    },
+    {
+      "detail": "encode_base16(_content: str) -\u003e str",
+      "kind": 3,
+      "label": "encode_base16",
+      "sortText": "2"
+    },
+    {
+      "detail": "encode_base64(_content: str, *, url_safe: bool = false, padding: bool = true) -\u003e str",
+      "kind": 3,
+      "label": "encode_base64",
+      "sortText": "2"
+    },
+    {
+      "detail": "ends_with(_val: str, _end: str) -\u003e bool",
+      "kind": 3,
+      "label": "ends_with",
+      "sortText": "2"
+    },
+    {
+      "detail": "error(_msg: str) -\u003e error",
+      "kind": 3,
+      "label": "error",
+      "sortText": "2"
+    },
+    {
+      "detail": "exit(_code: int|bool = 0) -\u003e void",
+      "kind": 3,
+      "label": "exit",
+      "sortText": "2"
+    },
+    {
+      "detail": "find_paths(_path: str, *, depth: int = -1, relative: [\"target\", \"cwd\", \"absolute\"] = \"target\") -\u003e error|str[]",
+      "kind": 3,
+      "label": "find_paths",
+      "sortText": "2"
+    },
+    {
+      "detail": "floor(_num: float) -\u003e int",
+      "kind": 3,
+      "label": "floor",
+      "sortText": "2"
+    },
+    {
+      "detail": "gen_fid(*, alphabet: str?, tick_size_ms: int?, num_random_chars: int?) -\u003e error|str",
+      "kind": 3,
+      "label": "gen_fid",
+      "sortText": "2"
+    },
+    {
+      "detail": "get_args() -\u003e str[]",
+      "kind": 3,
+      "label": "get_args",
+      "sortText": "2"
+    },
+    {
+      "detail": "get_env(_var: str) -\u003e str",
+      "kind": 3,
+      "label": "get_env",
+      "sortText": "2"
+    },
+    {
+      "detail": "get_path(_path: str) -\u003e { \"exists\": bool, \"full_path\": str, \"base_name\"?: str, \"permissions\"?: str, \"type\"?: str, \"size_bytes\"?: int, \"modified_millis\"?: int, \"accessed_millis\"?: int }",
+      "kind": 3,
+      "label": "get_path",
+      "sortText": "2"
+    },
+    {
+      "detail": "get_rad_home() -\u003e str",
+      "kind": 3,
+      "label": "get_rad_home",
+      "sortText": "2"
+    },
+    {
+      "detail": "get_stash_path(_sub_path: str = \"\") -\u003e error|str",
+      "kind": 3,
+      "label": "get_stash_path",
+      "sortText": "2"
+    },
+    {
+      "detail": "has_stdin() -\u003e bool",
+      "kind": 3,
+      "label": "has_stdin",
+      "sortText": "2"
+    },
+    {
+      "detail": "hash(_val: str, algo: [\"sha1\", \"sha256\", \"sha512\", \"md5\"] = \"sha1\") -\u003e str",
+      "kind": 3,
+      "label": "hash",
+      "sortText": "2"
+    },
+    {
+      "detail": "http_connect(url: str, *, body: any?, json: any?, headers: map?, insecure: bool = false) -\u003e { \"success\": bool, \"status_code\"?: int, \"headers\": map, \"body\"?: any, \"error\"?: str, \"duration_seconds\": float }",
+      "kind": 3,
+      "label": "http_connect",
+      "sortText": "2"
+    },
+    {
+      "detail": "http_delete(url: str, *, body: any?, json: any?, headers: map?, insecure: bool = false) -\u003e { \"success\": bool, \"status_code\"?: int, \"headers\": map, \"body\"?: any, \"error\"?: str, \"duration_seconds\": float }",
+      "kind": 3,
+      "label": "http_delete",
+      "sortText": "2"
+    },
+    {
+      "detail": "http_get(url: str, *, body: any?, json: any?, headers: map?, insecure: bool = false) -\u003e { \"success\": bool, \"status_code\"?: int, \"headers\": map, \"body\"?: any, \"error\"?: str, \"duration_seconds\": float }",
+      "kind": 3,
+      "label": "http_get",
+      "sortText": "2"
+    },
+    {
+      "detail": "http_head(url: str, *, body: any?, json: any?, headers: map?, insecure: bool = false) -\u003e { \"success\": bool, \"status_code\"?: int, \"headers\": map, \"body\"?: any, \"error\"?: str, \"duration_seconds\": float }",
+      "kind": 3,
+      "label": "http_head",
+      "sortText": "2"
+    },
+    {
+      "detail": "http_options(url: str, *, body: any?, json: any?, headers: map?, insecure: bool = false) -\u003e { \"success\": bool, \"status_code\"?: int, \"headers\": map, \"body\"?: any, \"error\"?: str, \"duration_seconds\": float }",
+      "kind": 3,
+      "label": "http_options",
+      "sortText": "2"
+    },
+    {
+      "detail": "http_patch(url: str, *, body: any?, json: any?, headers: map?, insecure: bool = false) -\u003e { \"success\": bool, \"status_code\"?: int, \"headers\": map, \"body\"?: any, \"error\"?: str, \"duration_seconds\": float }",
+      "kind": 3,
+      "label": "http_patch",
+      "sortText": "2"
+    },
+    {
+      "detail": "http_post(url: str, *, body: any?, json: any?, headers: map?, insecure: bool = false) -\u003e { \"success\": bool, \"status_code\"?: int, \"headers\": map, \"body\"?: any, \"error\"?: str, \"duration_seconds\": float }",
+      "kind": 3,
+      "label": "http_post",
+      "sortText": "2"
+    },
+    {
+      "detail": "http_put(url: str, *, body: any?, json: any?, headers: map?, insecure: bool = false) -\u003e { \"success\": bool, \"status_code\"?: int, \"headers\": map, \"body\"?: any, \"error\"?: str, \"duration_seconds\": float }",
+      "kind": 3,
+      "label": "http_put",
+      "sortText": "2"
+    },
+    {
+      "detail": "http_trace(url: str, *, body: any?, json: any?, headers: map?, insecure: bool = false) -\u003e { \"success\": bool, \"status_code\"?: int, \"headers\": map, \"body\"?: any, \"error\"?: str, \"duration_seconds\": float }",
+      "kind": 3,
+      "label": "http_trace",
+      "sortText": "2"
+    },
+    {
+      "detail": "index_of(_subject: str|list, _target: any, *, n: int = 0, start: int = 0) -\u003e int?",
+      "kind": 3,
+      "label": "index_of",
+      "sortText": "2"
+    },
+    {
+      "detail": "input(prompt: str = \"\u003e \", *, hint: str = \"\", default: str = \"\", secret: bool = false) -\u003e error|str",
+      "kind": 3,
+      "label": "input",
+      "sortText": "2"
+    },
+    {
+      "detail": "is_defined(_var: str) -\u003e bool",
+      "kind": 3,
+      "label": "is_defined",
+      "sortText": "2"
+    },
+    {
+      "detail": "join(_list: list, sep: str = \"\", prefix: str = \"\", suffix: str = \"\") -\u003e str",
+      "kind": 3,
+      "label": "join",
+      "sortText": "2"
+    },
+    {
+      "detail": "load_stash_file(_path: str, _default: str = \"\") -\u003e error|{ \"full_path\": str, \"created\": bool, \"content\"?: str }",
+      "kind": 3,
+      "label": "load_stash_file",
+      "sortText": "2"
+    },
+    {
+      "detail": "load_state() -\u003e error|map",
+      "kind": 3,
+      "label": "load_state",
+      "sortText": "2"
+    },
+    {
+      "detail": "lower(_val: str) -\u003e str",
+      "kind": 3,
+      "label": "lower",
+      "sortText": "2"
+    },
+    {
+      "detail": "matches(_str: str, _pattern: str, *, partial: bool = false) -\u003e bool|error",
+      "kind": 3,
+      "label": "matches",
+      "sortText": "2"
+    },
+    {
+      "detail": "max(*_nums: float|float[]) -\u003e int|float|error",
+      "kind": 3,
+      "label": "max",
+      "sortText": "2"
+    },
+    {
+      "detail": "min(*_nums: float|float[]) -\u003e int|float|error",
+      "kind": 3,
+      "label": "min",
+      "sortText": "2"
+    },
+    {
+      "detail": "multipick(_options: str[], *, prompt: str?, min: int = 0, max: int?) -\u003e str[]",
+      "kind": 3,
+      "label": "multipick",
+      "sortText": "2"
+    },
+    {
+      "detail": "now(*, tz: str = \"local\") -\u003e error|{ \"date\": str, \"year\": int, \"month\": int, \"day\": int, \"hour\": int, \"minute\": int, \"second\": int, \"time\": str, \"epoch\": { \"seconds\": int, \"millis\": int, \"nanos\": int } }",
+      "kind": 3,
+      "label": "now",
+      "sortText": "2"
+    },
+    {
+      "detail": "parse_date(_date: str, *, format: str?, tz: str = \"local\") -\u003e error|{ \"date\": str, \"year\": int, \"month\": int, \"day\": int, \"hour\": int, \"minute\": int, \"second\": int, \"time\": str, \"epoch\": { \"seconds\": int, \"millis\": int, \"nanos\": int } }",
+      "kind": 3,
+      "label": "parse_date",
+      "sortText": "2"
+    },
+    {
+      "detail": "parse_duration(_duration: str) -\u003e error|{ \"nanos\": int, \"micros\": float, \"millis\": float, \"seconds\": float, \"minutes\": float, \"hours\": float, \"days\": float }",
+      "kind": 3,
+      "label": "parse_duration",
+      "sortText": "2"
+    },
+    {
+      "detail": "parse_epoch(_epoch: int|float, *, tz: str = \"local\", unit: [\"auto\", \"seconds\", \"millis\", \"micros\", \"nanos\", \"milliseconds\", \"microseconds\", \"nanoseconds\"] = \"auto\") -\u003e error|{ \"date\": str, \"year\": int, \"month\": int, \"day\": int, \"hour\": int, \"minute\": int, \"second\": int, \"time\": str, \"epoch\": { \"seconds\": int, \"millis\": int, \"nanos\": int } }",
+      "kind": 3,
+      "label": "parse_epoch",
+      "sortText": "2"
+    },
+    {
+      "detail": "parse_float(_str: str) -\u003e float|error",
+      "kind": 3,
+      "label": "parse_float",
+      "sortText": "2"
+    },
+    {
+      "detail": "parse_int(_str: str) -\u003e int|error",
+      "kind": 3,
+      "label": "parse_int",
+      "sortText": "2"
+    },
+    {
+      "detail": "parse_json(_str: str) -\u003e any|error",
+      "kind": 3,
+      "label": "parse_json",
+      "sortText": "2"
+    },
+    {
+      "detail": "pick(_options: str[], _filter: (str|str[])?, *, prompt: str = \"Pick an option\", prefer_exact: bool = false) -\u003e str",
+      "kind": 3,
+      "label": "pick",
+      "sortText": "2"
+    },
+    {
+      "detail": "pick_from_resource(path: str, _filter: str?, *, prompt: str = \"Pick an option\", prefer_exact: bool = true) -\u003e any",
+      "kind": 3,
+      "label": "pick_from_resource",
+      "sortText": "2"
+    },
+    {
+      "detail": "pick_kv(keys: str[], values: any[], _filter: (str|str[])?, *, prompt: str = \"Pick an option\", prefer_exact: bool = false) -\u003e any",
+      "kind": 3,
+      "label": "pick_kv",
+      "sortText": "2"
+    },
+    {
+      "detail": "pow(_base: float, _exponent: float) -\u003e float",
+      "kind": 3,
+      "label": "pow",
+      "sortText": "2"
+    },
+    {
+      "detail": "rand() -\u003e float",
+      "kind": 3,
+      "label": "rand",
+      "sortText": "2"
+    },
+    {
+      "detail": "rand_int(_arg1: int = 9223372036854775807, _arg2: int?) -\u003e int",
+      "kind": 3,
+      "label": "rand_int",
+      "sortText": "2"
+    },
+    {
+      "detail": "range(_arg1: float|int, _arg2: (float|int)?, _step: float|int = 1) -\u003e float[]|int[]",
+      "kind": 3,
+      "label": "range",
+      "sortText": "2"
+    },
+    {
+      "detail": "read_file(_path: str, *, mode: [\"text\", \"bytes\"] = \"text\") -\u003e error|{ \"size_bytes\": int, \"content\": str|int[] }",
+      "kind": 3,
+      "label": "read_file",
+      "sortText": "2"
+    },
+    {
+      "detail": "read_stdin() -\u003e str?|error",
+      "kind": 3,
+      "label": "read_stdin",
+      "sortText": "2"
+    },
+    {
+      "detail": "replace(_original: str, _find: str, _replace: str) -\u003e str",
+      "kind": 3,
+      "label": "replace",
+      "sortText": "2"
+    },
+    {
+      "detail": "reverse(_val: str|list) -\u003e str|list",
+      "kind": 3,
+      "label": "reverse",
+      "sortText": "2"
+    },
+    {
+      "detail": "round(_num: float, _decimals: int = 0) -\u003e error|int|float",
+      "kind": 3,
+      "label": "round",
+      "sortText": "2"
+    },
+    {
+      "detail": "seed_random(_seed: int) -\u003e void",
+      "kind": 3,
+      "label": "seed_random",
+      "sortText": "2"
+    },
+    {
+      "detail": "sleep(_duration: int|float|str, *, title: str?) -\u003e void",
+      "kind": 3,
+      "label": "sleep",
+      "sortText": "2"
+    },
+    {
+      "detail": "sort(_primary: list|str, *_others: list|str, *, reverse: bool = false) -\u003e list|str",
+      "kind": 3,
+      "label": "sort",
+      "sortText": "2"
+    },
+    {
+      "detail": "split(_val: str, _sep: str, *, limit: int?) -\u003e str[]",
+      "kind": 3,
+      "label": "split",
+      "sortText": "2"
+    },
+    {
+      "detail": "split_lines(_val: str) -\u003e str[]",
+      "kind": 3,
+      "label": "split_lines",
+      "sortText": "2"
+    },
+    {
+      "detail": "starts_with(_val: str, _start: str) -\u003e bool",
+      "kind": 3,
+      "label": "starts_with",
+      "sortText": "2"
+    },
+    {
+      "detail": "sum(_nums: float[]) -\u003e error|int|float",
+      "kind": 3,
+      "label": "sum",
+      "sortText": "2"
+    },
+    {
+      "detail": "trim(_subject: str, _chars: str = \" \\t\\n\") -\u003e str",
+      "kind": 3,
+      "label": "trim",
+      "sortText": "2"
+    },
+    {
+      "detail": "trim_left(_subject: str, _chars: str = \" \\t\\n\") -\u003e str",
+      "kind": 3,
+      "label": "trim_left",
+      "sortText": "2"
+    },
+    {
+      "detail": "trim_prefix(_subject: str, _prefix: str) -\u003e str",
+      "kind": 3,
+      "label": "trim_prefix",
+      "sortText": "2"
+    },
+    {
+      "detail": "trim_right(_subject: str, _chars: str = \" \\t\\n\") -\u003e str",
+      "kind": 3,
+      "label": "trim_right",
+      "sortText": "2"
+    },
+    {
+      "detail": "trim_suffix(_subject: str, _suffix: str) -\u003e str",
+      "kind": 3,
+      "label": "trim_suffix",
+      "sortText": "2"
+    },
+    {
+      "detail": "truncate(_str: str, _len: int) -\u003e error|str",
+      "kind": 3,
+      "label": "truncate",
+      "sortText": "2"
+    },
+    {
+      "detail": "unique(_list: any[]) -\u003e any[]",
+      "kind": 3,
+      "label": "unique",
+      "sortText": "2"
+    },
+    {
+      "detail": "upper(_val: str) -\u003e str",
+      "kind": 3,
+      "label": "upper",
+      "sortText": "2"
+    },
+    {
+      "detail": "uuid_v4() -\u003e str",
+      "kind": 3,
+      "label": "uuid_v4",
+      "sortText": "2"
+    },
+    {
+      "detail": "uuid_v7() -\u003e str",
+      "kind": 3,
+      "label": "uuid_v7",
+      "sortText": "2"
+    },
+    {
+      "detail": "write_file(_path: str, _content: str, *, append: bool = false) -\u003e error|{ \"bytes_written\": int, \"path\": str }",
+      "kind": 3,
+      "label": "write_file",
+      "sortText": "2"
+    },
+    {
+      "detail": "write_stash_file(_path: str, _content: str) -\u003e error?",
+      "kind": 3,
+      "label": "write_stash_file",
+      "sortText": "2"
+    },
+    {
+      "detail": "zip(*_lists: list, *, fill: any?, strict: bool = false) -\u003e error|list[]",
+      "kind": 3,
+      "label": "zip",
+      "sortText": "2"
+    }
+  ]
+}
+### TITLE ###
+MapKeysAfterDotNestedBlockLocal
+### DOCUMENT ###
+fn f():
+    if true:
+        gp = get_path("x")
+    print(gp.exists)
+### COMPLETION 3:13 ###
+### STDOUT ###
+{
+  "jsonrpc": "2.0",
+  "method": "textDocument/publishDiagnostics",
+  "params": {
+    "diagnostics": [],
+    "uri": "file:///test.rad"
+  }
+}
+
+{
+  "id": 1,
+  "jsonrpc": "2.0",
+  "result": [
+    {
+      "detail": "int?",
+      "documentation": "Optional key - may be absent at runtime; accessing it without a guard errors if missing.",
+      "kind": 5,
+      "label": "accessed_millis",
+      "sortText": "0"
+    },
+    {
+      "detail": "str?",
+      "documentation": "Optional key - may be absent at runtime; accessing it without a guard errors if missing.",
+      "kind": 5,
+      "label": "base_name",
+      "sortText": "0"
+    },
+    {
+      "detail": "bool",
+      "kind": 5,
+      "label": "exists",
+      "sortText": "0"
+    },
+    {
+      "detail": "str",
+      "kind": 5,
+      "label": "full_path",
+      "sortText": "0"
+    },
+    {
+      "detail": "int?",
+      "documentation": "Optional key - may be absent at runtime; accessing it without a guard errors if missing.",
+      "kind": 5,
+      "label": "modified_millis",
+      "sortText": "0"
+    },
+    {
+      "detail": "str?",
+      "documentation": "Optional key - may be absent at runtime; accessing it without a guard errors if missing.",
+      "kind": 5,
+      "label": "permissions",
+      "sortText": "0"
+    },
+    {
+      "detail": "int?",
+      "documentation": "Optional key - may be absent at runtime; accessing it without a guard errors if missing.",
+      "kind": 5,
+      "label": "size_bytes",
+      "sortText": "0"
+    },
+    {
+      "detail": "str?",
+      "documentation": "Optional key - may be absent at runtime; accessing it without a guard errors if missing.",
+      "kind": 5,
+      "label": "type",
+      "sortText": "0"
+    },
+    {
+      "detail": "fn()",
+      "kind": 3,
+      "label": "f",
+      "sortText": "1"
+    },
+    {
+      "detail": "black(_item: any) -\u003e str",
+      "kind": 3,
+      "label": "black",
+      "sortText": "1z"
+    },
+    {
+      "detail": "blue(_item: any) -\u003e str",
+      "kind": 3,
+      "label": "blue",
+      "sortText": "1z"
+    },
+    {
+      "detail": "bold(_item: any) -\u003e str",
+      "kind": 3,
+      "label": "bold",
+      "sortText": "1z"
+    },
+    {
+      "detail": "color_rgb(_val: any, red: int, green: int, blue: int) -\u003e error|str",
+      "kind": 3,
+      "label": "color_rgb",
+      "sortText": "1z"
+    },
+    {
+      "detail": "colorize(_val: any, _enum: any[], *, skip_if_single: bool = false) -\u003e str",
+      "kind": 3,
+      "label": "colorize",
+      "sortText": "1z"
+    },
+    {
+      "detail": "cyan(_item: any) -\u003e str",
+      "kind": 3,
+      "label": "cyan",
+      "sortText": "1z"
+    },
+    {
+      "detail": "debug(*_items: any, *, sep: str = \" \", end: str = \"\\n\") -\u003e void",
+      "kind": 3,
+      "label": "debug",
+      "sortText": "1z"
+    },
+    {
+      "detail": "dim(_item: any) -\u003e str",
+      "kind": 3,
+      "label": "dim",
+      "sortText": "1z"
+    },
+    {
+      "detail": "filter(_coll: map|list, _fn: fn(any) -\u003e bool | fn(any, any) -\u003e bool) -\u003e map|list",
+      "kind": 3,
+      "label": "filter",
+      "sortText": "1z"
+    },
+    {
+      "detail": "flat_map(_coll: map|list, _fn: any?) -\u003e list",
+      "kind": 3,
+      "label": "flat_map",
+      "sortText": "1z"
+    },
+    {
+      "detail": "float(_var: any) -\u003e float|error",
+      "kind": 3,
+      "label": "float",
+      "sortText": "1z"
+    },
+    {
+      "detail": "green(_item: any) -\u003e str",
+      "kind": 3,
+      "label": "green",
+      "sortText": "1z"
+    },
+    {
+      "detail": "hyperlink(_val: any, _link: str) -\u003e str",
+      "kind": 3,
+      "label": "hyperlink",
+      "sortText": "1z"
+    },
+    {
+      "detail": "int(_var: any) -\u003e int|error",
+      "kind": 3,
+      "label": "int",
+      "sortText": "1z"
+    },
+    {
+      "detail": "italic(_item: any) -\u003e str",
+      "kind": 3,
+      "label": "italic",
+      "sortText": "1z"
+    },
+    {
+      "detail": "keys(_map: map) -\u003e any[]",
+      "kind": 3,
+      "label": "keys",
+      "sortText": "1z"
+    },
+    {
+      "detail": "len(_val: str|list|map) -\u003e int",
+      "kind": 3,
+      "label": "len",
+      "sortText": "1z"
+    },
+    {
+      "detail": "load(_map: map, _key: any, _loader: fn() -\u003e any, *, reload: bool = false, override: any?) -\u003e error|any",
+      "kind": 3,
+      "label": "load",
+      "sortText": "1z"
+    },
+    {
+      "detail": "magenta(_item: any) -\u003e str",
+      "kind": 3,
+      "label": "magenta",
+      "sortText": "1z"
+    },
+    {
+      "detail": "map(_coll: map|list, _fn: fn(any) -\u003e any | fn(any, any) -\u003e any) -\u003e map|list",
+      "kind": 3,
+      "label": "map",
+      "sortText": "1z"
+    },
+    {
+      "detail": "orange(_item: any) -\u003e str",
+      "kind": 3,
+      "label": "orange",
+      "sortText": "1z"
+    },
+    {
+      "detail": "pink(_item: any) -\u003e str",
+      "kind": 3,
+      "label": "pink",
+      "sortText": "1z"
+    },
+    {
+      "detail": "plain(_item: any) -\u003e str",
+      "kind": 3,
+      "label": "plain",
+      "sortText": "1z"
+    },
+    {
+      "detail": "pprint(_item: any?) -\u003e void",
+      "kind": 3,
+      "label": "pprint",
+      "sortText": "1z"
+    },
+    {
+      "detail": "print(*_items: any, *, sep: str = \" \", end: str = \"\\n\") -\u003e void",
+      "kind": 3,
+      "label": "print",
+      "sortText": "1z"
+    },
+    {
+      "detail": "print_err(*_items: any, *, sep: str = \" \", end: str = \"\\n\") -\u003e void",
+      "kind": 3,
+      "label": "print_err",
+      "sortText": "1z"
+    },
+    {
+      "detail": "red(_item: any) -\u003e str",
+      "kind": 3,
+      "label": "red",
+      "sortText": "1z"
+    },
+    {
+      "detail": "save_state(_state: map) -\u003e error?",
+      "kind": 3,
+      "label": "save_state",
+      "sortText": "1z"
+    },
+    {
+      "detail": "str(_var: any) -\u003e str",
+      "kind": 3,
+      "label": "str",
+      "sortText": "1z"
+    },
+    {
+      "detail": "strikethrough(_item: any) -\u003e str",
+      "kind": 3,
+      "label": "strikethrough",
+      "sortText": "1z"
+    },
+    {
+      "detail": "type_of(_var: any) -\u003e [\"int\", \"str\", \"list\", \"map\", \"float\", \"bool\", \"null\", \"error\", \"function\"]",
+      "kind": 3,
+      "label": "type_of",
+      "sortText": "1z"
+    },
+    {
+      "detail": "underline(_item: any) -\u003e str",
+      "kind": 3,
+      "label": "underline",
+      "sortText": "1z"
+    },
+    {
+      "detail": "values(_map: map) -\u003e any[]",
+      "kind": 3,
+      "label": "values",
+      "sortText": "1z"
+    },
+    {
+      "detail": "white(_item: any) -\u003e str",
+      "kind": 3,
+      "label": "white",
+      "sortText": "1z"
+    },
+    {
+      "detail": "yellow(_item: any) -\u003e str",
+      "kind": 3,
+      "label": "yellow",
+      "sortText": "1z"
+    },
+    {
+      "detail": "abs(_num: int|float) -\u003e int|float",
+      "kind": 3,
+      "label": "abs",
+      "sortText": "2"
+    },
+    {
+      "detail": "ceil(_num: float) -\u003e int",
+      "kind": 3,
+      "label": "ceil",
+      "sortText": "2"
+    },
+    {
+      "detail": "clamp(val: int|float, min: int|float, max: int|float) -\u003e error|int|float",
+      "kind": 3,
+      "label": "clamp",
+      "sortText": "2"
+    },
+    {
+      "detail": "confirm(prompt: str = \"Confirm? [Y/n] \u003e \") -\u003e error|bool",
+      "kind": 3,
+      "label": "confirm",
+      "sortText": "2"
+    },
+    {
+      "detail": "convert_duration(_value: int|float, _unit: [\"nanos\", \"micros\", \"millis\", \"seconds\", \"minutes\", \"hours\", \"days\"]) -\u003e error|{ \"nanos\": int, \"micros\": float, \"millis\": float, \"seconds\": float, \"minutes\": float, \"hours\": float, \"days\": float }",
+      "kind": 3,
+      "label": "convert_duration",
+      "sortText": "2"
+    },
+    {
+      "detail": "count(_str: str, _substr: str) -\u003e int",
+      "kind": 3,
+      "label": "count",
+      "sortText": "2"
+    },
+    {
+      "detail": "decode_base16(_content: str) -\u003e error|str",
+      "kind": 3,
+      "label": "decode_base16",
+      "sortText": "2"
+    },
+    {
+      "detail": "decode_base64(_content: str, *, url_safe: bool = false, padding: bool = true) -\u003e error|str",
+      "kind": 3,
+      "label": "decode_base64",
+      "sortText": "2"
+    },
+    {
+      "detail": "delete_path(_path: str) -\u003e bool",
+      "kind": 3,
+      "label": "delete_path",
+      "sortText": "2"
+    },
+    {
+      "detail": "encode_base16(_content: str) -\u003e str",
+      "kind": 3,
+      "label": "encode_base16",
+      "sortText": "2"
+    },
+    {
+      "detail": "encode_base64(_content: str, *, url_safe: bool = false, padding: bool = true) -\u003e str",
+      "kind": 3,
+      "label": "encode_base64",
+      "sortText": "2"
+    },
+    {
+      "detail": "ends_with(_val: str, _end: str) -\u003e bool",
+      "kind": 3,
+      "label": "ends_with",
+      "sortText": "2"
+    },
+    {
+      "detail": "error(_msg: str) -\u003e error",
+      "kind": 3,
+      "label": "error",
+      "sortText": "2"
+    },
+    {
+      "detail": "exit(_code: int|bool = 0) -\u003e void",
+      "kind": 3,
+      "label": "exit",
+      "sortText": "2"
+    },
+    {
+      "detail": "find_paths(_path: str, *, depth: int = -1, relative: [\"target\", \"cwd\", \"absolute\"] = \"target\") -\u003e error|str[]",
+      "kind": 3,
+      "label": "find_paths",
+      "sortText": "2"
+    },
+    {
+      "detail": "floor(_num: float) -\u003e int",
+      "kind": 3,
+      "label": "floor",
+      "sortText": "2"
+    },
+    {
+      "detail": "gen_fid(*, alphabet: str?, tick_size_ms: int?, num_random_chars: int?) -\u003e error|str",
+      "kind": 3,
+      "label": "gen_fid",
+      "sortText": "2"
+    },
+    {
+      "detail": "get_args() -\u003e str[]",
+      "kind": 3,
+      "label": "get_args",
+      "sortText": "2"
+    },
+    {
+      "detail": "get_env(_var: str) -\u003e str",
+      "kind": 3,
+      "label": "get_env",
+      "sortText": "2"
+    },
+    {
+      "detail": "get_path(_path: str) -\u003e { \"exists\": bool, \"full_path\": str, \"base_name\"?: str, \"permissions\"?: str, \"type\"?: str, \"size_bytes\"?: int, \"modified_millis\"?: int, \"accessed_millis\"?: int }",
+      "kind": 3,
+      "label": "get_path",
+      "sortText": "2"
+    },
+    {
+      "detail": "get_rad_home() -\u003e str",
+      "kind": 3,
+      "label": "get_rad_home",
+      "sortText": "2"
+    },
+    {
+      "detail": "get_stash_path(_sub_path: str = \"\") -\u003e error|str",
+      "kind": 3,
+      "label": "get_stash_path",
+      "sortText": "2"
+    },
+    {
+      "detail": "has_stdin() -\u003e bool",
+      "kind": 3,
+      "label": "has_stdin",
+      "sortText": "2"
+    },
+    {
+      "detail": "hash(_val: str, algo: [\"sha1\", \"sha256\", \"sha512\", \"md5\"] = \"sha1\") -\u003e str",
+      "kind": 3,
+      "label": "hash",
+      "sortText": "2"
+    },
+    {
+      "detail": "http_connect(url: str, *, body: any?, json: any?, headers: map?, insecure: bool = false) -\u003e { \"success\": bool, \"status_code\"?: int, \"headers\": map, \"body\"?: any, \"error\"?: str, \"duration_seconds\": float }",
+      "kind": 3,
+      "label": "http_connect",
+      "sortText": "2"
+    },
+    {
+      "detail": "http_delete(url: str, *, body: any?, json: any?, headers: map?, insecure: bool = false) -\u003e { \"success\": bool, \"status_code\"?: int, \"headers\": map, \"body\"?: any, \"error\"?: str, \"duration_seconds\": float }",
+      "kind": 3,
+      "label": "http_delete",
+      "sortText": "2"
+    },
+    {
+      "detail": "http_get(url: str, *, body: any?, json: any?, headers: map?, insecure: bool = false) -\u003e { \"success\": bool, \"status_code\"?: int, \"headers\": map, \"body\"?: any, \"error\"?: str, \"duration_seconds\": float }",
+      "kind": 3,
+      "label": "http_get",
+      "sortText": "2"
+    },
+    {
+      "detail": "http_head(url: str, *, body: any?, json: any?, headers: map?, insecure: bool = false) -\u003e { \"success\": bool, \"status_code\"?: int, \"headers\": map, \"body\"?: any, \"error\"?: str, \"duration_seconds\": float }",
+      "kind": 3,
+      "label": "http_head",
+      "sortText": "2"
+    },
+    {
+      "detail": "http_options(url: str, *, body: any?, json: any?, headers: map?, insecure: bool = false) -\u003e { \"success\": bool, \"status_code\"?: int, \"headers\": map, \"body\"?: any, \"error\"?: str, \"duration_seconds\": float }",
+      "kind": 3,
+      "label": "http_options",
+      "sortText": "2"
+    },
+    {
+      "detail": "http_patch(url: str, *, body: any?, json: any?, headers: map?, insecure: bool = false) -\u003e { \"success\": bool, \"status_code\"?: int, \"headers\": map, \"body\"?: any, \"error\"?: str, \"duration_seconds\": float }",
+      "kind": 3,
+      "label": "http_patch",
+      "sortText": "2"
+    },
+    {
+      "detail": "http_post(url: str, *, body: any?, json: any?, headers: map?, insecure: bool = false) -\u003e { \"success\": bool, \"status_code\"?: int, \"headers\": map, \"body\"?: any, \"error\"?: str, \"duration_seconds\": float }",
+      "kind": 3,
+      "label": "http_post",
+      "sortText": "2"
+    },
+    {
+      "detail": "http_put(url: str, *, body: any?, json: any?, headers: map?, insecure: bool = false) -\u003e { \"success\": bool, \"status_code\"?: int, \"headers\": map, \"body\"?: any, \"error\"?: str, \"duration_seconds\": float }",
+      "kind": 3,
+      "label": "http_put",
+      "sortText": "2"
+    },
+    {
+      "detail": "http_trace(url: str, *, body: any?, json: any?, headers: map?, insecure: bool = false) -\u003e { \"success\": bool, \"status_code\"?: int, \"headers\": map, \"body\"?: any, \"error\"?: str, \"duration_seconds\": float }",
+      "kind": 3,
+      "label": "http_trace",
+      "sortText": "2"
+    },
+    {
+      "detail": "index_of(_subject: str|list, _target: any, *, n: int = 0, start: int = 0) -\u003e int?",
+      "kind": 3,
+      "label": "index_of",
+      "sortText": "2"
+    },
+    {
+      "detail": "input(prompt: str = \"\u003e \", *, hint: str = \"\", default: str = \"\", secret: bool = false) -\u003e error|str",
+      "kind": 3,
+      "label": "input",
+      "sortText": "2"
+    },
+    {
+      "detail": "is_defined(_var: str) -\u003e bool",
+      "kind": 3,
+      "label": "is_defined",
+      "sortText": "2"
+    },
+    {
+      "detail": "join(_list: list, sep: str = \"\", prefix: str = \"\", suffix: str = \"\") -\u003e str",
+      "kind": 3,
+      "label": "join",
+      "sortText": "2"
+    },
+    {
+      "detail": "load_stash_file(_path: str, _default: str = \"\") -\u003e error|{ \"full_path\": str, \"created\": bool, \"content\"?: str }",
+      "kind": 3,
+      "label": "load_stash_file",
+      "sortText": "2"
+    },
+    {
+      "detail": "load_state() -\u003e error|map",
+      "kind": 3,
+      "label": "load_state",
+      "sortText": "2"
+    },
+    {
+      "detail": "lower(_val: str) -\u003e str",
+      "kind": 3,
+      "label": "lower",
+      "sortText": "2"
+    },
+    {
+      "detail": "matches(_str: str, _pattern: str, *, partial: bool = false) -\u003e bool|error",
+      "kind": 3,
+      "label": "matches",
+      "sortText": "2"
+    },
+    {
+      "detail": "max(*_nums: float|float[]) -\u003e int|float|error",
+      "kind": 3,
+      "label": "max",
+      "sortText": "2"
+    },
+    {
+      "detail": "min(*_nums: float|float[]) -\u003e int|float|error",
+      "kind": 3,
+      "label": "min",
+      "sortText": "2"
+    },
+    {
+      "detail": "multipick(_options: str[], *, prompt: str?, min: int = 0, max: int?) -\u003e str[]",
+      "kind": 3,
+      "label": "multipick",
+      "sortText": "2"
+    },
+    {
+      "detail": "now(*, tz: str = \"local\") -\u003e error|{ \"date\": str, \"year\": int, \"month\": int, \"day\": int, \"hour\": int, \"minute\": int, \"second\": int, \"time\": str, \"epoch\": { \"seconds\": int, \"millis\": int, \"nanos\": int } }",
+      "kind": 3,
+      "label": "now",
+      "sortText": "2"
+    },
+    {
+      "detail": "parse_date(_date: str, *, format: str?, tz: str = \"local\") -\u003e error|{ \"date\": str, \"year\": int, \"month\": int, \"day\": int, \"hour\": int, \"minute\": int, \"second\": int, \"time\": str, \"epoch\": { \"seconds\": int, \"millis\": int, \"nanos\": int } }",
+      "kind": 3,
+      "label": "parse_date",
+      "sortText": "2"
+    },
+    {
+      "detail": "parse_duration(_duration: str) -\u003e error|{ \"nanos\": int, \"micros\": float, \"millis\": float, \"seconds\": float, \"minutes\": float, \"hours\": float, \"days\": float }",
+      "kind": 3,
+      "label": "parse_duration",
+      "sortText": "2"
+    },
+    {
+      "detail": "parse_epoch(_epoch: int|float, *, tz: str = \"local\", unit: [\"auto\", \"seconds\", \"millis\", \"micros\", \"nanos\", \"milliseconds\", \"microseconds\", \"nanoseconds\"] = \"auto\") -\u003e error|{ \"date\": str, \"year\": int, \"month\": int, \"day\": int, \"hour\": int, \"minute\": int, \"second\": int, \"time\": str, \"epoch\": { \"seconds\": int, \"millis\": int, \"nanos\": int } }",
+      "kind": 3,
+      "label": "parse_epoch",
+      "sortText": "2"
+    },
+    {
+      "detail": "parse_float(_str: str) -\u003e float|error",
+      "kind": 3,
+      "label": "parse_float",
+      "sortText": "2"
+    },
+    {
+      "detail": "parse_int(_str: str) -\u003e int|error",
+      "kind": 3,
+      "label": "parse_int",
+      "sortText": "2"
+    },
+    {
+      "detail": "parse_json(_str: str) -\u003e any|error",
+      "kind": 3,
+      "label": "parse_json",
+      "sortText": "2"
+    },
+    {
+      "detail": "pick(_options: str[], _filter: (str|str[])?, *, prompt: str = \"Pick an option\", prefer_exact: bool = false) -\u003e str",
+      "kind": 3,
+      "label": "pick",
+      "sortText": "2"
+    },
+    {
+      "detail": "pick_from_resource(path: str, _filter: str?, *, prompt: str = \"Pick an option\", prefer_exact: bool = true) -\u003e any",
+      "kind": 3,
+      "label": "pick_from_resource",
+      "sortText": "2"
+    },
+    {
+      "detail": "pick_kv(keys: str[], values: any[], _filter: (str|str[])?, *, prompt: str = \"Pick an option\", prefer_exact: bool = false) -\u003e any",
+      "kind": 3,
+      "label": "pick_kv",
+      "sortText": "2"
+    },
+    {
+      "detail": "pow(_base: float, _exponent: float) -\u003e float",
+      "kind": 3,
+      "label": "pow",
+      "sortText": "2"
+    },
+    {
+      "detail": "rand() -\u003e float",
+      "kind": 3,
+      "label": "rand",
+      "sortText": "2"
+    },
+    {
+      "detail": "rand_int(_arg1: int = 9223372036854775807, _arg2: int?) -\u003e int",
+      "kind": 3,
+      "label": "rand_int",
+      "sortText": "2"
+    },
+    {
+      "detail": "range(_arg1: float|int, _arg2: (float|int)?, _step: float|int = 1) -\u003e float[]|int[]",
+      "kind": 3,
+      "label": "range",
+      "sortText": "2"
+    },
+    {
+      "detail": "read_file(_path: str, *, mode: [\"text\", \"bytes\"] = \"text\") -\u003e error|{ \"size_bytes\": int, \"content\": str|int[] }",
+      "kind": 3,
+      "label": "read_file",
+      "sortText": "2"
+    },
+    {
+      "detail": "read_stdin() -\u003e str?|error",
+      "kind": 3,
+      "label": "read_stdin",
+      "sortText": "2"
+    },
+    {
+      "detail": "replace(_original: str, _find: str, _replace: str) -\u003e str",
+      "kind": 3,
+      "label": "replace",
+      "sortText": "2"
+    },
+    {
+      "detail": "reverse(_val: str|list) -\u003e str|list",
+      "kind": 3,
+      "label": "reverse",
+      "sortText": "2"
+    },
+    {
+      "detail": "round(_num: float, _decimals: int = 0) -\u003e error|int|float",
+      "kind": 3,
+      "label": "round",
+      "sortText": "2"
+    },
+    {
+      "detail": "seed_random(_seed: int) -\u003e void",
+      "kind": 3,
+      "label": "seed_random",
+      "sortText": "2"
+    },
+    {
+      "detail": "sleep(_duration: int|float|str, *, title: str?) -\u003e void",
+      "kind": 3,
+      "label": "sleep",
+      "sortText": "2"
+    },
+    {
+      "detail": "sort(_primary: list|str, *_others: list|str, *, reverse: bool = false) -\u003e list|str",
+      "kind": 3,
+      "label": "sort",
+      "sortText": "2"
+    },
+    {
+      "detail": "split(_val: str, _sep: str, *, limit: int?) -\u003e str[]",
+      "kind": 3,
+      "label": "split",
+      "sortText": "2"
+    },
+    {
+      "detail": "split_lines(_val: str) -\u003e str[]",
+      "kind": 3,
+      "label": "split_lines",
+      "sortText": "2"
+    },
+    {
+      "detail": "starts_with(_val: str, _start: str) -\u003e bool",
+      "kind": 3,
+      "label": "starts_with",
+      "sortText": "2"
+    },
+    {
+      "detail": "sum(_nums: float[]) -\u003e error|int|float",
+      "kind": 3,
+      "label": "sum",
+      "sortText": "2"
+    },
+    {
+      "detail": "trim(_subject: str, _chars: str = \" \\t\\n\") -\u003e str",
+      "kind": 3,
+      "label": "trim",
+      "sortText": "2"
+    },
+    {
+      "detail": "trim_left(_subject: str, _chars: str = \" \\t\\n\") -\u003e str",
+      "kind": 3,
+      "label": "trim_left",
+      "sortText": "2"
+    },
+    {
+      "detail": "trim_prefix(_subject: str, _prefix: str) -\u003e str",
+      "kind": 3,
+      "label": "trim_prefix",
+      "sortText": "2"
+    },
+    {
+      "detail": "trim_right(_subject: str, _chars: str = \" \\t\\n\") -\u003e str",
+      "kind": 3,
+      "label": "trim_right",
+      "sortText": "2"
+    },
+    {
+      "detail": "trim_suffix(_subject: str, _suffix: str) -\u003e str",
+      "kind": 3,
+      "label": "trim_suffix",
+      "sortText": "2"
+    },
+    {
+      "detail": "truncate(_str: str, _len: int) -\u003e error|str",
+      "kind": 3,
+      "label": "truncate",
+      "sortText": "2"
+    },
+    {
+      "detail": "unique(_list: any[]) -\u003e any[]",
+      "kind": 3,
+      "label": "unique",
+      "sortText": "2"
+    },
+    {
+      "detail": "upper(_val: str) -\u003e str",
+      "kind": 3,
+      "label": "upper",
+      "sortText": "2"
+    },
+    {
+      "detail": "uuid_v4() -\u003e str",
+      "kind": 3,
+      "label": "uuid_v4",
+      "sortText": "2"
+    },
+    {
+      "detail": "uuid_v7() -\u003e str",
+      "kind": 3,
+      "label": "uuid_v7",
+      "sortText": "2"
+    },
+    {
+      "detail": "write_file(_path: str, _content: str, *, append: bool = false) -\u003e error|{ \"bytes_written\": int, \"path\": str }",
+      "kind": 3,
+      "label": "write_file",
+      "sortText": "2"
+    },
+    {
+      "detail": "write_stash_file(_path: str, _content: str) -\u003e error?",
+      "kind": 3,
+      "label": "write_stash_file",
+      "sortText": "2"
+    },
+    {
+      "detail": "zip(*_lists: list, *, fill: any?, strict: bool = false) -\u003e error|list[]",
+      "kind": 3,
+      "label": "zip",
+      "sortText": "2"
+    }
+  ]
+}

--- a/rts/check/narrow.go
+++ b/rts/check/narrow.go
@@ -158,7 +158,7 @@ func (tc *typeChecker) narrowTruthyIdent(ident *rl.Identifier, frame *Frame) Ref
 }
 
 // interpretUnaryCondition handles `not <expr>`. Other unary ops
-// (-, +) aren'\''t boolean and don'\''t produce refinements.
+// (-, +) aren'\”t boolean and don'\”t produce refinements.
 //
 // Logical negation flips the refinement: what was the truthy
 // narrowing becomes the falsy narrowing and vice versa. Refinement.
@@ -203,18 +203,19 @@ func (tc *typeChecker) interpretBinaryCondition(c *rl.OpBinary, frame *Frame) Re
 // the narrowing semantics:
 //
 //   - WhenTrue: both a and b evaluated truthy. The truthy narrowing
-//     is a'\''s WhenTrue applied first, then b'\''s WhenTrue computed
+//     is a'\”s WhenTrue applied first, then b'\”s WhenTrue computed
 //     against the a-truthy frame and merged on top. Latter wins on
-//     conflicts since it'\''s computed in the tighter frame.
+//     conflicts since it'\”s computed in the tighter frame.
 //
 //   - WhenFalse: at least one of a, b is falsy. This is a disjunction
-//     - either "a falsy" or "a truthy, b falsy" - and we don'\''t have
+//
+//   - either "a falsy" or "a truthy, b falsy" - and we don'\”t have
 //     a way to express "OR of two refinements" without losing info.
 //     Conservative: empty WhenFalse. Pyright takes the same shortcut.
 //
-// The right-hand side is interpreted with a'\''s truthy narrowing
+// The right-hand side is interpreted with a'\”s truthy narrowing
 // active: in `x != null and x > 5`, the `x > 5` is evaluated knowing
-// x is non-null. That'\''s why we walk the right under
+// x is non-null. That'\”s why we walk the right under
 // frame.WithMany(leftRef.WhenTrue) before interpreting.
 func (tc *typeChecker) interpretAnd(c *rl.OpBinary, frame *Frame) Refinement {
 	leftRef := tc.interpretCondition(c.Left, frame)
@@ -228,8 +229,8 @@ func (tc *typeChecker) interpretAnd(c *rl.OpBinary, frame *Frame) Refinement {
 
 // interpretOr handles `a or b`. Mirror image of and:
 //
-//   - WhenFalse: both falsy. Sequential apply: a'\''s WhenFalse first,
-//     b'\''s WhenFalse computed against the a-falsy frame, then
+//   - WhenFalse: both falsy. Sequential apply: a'\”s WhenFalse first,
+//     b'\”s WhenFalse computed against the a-falsy frame, then
 //     merged.
 //
 //   - WhenTrue: at least one truthy. Disjunction, conservatively empty.
@@ -244,8 +245,8 @@ func (tc *typeChecker) interpretOr(c *rl.OpBinary, frame *Frame) Refinement {
 }
 
 // mergeRefinementMaps overlays b on top of a. When both refine the
-// same symbol, b'\''s narrowing wins because b was computed in the
-// tighter frame (after a'\''s refinement was applied).
+// same symbol, b'\”s narrowing wins because b was computed in the
+// tighter frame (after a'\”s refinement was applied).
 func mergeRefinementMaps(a, b map[*Symbol]rl.TypingT) map[*Symbol]rl.TypingT {
 	out := make(map[*Symbol]rl.TypingT, len(a)+len(b))
 	for k, v := range a {
@@ -331,7 +332,7 @@ func (tc *typeChecker) narrowTypeOfEquality(op rl.Operator, ident *rl.Identifier
 // refinementForBranches builds a Refinement from the computed truthy
 // and falsy narrowed types. Either may be nil meaning "no narrowing
 // on this branch"; we skip the map entry in that case so frame join
-// later doesn'\''t union with a base type to produce the base type.
+// later doesn'\”t union with a base type to produce the base type.
 //
 // op switches truthy/falsy: == puts the matching arm in WhenTrue; !=
 // puts it in WhenFalse.
@@ -376,7 +377,7 @@ func typeOfPattern(c *rl.OpBinary) (*rl.Identifier, string, bool) {
 
 // typeOfCallOfIdent matches exactly `type_of(<ident>)`. Anything more
 // elaborate (chained call, multiple args, named args, non-identifier
-// argument) falls through - those don'\''t cleanly correspond to a
+// argument) falls through - those don'\”t cleanly correspond to a
 // narrowable path.
 func typeOfCallOfIdent(n rl.Node) (*rl.Identifier, bool) {
 	call, ok := n.(*rl.Call)
@@ -398,7 +399,7 @@ func typeOfCallOfIdent(n rl.Node) (*rl.Identifier, bool) {
 }
 
 // narrowStrEnumEquality handles `<ident> ==/!= "<value>"` when the
-// identifier'\''s base type is a string-enum. Truthy keeps the matching
+// identifier'\”s base type is a string-enum. Truthy keeps the matching
 // value (a single-valued enum); falsy keeps the rest. Either side can
 // collapse to Never if the partition leaves nothing.
 //
@@ -559,7 +560,7 @@ func identInStringList(c *rl.OpBinary) (*rl.Identifier, []string, bool) {
 // simpleStringValue returns the literal value of a non-interpolated
 // string literal, or false for anything else. Interpolated strings
 // could in principle be constant-folded, but the static checker
-// doesn'\''t do constant folding and the catalog is intentionally
+// doesn'\”t do constant folding and the catalog is intentionally
 // shape-driven.
 func simpleStringValue(n rl.Node) (string, bool) {
 	s, ok := n.(*rl.LitString)
@@ -669,30 +670,30 @@ func matchesTypeOf(t rl.TypingT, target string) bool {
 // caller treats it as "no narrowing applied" rather than "Never".
 //
 // Decision table:
-//   - Any / Dynamic / ErrorType base: (nil, nil) - we can'\''t prove
+//   - Any / Dynamic / ErrorType base: (nil, nil) - we can'\”t prove
 //     either side against a fully-open or poisoned type.
 //   - Union: partition arms by recursive call. Drop Never on each
 //     side (those arms contribute nothing). Preserve nil arms by
 //     passing the arm through unchanged - "no static handle" on
 //     this arm means we keep the whole arm as a fallback.
 //   - Optional<T>:
-//       target == "null":
-//         truthy: TypingNullT (definite - the null arm matched).
-//         falsy:  x is non-null - return T.
-//       inner matches target:
-//         truthy: T (the non-null component).
-//         falsy:  TypingNullT (only possibility left).
-//       inner doesn'\''t match target:
-//         truthy: Never (inner doesn'\''t match, null doesn'\''t
-//                 match any non-null target).
-//         falsy:  the original Optional<T> stays.
+//     target == "null":
+//     truthy: TypingNullT (definite - the null arm matched).
+//     falsy:  x is non-null - return T.
+//     inner matches target:
+//     truthy: T (the non-null component).
+//     falsy:  TypingNullT (only possibility left).
+//     inner doesn'\”t match target:
+//     truthy: Never (inner doesn'\”t match, null doesn'\”t
+//     match any non-null target).
+//     falsy:  the original Optional<T> stays.
 //   - TypingNullT (definite-null leaf):
-//       target == "null":  truthy=null, falsy=Never.
-//       any other target:  truthy=Never, falsy=null.
+//     target == "null":  truthy=null, falsy=Never.
+//     any other target:  truthy=Never, falsy=null.
 //   - Leaf (non-Optional, non-null):
-//       target == "null": truthy=Never, falsy=base.
-//       matches:           truthy=base,  falsy=Never.
-//       doesn'\''t match:   truthy=Never, falsy=base.
+//     target == "null": truthy=Never, falsy=base.
+//     matches:           truthy=base,  falsy=Never.
+//     doesn'\”t match:   truthy=Never, falsy=base.
 func narrowByTypeOf(base rl.TypingT, target string) (truthy, falsy rl.TypingT) {
 	if base == nil {
 		return nil, nil

--- a/rts/check/snapshot_test.go
+++ b/rts/check/snapshot_test.go
@@ -24,9 +24,9 @@ import (
 //
 //	go test ./rts/check/ -run TestCheckSnapshots -update
 //
-// The harness is intentionally simple: each case'\''s INPUT is a Rad
+// The harness is intentionally simple: each case'\”s INPUT is a Rad
 // script, the STDOUT section is the expected DumpForSnapshot output.
-// Stderr / exit-code aren'\''t used (the checker isn'\''t a runtime).
+// Stderr / exit-code aren'\”t used (the checker isn'\”t a runtime).
 func TestCheckSnapshots(t *testing.T) {
 	snapshotDir := "snapshots"
 	if _, err := os.Stat(snapshotDir); os.IsNotExist(err) {

--- a/rts/check/snapshots/map_keys/access.snap
+++ b/rts/check/snapshots/map_keys/access.snap
@@ -1,0 +1,164 @@
+### TITLE ###
+UnknownKeyDotAccess
+### DESCRIPTION ###
+Reading a key the typed-map return shape doesn't declare fires
+ErrUnknownMapKey - get_path has no 'nonsense' key.
+### INPUT ###
+gp = get_path("f")
+print(gp.nonsense)
+### STDOUT ###
+# Identifier types
+  gp @ 1:1 -> <no-type>
+  get_path @ 1:6 -> dynamic
+  print @ 2:1 -> dynamic
+  gp @ 2:7 -> { "accessed_millis"?: int, "base_name"?: str, "exists": bool, "full_path": str, "modified_millis"?: int, "permissions"?: str, "size_bytes"?: int, "type"?: str }
+
+# Symbol types
+  gp (local): { "accessed_millis"?: int, "base_name"?: str, "exists": bool, "full_path": str, "modified_millis"?: int, "permissions"?: str, "size_bytes"?: int, "type"?: str }
+
+# Diagnostics
+  [error] RAD40014 @ 2:10 - Key "nonsense" does not exist on this map
+    help: Available keys: accessed_millis, base_name, exists, full_path, modified_millis, permissions, size_bytes, type
+### TITLE ###
+UnknownKeyBracketLiteral
+### DESCRIPTION ###
+A string-literal bracket index is checked the same as dot access.
+### INPUT ###
+gp = get_path("f")
+print(gp["nonsense"])
+### STDOUT ###
+# Identifier types
+  gp @ 1:1 -> <no-type>
+  get_path @ 1:6 -> dynamic
+  print @ 2:1 -> dynamic
+  gp @ 2:7 -> { "accessed_millis"?: int, "base_name"?: str, "exists": bool, "full_path": str, "modified_millis"?: int, "permissions"?: str, "size_bytes"?: int, "type"?: str }
+
+# Symbol types
+  gp (local): { "accessed_millis"?: int, "base_name"?: str, "exists": bool, "full_path": str, "modified_millis"?: int, "permissions"?: str, "size_bytes"?: int, "type"?: str }
+
+# Diagnostics
+  [error] RAD40014 @ 2:10 - Key "nonsense" does not exist on this map
+    help: Available keys: accessed_millis, base_name, exists, full_path, modified_millis, permissions, size_bytes, type
+### TITLE ###
+KnownRequiredKey
+### DESCRIPTION ###
+A declared required key resolves cleanly, no diagnostic.
+### INPUT ###
+gp = get_path("f")
+print(gp.full_path)
+### STDOUT ###
+# Identifier types
+  gp @ 1:1 -> <no-type>
+  get_path @ 1:6 -> dynamic
+  print @ 2:1 -> dynamic
+  gp @ 2:7 -> { "accessed_millis"?: int, "base_name"?: str, "exists": bool, "full_path": str, "modified_millis"?: int, "permissions"?: str, "size_bytes"?: int, "type"?: str }
+
+# Symbol types
+  gp (local): { "accessed_millis"?: int, "base_name"?: str, "exists": bool, "full_path": str, "modified_millis"?: int, "permissions"?: str, "size_bytes"?: int, "type"?: str }
+
+# Diagnostics
+  (none)
+### TITLE ###
+OptionalKeyNoWarning
+### DESCRIPTION ###
+An optional key (size_bytes?) resolves to its type with no
+"may be absent" diagnostic, per the typed-map access design.
+### INPUT ###
+gp = get_path("f")
+print(gp.size_bytes)
+### STDOUT ###
+# Identifier types
+  gp @ 1:1 -> <no-type>
+  get_path @ 1:6 -> dynamic
+  print @ 2:1 -> dynamic
+  gp @ 2:7 -> { "accessed_millis"?: int, "base_name"?: str, "exists": bool, "full_path": str, "modified_millis"?: int, "permissions"?: str, "size_bytes"?: int, "type"?: str }
+
+# Symbol types
+  gp (local): { "accessed_millis"?: int, "base_name"?: str, "exists": bool, "full_path": str, "modified_millis"?: int, "permissions"?: str, "size_bytes"?: int, "type"?: str }
+
+# Diagnostics
+  (none)
+### TITLE ###
+UfcsCallNotTreatedAsKey
+### DESCRIPTION ###
+`gp.keys()` is a UFCS call, not a key access, so it must not
+fire ErrUnknownMapKey even though 'keys' isn't a declared key.
+### INPUT ###
+gp = get_path("f")
+print(gp.keys())
+### STDOUT ###
+# Identifier types
+  gp @ 1:1 -> <no-type>
+  get_path @ 1:6 -> dynamic
+  print @ 2:1 -> dynamic
+  gp @ 2:7 -> { "accessed_millis"?: int, "base_name"?: str, "exists": bool, "full_path": str, "modified_millis"?: int, "permissions"?: str, "size_bytes"?: int, "type"?: str }
+  keys @ 2:10 -> dynamic
+
+# Symbol types
+  gp (local): { "accessed_millis"?: int, "base_name"?: str, "exists": bool, "full_path": str, "modified_millis"?: int, "permissions"?: str, "size_bytes"?: int, "type"?: str }
+
+# Diagnostics
+  (none)
+### TITLE ###
+WriteUnknownKeyAllowed
+### DESCRIPTION ###
+Writing an undeclared key is a legal runtime add, so the final
+write segment is exempt from the unknown-key check.
+### INPUT ###
+gp = get_path("f")
+gp.newkey = 5
+### STDOUT ###
+# Identifier types
+  gp @ 1:1 -> <no-type>
+  get_path @ 1:6 -> dynamic
+  gp @ 2:1 -> { "accessed_millis"?: int, "base_name"?: str, "exists": bool, "full_path": str, "modified_millis"?: int, "permissions"?: str, "size_bytes"?: int, "type"?: str }
+
+# Symbol types
+  gp (local): { "accessed_millis"?: int, "base_name"?: str, "exists": bool, "full_path": str, "modified_millis"?: int, "permissions"?: str, "size_bytes"?: int, "type"?: str }
+
+# Diagnostics
+  (none)
+### TITLE ###
+WriteThroughUnknownIntermediateFires
+### DESCRIPTION ###
+Only the final write segment is exempt; an undeclared
+intermediate key is still a read and fires ErrUnknownMapKey.
+### INPUT ###
+gp = get_path("f")
+gp.nonsense.x = 5
+### STDOUT ###
+# Identifier types
+  gp @ 1:1 -> <no-type>
+  get_path @ 1:6 -> dynamic
+  gp @ 2:1 -> { "accessed_millis"?: int, "base_name"?: str, "exists": bool, "full_path": str, "modified_millis"?: int, "permissions"?: str, "size_bytes"?: int, "type"?: str }
+
+# Symbol types
+  gp (local): { "accessed_millis"?: int, "base_name"?: str, "exists": bool, "full_path": str, "modified_millis"?: int, "permissions"?: str, "size_bytes"?: int, "type"?: str }
+
+# Diagnostics
+  [error] RAD40014 @ 2:4 - Key "nonsense" does not exist on this map
+    help: Available keys: accessed_millis, base_name, exists, full_path, modified_millis, permissions, size_bytes, type
+### TITLE ###
+DynamicKeyNotChecked
+### DESCRIPTION ###
+A non-literal (dynamic) key can't be resolved statically, so no
+existence check fires.
+### INPUT ###
+gp = get_path("f")
+k = "full_path"
+print(gp[k])
+### STDOUT ###
+# Identifier types
+  gp @ 1:1 -> <no-type>
+  get_path @ 1:6 -> dynamic
+  k @ 2:1 -> <no-type>
+  print @ 3:1 -> dynamic
+  gp @ 3:7 -> { "accessed_millis"?: int, "base_name"?: str, "exists": bool, "full_path": str, "modified_millis"?: int, "permissions"?: str, "size_bytes"?: int, "type"?: str }
+  k @ 3:10 -> str
+
+# Symbol types
+  gp (local): { "accessed_millis"?: int, "base_name"?: str, "exists": bool, "full_path": str, "modified_millis"?: int, "permissions"?: str, "size_bytes"?: int, "type"?: str }
+  k (local): str
+
+# Diagnostics
+  (none)

--- a/rts/check/suggestion.go
+++ b/rts/check/suggestion.go
@@ -118,6 +118,52 @@ func findSimilarNames(scope *Scope, builtins map[string]bool, target string, lim
 	return out
 }
 
+// findSimilarInSet ranks a fixed candidate list by edit distance to
+// `target`, returning up to `limit` close matches. Same threshold as
+// findSimilarNames, but for cases where the candidates are an
+// enumerable set (e.g. a struct type's declared keys) rather than a
+// scope chain.
+func findSimilarInSet(candidates []string, target string, limit int) []string {
+	if limit <= 0 {
+		return nil
+	}
+	maxDist := len(target)/2 + 1
+	if maxDist < 2 {
+		maxDist = 2
+	}
+
+	type cand struct {
+		name string
+		dist int
+	}
+	var cands []cand
+	for _, name := range candidates {
+		if name == target {
+			continue
+		}
+		d := levenshtein(target, name)
+		if d > 0 && d <= maxDist {
+			cands = append(cands, cand{name: name, dist: d})
+		}
+	}
+
+	sort.Slice(cands, func(i, j int) bool {
+		if cands[i].dist != cands[j].dist {
+			return cands[i].dist < cands[j].dist
+		}
+		return cands[i].name < cands[j].name
+	})
+
+	if len(cands) > limit {
+		cands = cands[:limit]
+	}
+	out := make([]string, len(cands))
+	for i, c := range cands {
+		out[i] = c.name
+	}
+	return out
+}
+
 // formatDidYouMean renders a list of suggestion candidates into the
 // `did you mean ...?` line shown after a static diagnostic. Three
 // cases:

--- a/rts/check/type_check.go
+++ b/rts/check/type_check.go
@@ -684,10 +684,10 @@ func (tc *typeChecker) walkStmts(stmts []rl.Node) {
 //
 // For each branch with a condition:
 //   - The condition is interpreted against the accumulated falsy
-//     frame (everything previous branches couldn'\''t match).
+//     frame (everything previous branches couldn'\”t match).
 //   - The branch body walks with WhenTrue layered on the accumulated
 //     frame; subsequent branches accumulate WhenFalse.
-//   - If the branch falls off the end (doesn'\''t return/break/continue),
+//   - If the branch falls off the end (doesn'\”t return/break/continue),
 //     its exit frame contributes to the join.
 //
 // The else branch (no condition) walks with the final accumulated
@@ -735,19 +735,19 @@ func (tc *typeChecker) walkIf(n *rl.If) {
 
 // walkFnDef handles a function definition statement. The body opens
 // a fresh frame so that narrowings active in the surrounding scope
-// don'\''t leak into the function body - a function can be called
-// from anywhere, and the call-site enclosing narrowings aren'\''t
+// don'\”t leak into the function body - a function can be called
+// from anywhere, and the call-site enclosing narrowings aren'\”t
 // available at the body. Body-internal narrowings stay isolated too:
 // after walking, tc.frame is restored to whatever the surrounding
 // scope had before the function definition.
 //
 // Param default expressions are walked under the SURROUNDING frame
-// (defaults are evaluated at call time but in the caller'\''s scope,
-// not the callee'\''s - matching the runtime'\''s lazy default eval).
+// (defaults are evaluated at call time but in the caller'\”s scope,
+// not the callee'\”s - matching the runtime'\”s lazy default eval).
 //
 // Closure rule deferred: same caveat as synthLambda. Captured
 // narrowings from the enclosing frame are NOT preserved. For a
-// closure-friendly design we'\''d need Pyright'\''s reassignment-after-
+// closure-friendly design we'\”d need Pyright'\”s reassignment-after-
 // definition check. Today, nested functions just see Dynamic for
 // outer locals. Conservative but sound.
 func (tc *typeChecker) walkFnDef(n *rl.FnDef) {
@@ -895,16 +895,16 @@ func mapKeyValTypes(iter rl.TypingT) (rl.TypingT, rl.TypingT) {
 }
 
 // walkWhileLoop handles `while [cond]:`. Inside the body the
-// condition'\''s WhenTrue applies (we entered because cond was
+// condition'\”s WhenTrue applies (we entered because cond was
 // truthy); after the loop the WhenFalse applies (we exited because
 // cond finally turned falsy).
 //
 // Sorbet rule for body-assigned vars: before applying the condition
 // narrowing, drop narrowings for any symbol the body reassigns. The
 // body may run any number of times, so a "narrowed before entering
-// the body" type isn'\''t sound for an iteration where the body
+// the body" type isn'\”t sound for an iteration where the body
 // already changed the var. Resetting to the base SymbolTypes /
-// Declared is the conservative answer that lets the body'\''s own
+// Declared is the conservative answer that lets the body'\”s own
 // assignments re-narrow on each iteration as needed.
 //
 // We collect the assigned-symbol set from the body statements with
@@ -1119,17 +1119,17 @@ func loopElementType(iter rl.TypingT) rl.TypingT {
 
 // walkSwitch handles `switch <disc>:` with per-case narrowing of the
 // discriminant. For each case the body walks with the discriminant
-// symbol narrowed to the case'\''s match type; the discriminant'\''s
+// symbol narrowed to the case'\”s match type; the discriminant'\”s
 // residual (= base minus all peeled cases) flows into the default
 // branch.
 //
 // String-enum exhaustiveness: when the discriminant is a closed type
 // (string-enum) and no default arm catches the rest, the residual
-// after peeling all explicit cases should be Never. If it'\''s
+// after peeling all explicit cases should be Never. If it'\”s
 // non-Never, the switch is missing variants - emit an
 // ErrNonExhaustiveSwitch diagnostic naming the unmatched values.
 //
-// Non-enum discriminants get the normal walk (case bodies don'\''t
+// Non-enum discriminants get the normal walk (case bodies don'\”t
 // narrow) and no exhaustiveness check. The mechanism is in place;
 // extending it to int / int-enum / sealed unions is straightforward
 // when those types arrive.
@@ -1246,7 +1246,7 @@ func (tc *typeChecker) walkSwitchAlt(alt rl.Node) bool {
 }
 
 // matchTypeForCaseKeys turns a list of case keys into the type that
-// the discriminant takes inside that case'\''s body. For string
+// the discriminant takes inside that case'\”s body. For string
 // literals we build a string-enum naming the matched values; for
 // anything else we currently return nil (no narrowing applied).
 //
@@ -1268,7 +1268,7 @@ func (tc *typeChecker) matchTypeForCaseKeys(keys []rl.Node) rl.TypingT {
 }
 
 // subtractEnumType removes the values of caseType from base. Returns
-// base unchanged if either side isn'\''t a string-enum. For exhausted
+// base unchanged if either side isn'\”t a string-enum. For exhausted
 // enums (all values peeled), returns Never.
 func subtractEnumType(base, caseType rl.TypingT) rl.TypingT {
 	if base == nil {
@@ -1295,7 +1295,7 @@ func subtractEnumType(base, caseType rl.TypingT) rl.TypingT {
 	return rl.NewStrEnumType(remaining...)
 }
 
-// isClosedDiscriminant reports whether a discriminant'\''s static type
+// isClosedDiscriminant reports whether a discriminant'\”s static type
 // is a closed set the checker can exhaustively analyze. Today: just
 // string-enums. Bool would be a near-term extension (true / false
 // being the closed set), if we add an exhaustive-bool predicate.
@@ -1468,7 +1468,7 @@ func caseKeyDisplayText(n rl.Node) string {
 // emitNonExhaustiveSwitch records a diagnostic naming the unmatched
 // values of a closed discriminant. The message lists the values so
 // the user can read the fix off the diagnostic without inspecting
-// the discriminant'\''s declared type.
+// the discriminant'\”s declared type.
 func (tc *typeChecker) emitNonExhaustiveSwitch(n *rl.Switch, residual rl.TypingT) {
 	msg := "Switch is not exhaustive"
 	if enum, ok := residual.(*rl.TypingStrEnumT); ok {
@@ -1486,7 +1486,7 @@ func (tc *typeChecker) emitNonExhaustiveSwitch(n *rl.Switch, residual rl.TypingT
 }
 
 // branchExitsEarly is a deep "does this body always diverge?" check
-// suitable for if/switch branch joins. Phase 4e'\''s "last statement
+// suitable for if/switch branch joins. Phase 4e'\”s "last statement
 // is a return/break/continue" version was too shallow: a common
 // guard pattern like
 //
@@ -1496,7 +1496,7 @@ func (tc *typeChecker) emitNonExhaustiveSwitch(n *rl.Switch, residual rl.TypingT
 //
 // has return as the second-to-last statement of the if body, but
 // branchExitsEarly only inspected the LAST statement (log_it()), so
-// the surrounding flow didn'\''t pick up the divergence and the
+// the surrounding flow didn'\”t pick up the divergence and the
 // "after-the-if" narrowing was wrong.
 //
 // The new predicate walks the body, recursing through if (every
@@ -1514,13 +1514,13 @@ func (tc *typeChecker) emitNonExhaustiveSwitch(n *rl.Switch, residual rl.TypingT
 // insideLoop controls whether break/continue count as divergence:
 // only inside an actual loop do they transfer control past the
 // enclosing construct. The current call sites (walkIf, walkSwitch)
-// don'\''t themselves carry a loop indicator yet, so they default to
+// don'\”t themselves carry a loop indicator yet, so they default to
 // true to preserve the prior behavior - break/continue have always
 // been treated as "exits this branch" in practice because
 // branchExitsEarly accepted them unconditionally.
 // branchExits is the typeChecker method form. The receiver lets the
 // divergence walk consult sym info (noReturn builtins, closed-enum
-// switch exhaustiveness) that the standalone helper can'\''t reach.
+// switch exhaustiveness) that the standalone helper can'\”t reach.
 // Callers from walkIf / walkSwitch use this method form.
 func (tc *typeChecker) branchExits(body []rl.Node) bool {
 	return bodyDiverges(body, divergeCtx{insideLoop: true}, tc)
@@ -1584,7 +1584,7 @@ func stmtDiverges(n rl.Node, ctx divergeCtx, tc *typeChecker) bool {
 
 // ifDiverges: every branch must diverge AND there must be an explicit
 // else. Without an else, the "no branch matched" path is an implicit
-// fall-through, so the if as a whole doesn'\''t diverge.
+// fall-through, so the if as a whole doesn'\”t diverge.
 func ifDiverges(n *rl.If, ctx divergeCtx, tc *typeChecker) bool {
 	hasElse := false
 	for _, branch := range n.Branches {
@@ -1599,7 +1599,7 @@ func ifDiverges(n *rl.If, ctx divergeCtx, tc *typeChecker) bool {
 }
 
 // switchDiverges: every explicit case must diverge, AND either a
-// default arm is present and also diverges, OR the discriminant'\''s
+// default arm is present and also diverges, OR the discriminant'\”s
 // residual after peeling all cases is Never (i.e., exhaustive on a
 // closed type).
 func switchDiverges(n *rl.Switch, ctx divergeCtx, tc *typeChecker) bool {
@@ -1649,7 +1649,7 @@ func altDiverges(alt rl.Node, ctx divergeCtx, tc *typeChecker) bool {
 // the body has no top-level break that targets this loop. A
 // conditional `while cond:` may execute zero times - non-divergent.
 // (Detecting constant-true conditions would require literal folding;
-// we don'\''t do it today.)
+// we don'\”t do it today.)
 func whileDiverges(n *rl.WhileLoop, tc *typeChecker) bool {
 	if n.Condition != nil {
 		return false
@@ -1702,7 +1702,7 @@ func altHasTopLevelBreak(alt rl.Node) bool {
 
 // callIsNoReturn reports whether call is to a builtin function
 // whose runtime semantics never return - exit(), today. Future
-// shape: check the builtin signature'\''s return type against Never.
+// shape: check the builtin signature'\”s return type against Never.
 func callIsNoReturn(call *rl.Call, tc *typeChecker) bool {
 	if tc == nil {
 		return false
@@ -1724,10 +1724,10 @@ func callIsNoReturn(call *rl.Call, tc *typeChecker) bool {
 
 // joinFrames computes the post-branch frame from a set of branch-exit
 // frames. For each symbol narrowed by any branch (relative to
-// initial), the joined type is the union of each branch'\''s effective
-// type for that symbol. Branches that didn'\''t narrow the symbol
+// initial), the joined type is the union of each branch'\”s effective
+// type for that symbol. Branches that didn'\”t narrow the symbol
 // contribute the base type from info.SymbolTypes - or the initial
-// frame'\''s narrowing if present, via Frame.Lookup'\''s parent walk.
+// frame'\”s narrowing if present, via Frame.Lookup'\”s parent walk.
 //
 // Returns initial unchanged when no branch narrowed anything (or
 // when only one branch survived early-exit filtering).
@@ -1780,7 +1780,7 @@ func (tc *typeChecker) joinFrames(initial *Frame, branches []*Frame) *Frame {
 //     Both contribute nothing to a join; unioning them with X gives X.
 //  3. Structural merge: collapse multiple StrEnum arms into one with
 //     the unioned value set. (Future: do the same for Optional arms
-//     with compatible inners.) Preserves the first occurrence'\''s
+//     with compatible inners.) Preserves the first occurrence'\”s
 //     position in the result for diagnostic order.
 //  4. Pairwise subsumption: if some arm B is assignable-from another
 //     arm A (B is a super-type of A), drop A. This is what makes
@@ -1827,7 +1827,7 @@ func unionTypesForJoin(types []rl.TypingT) rl.TypingT {
 }
 
 // UnionJoinForTest exposes unionTypesForJoin for testing. Tests in
-// the check_test package can'\''t reach the unexported helper; this
+// the check_test package can'\”t reach the unexported helper; this
 // thin wrapper keeps the test interface explicit (not "everything in
 // the package is exported"). Not for production use.
 func UnionJoinForTest(types []rl.TypingT) rl.TypingT {
@@ -1904,7 +1904,7 @@ func isUninhabited(t rl.TypingT) bool {
 // closed-enum cases produces `StrEnum<"a","b","c">` instead of
 // `StrEnum<"a">|StrEnum<"b">|StrEnum<"c">`.
 //
-// The first StrEnum'\''s position in the input is preserved as the
+// The first StrEnum'\”s position in the input is preserved as the
 // position of the merged result. This keeps diagnostic ordering
 // stable when other arms are interleaved.
 func mergeStructuralByKind(types []rl.TypingT) []rl.TypingT {
@@ -1952,10 +1952,10 @@ func mergeStructuralByKind(types []rl.TypingT) []rl.TypingT {
 // each one (a) drop it if anything already kept subsumes it; (b)
 // otherwise, drop any kept arms it subsumes, then add it.
 //
-// Gradual types (Any, Dynamic, ErrorType) don'\''t subsume on the
-// subsumer side: we don'\''t want `int | any` to collapse to `any`,
+// Gradual types (Any, Dynamic, ErrorType) don'\”t subsume on the
+// subsumer side: we don'\”t want `int | any` to collapse to `any`,
 // because the concrete int arm carries real static info that a
-// downstream narrowing might exploit. Matching Pyright'\''s rule
+// downstream narrowing might exploit. Matching Pyright'\”s rule
 // keeps concrete arms alive alongside gradual ones.
 //
 // O(n^2) but n is tiny (typically 2-5 arms); correctness over speed.
@@ -2023,7 +2023,7 @@ func dedupeByName(types []rl.TypingT) []rl.TypingT {
 }
 
 // isGradualLike identifies types the static checker uses to signal
-// "we couldn'\''t pin a type" (Any, Dynamic) or "an error is
+// "we couldn'\”t pin a type" (Any, Dynamic) or "an error is
 // suppressing cascades" (ErrorType). They should not subsume
 // concrete arms in a union join.
 func isGradualLike(t rl.TypingT) bool {
@@ -3164,7 +3164,7 @@ func (tc *typeChecker) addUnaryOpIssue(span rl.Span, op rl.Operator, operand rl.
 // `xs = []` followed by `xs.append(1)` to `List<int>`, but the safe
 // over-approximation lets every existing program type-check today.
 
-// synthLambda walks the lambda'\''s body and synthesizes a structural
+// synthLambda walks the lambda'\”s body and synthesizes a structural
 // TypingFnT. Params come from the grammar annotation (l.Typing.Params,
 // possibly with nil per-param Type for unannotated args - that maps
 // to `any`). The return type is the headline work here:
@@ -3179,13 +3179,13 @@ func (tc *typeChecker) addUnaryOpIssue(span rl.Span, op rl.Operator, operand rl.
 //
 // Closure rule deferred: same caveat as walkFnDef. Captured-path
 // narrowings from the enclosing frame are NOT preserved. For a
-// closure-friendly design we'\''d need Pyright'\''s reassignment-
+// closure-friendly design we'\”d need Pyright'\”s reassignment-
 // after-definition check. Today, the body opens a fresh frame so
 // outer locals appear unnarrowed (read as their base type).
 //
-// Recursion: anonymous lambdas can'\''t self-reference. A named
+// Recursion: anonymous lambdas can'\”t self-reference. A named
 // recursive lambda bound to a local (`f = fn(x) f(x-1)`) would synth
-// the recursive `f` to Dynamic because SymbolTypes[f] isn'\''t set
+// the recursive `f` to Dynamic because SymbolTypes[f] isn'\”t set
 // during the walk. Sound but lossy - the inferred return would
 // collapse to Dynamic via any-like subsumption rules. Fixing this
 // needs the Tarjan SCC + placeholder return type machinery the plan

--- a/rts/check/type_check.go
+++ b/rts/check/type_check.go
@@ -2,6 +2,8 @@ package check
 
 import (
 	"fmt"
+	"sort"
+	"strings"
 
 	"github.com/amterp/rad/rts"
 	"github.com/amterp/rad/rts/rl"
@@ -2095,7 +2097,11 @@ func (tc *typeChecker) walkAssign(a *rl.Assign) {
 		// frame for these: indexed assign mutates the container's
 		// contents, not the binding, so the symbol's type is unchanged.
 		if vp, ok := a.Targets[i].(*rl.VarPath); ok {
-			_ = tc.synth(vp) // walk children for hover/use tracking
+			// Walk children for hover/use tracking. asTarget=true so
+			// the final segment (the write slot) doesn't fire the
+			// unknown-key check - writing an undeclared key is a
+			// legal runtime add - while intermediate reads still do.
+			_ = tc.synthVarPath(vp, true)
 			tc.checkIndexedAssignTarget(vp, val, valType)
 			continue
 		}
@@ -2354,7 +2360,7 @@ func (tc *typeChecker) synth(n rl.Node) rl.TypingT {
 	case *rl.Call:
 		return tc.synthCall(v, 0)
 	case *rl.VarPath:
-		return tc.synthVarPath(v)
+		return tc.synthVarPath(v, false)
 	case *rl.OpBinary:
 		return tc.synthOpBinary(v)
 	case *rl.OpUnary:
@@ -2420,24 +2426,40 @@ func (tc *typeChecker) synthCall(call *rl.Call, implicitReceiverCount int) rl.Ty
 }
 
 // synthVarPath walks a chained path expression (e.g. `a.b[c].d`,
-// `xs.sort()`). Non-UFCS segments are visited for hover/symbol
-// purposes only - their actual semantics (field access, indexing,
-// slicing) get static types in a later sub-commit.
+// `xs.sort()`), threading the running type from segment to segment so
+// each access resolves against the shape it actually has.
 //
 // UFCS segments are calls whose first positional argument is the
 // path's chain so far. We pull the Call out of the segment and
 // type-check it with an implicit-receiver count of 1, so arity
-// checks count the chain-receiver as the first arg.
-func (tc *typeChecker) synthVarPath(v *rl.VarPath) rl.TypingT {
-	_ = tc.synth(v.Root)
-	for _, seg := range v.Segments {
+// checks count the chain-receiver as the first arg; the chain then
+// continues from the call's return type.
+//
+// Field and string-literal-key access against a closed struct shape
+// (a builtin's typed-map return value, an annotated struct map) is
+// existence-checked: an unknown key is a guaranteed runtime
+// KeyNotFound, so we fire ErrUnknownMapKey. asTarget marks this path
+// as an assignment LHS; only its final segment is exempt from the
+// check, since writing an undeclared key is a legal runtime add
+// while every intermediate read must still resolve.
+func (tc *typeChecker) synthVarPath(v *rl.VarPath, asTarget bool) rl.TypingT {
+	cur := tc.synth(v.Root)
+	for i, seg := range v.Segments {
+		last := i == len(v.Segments)-1
 		switch {
 		case seg.IsUFCS:
 			if call, ok := seg.Index.(*rl.Call); ok {
-				_ = tc.synthCall(call, 1)
+				cur = tc.synthCall(call, 1)
+			} else {
+				// Defensive: the converter always sets Index to the
+				// Call when IsUFCS, so this branch is unreachable.
+				cur = rl.NewDynamicType()
 			}
+		case seg.Field != nil:
+			cur = tc.synthMemberAccess(cur, *seg.Field, seg.Span(), asTarget && last)
 		case seg.Index != nil:
 			_ = tc.synth(seg.Index)
+			cur = tc.synthIndexAccess(cur, seg.Index, seg.Span(), asTarget && last)
 		case seg.IsSlice:
 			if seg.Start != nil {
 				_ = tc.synth(seg.Start)
@@ -2445,9 +2467,86 @@ func (tc *typeChecker) synthVarPath(v *rl.VarPath) rl.TypingT {
 			if seg.End != nil {
 				_ = tc.synth(seg.End)
 			}
+			cur = rl.NewDynamicType()
 		}
 	}
-	return tc.record(v, rl.NewDynamicType())
+	return tc.record(v, cur)
+}
+
+// synthMemberAccess resolves a dot access (`recv.name`) against the
+// receiver's static type. On a closed struct shape an unknown key is
+// a guaranteed runtime KeyNotFound, so we emit ErrUnknownMapKey -
+// unless isWriteTarget, where writing a new key is a legal add.
+// Optional keys are valid keys: they resolve to their declared type
+// and never fire here, even though the key may be absent at runtime.
+func (tc *typeChecker) synthMemberAccess(recv rl.TypingT, name string, span rl.Span, isWriteTarget bool) rl.TypingT {
+	switch r := recv.(type) {
+	case *rl.TypingStructT:
+		if fieldT, _, found := r.Field(name); found {
+			if fieldT == nil {
+				// Defensive: a struct built with a nil field type
+				// shouldn't flow a nil into ExprTypes (record would
+				// then store nil and later .Name() calls would panic).
+				return rl.NewDynamicType()
+			}
+			return fieldT
+		}
+		if !isWriteTarget {
+			tc.emitUnknownMapKey(name, span, r)
+		}
+		return rl.NewDynamicType()
+	case *rl.TypingMapT:
+		// Uniform map: every key shares one type, so we can't prove
+		// any particular key is absent. Resolve to the value type.
+		return r.ValT()
+	}
+	return rl.NewDynamicType()
+}
+
+// synthIndexAccess resolves a bracket access (`recv[expr]`). A
+// static string-literal index against a struct shape is equivalent
+// to a dot access and gets the same existence check. Dynamic keys
+// and interpolated strings can't be resolved statically, so they
+// fall through to Dynamic.
+func (tc *typeChecker) synthIndexAccess(recv rl.TypingT, index rl.Node, span rl.Span, isWriteTarget bool) rl.TypingT {
+	switch r := recv.(type) {
+	case *rl.TypingStructT:
+		if lit, ok := index.(*rl.LitString); ok && lit.Simple {
+			// Point the diagnostic at the key literal itself, not the
+			// whole `["key"]` segment span - matches the precision of
+			// dot access, where the span covers just the field name.
+			return tc.synthMemberAccess(recv, lit.Value, lit.Span(), isWriteTarget)
+		}
+		return rl.NewDynamicType()
+	case *rl.TypingMapT:
+		return r.ValT()
+	}
+	return rl.NewDynamicType()
+}
+
+// emitUnknownMapKey records the unknown-key diagnostic. The message
+// stays short (the full struct shape can be very long and is better
+// surfaced via hover); the suggestion does the heavy lifting - a
+// `did you mean` fuzzy match against the declared keys when one is
+// close, followed by the full sorted key list. Both are deterministic.
+func (tc *typeChecker) emitUnknownMapKey(name string, span rl.Span, structT *rl.TypingStructT) {
+	keys := make([]string, 0, len(structT.Fields()))
+	for k := range structT.Fields() {
+		keys = append(keys, k.Name)
+	}
+	sort.Strings(keys)
+
+	suggestion := fmt.Sprintf("Available keys: %s", strings.Join(keys, ", "))
+	if didYouMean := formatDidYouMean(findSimilarInSet(keys, name, 3)); didYouMean != "" {
+		suggestion = didYouMean + " " + suggestion
+	}
+	tc.info.Issues = append(tc.info.Issues, BindIssue{
+		Span:       span,
+		Severity:   IssueError,
+		Code:       rl.ErrUnknownMapKey,
+		Message:    fmt.Sprintf("Key %q does not exist on this map", name),
+		Suggestion: suggestion,
+	})
 }
 
 // callSignatureFor returns the static signature of a call's callee,

--- a/rts/funcdocs.go
+++ b/rts/funcdocs.go
@@ -15,8 +15,8 @@ import (
 // callers need.
 type FuncDoc struct {
 	Name        string
-	Description string   // body of the H1 section, before any "##" subsection
-	Signature   string   // single line inside the `## Signature` section
+	Description string // body of the H1 section, before any "##" subsection
+	Signature   string // single line inside the `## Signature` section
 	Parameters  []FuncDocParam
 	Examples    []string // each rad code block inside `## Examples`
 	Category    string
@@ -144,7 +144,7 @@ func ParseFuncDoc(name, src string) (*FuncDoc, error) {
 	return doc, nil
 }
 
-// extractInlineCode pulls the first ``...`` inline-code span from
+// extractInlineCode pulls the first “...“ inline-code span from
 // the given lines. Returns "" when none is found. The signature
 // section is expected to be a single line of inline code; this
 // helper is forgiving about leading blank lines before that line.

--- a/rts/rl/ast_types.go
+++ b/rts/rl/ast_types.go
@@ -723,10 +723,10 @@ func (n *ArgBlock) Span() Span     { return n.span }
 
 // ArgDecl represents a single arg declaration (e.g. "name str? = "default").
 type ArgDecl struct {
-	span       Span
-	Name       string
-	NameSpan   Span // span of just the name identifier; for LSP semantic tokens
-	TypeName   string // "int", "str", "int[]", etc.
+	span     Span
+	Name     string
+	NameSpan Span   // span of just the name identifier; for LSP semantic tokens
+	TypeName string // "int", "str", "int[]", etc.
 	// Typing is the same type as TypeName but pre-parsed into the
 	// general TypingT shape so downstream consumers (binder, type
 	// checker, LSP) don't each re-implement the args-block grammar.

--- a/rts/rl/errors.go
+++ b/rts/rl/errors.go
@@ -11,10 +11,10 @@ type Error string
 // code no longer fires. New codes always pick the next unused
 // number in their band. Bands:
 //
-//   1xxxx  Syntax / parser errors    (this file's first block)
-//   2xxxx  Runtime errors            (interpreter)
-//   3xxxx  Type errors               (shared static + runtime)
-//   4xxxx  Validation / lint errors  (static only)
+//	1xxxx  Syntax / parser errors    (this file's first block)
+//	2xxxx  Runtime errors            (interpreter)
+//	3xxxx  Type errors               (shared static + runtime)
+//	4xxxx  Validation / lint errors  (static only)
 //
 // When adding here, also touch core/error_docs/<code>.md and the
 // reference at docs-web/docs/reference/errors.md.
@@ -29,28 +29,28 @@ const (
 	// numbers stay reserved per the tombstone rule, and so old logs
 	// remain greppable. The error_docs/<code>.md tombstones point
 	// readers at the codes that do fire.
-	ErrInvalidSyntax              Error = "10001"
-	ErrMissingColon               Error = "10002"
-	ErrMissingIdentifier_retired  Error = "10003"
-	ErrMissingExpression_retired  Error = "10004"
-	ErrMissingCloseParen_retired  Error = "10005"
+	ErrInvalidSyntax               Error = "10001"
+	ErrMissingColon                Error = "10002"
+	ErrMissingIdentifier_retired   Error = "10003"
+	ErrMissingExpression_retired   Error = "10004"
+	ErrMissingCloseParen_retired   Error = "10005"
 	ErrMissingCloseBracket_retired Error = "10006"
-	ErrMissingCloseBrace_retired  Error = "10007"
-	ErrReservedKeyword            Error = "10008"
-	ErrUnexpectedToken            Error = "10009"
-	ErrMissingOpenParen_retired   Error = "10010"
-	ErrMissingOpenBracket_retired Error = "10011"
-	ErrMissingOpenBrace_retired   Error = "10012"
-	ErrMissingComma_retired       Error = "10013"
-	ErrMissingEquals_retired      Error = "10014"
-	ErrMissingArrow_retired       Error = "10015"
-	ErrMissingType_retired        Error = "10016"
-	ErrMissingNewline_retired     Error = "10017"
-	ErrMissingIndent              Error = "10018"
-	ErrUnexpectedIndent_retired   Error = "10019"
-	ErrUnterminatedString         Error = "10020"
-	ErrMissingOperator            Error = "10021"
-	ErrKeywordMisuse              Error = "10022"
+	ErrMissingCloseBrace_retired   Error = "10007"
+	ErrReservedKeyword             Error = "10008"
+	ErrUnexpectedToken             Error = "10009"
+	ErrMissingOpenParen_retired    Error = "10010"
+	ErrMissingOpenBracket_retired  Error = "10011"
+	ErrMissingOpenBrace_retired    Error = "10012"
+	ErrMissingComma_retired        Error = "10013"
+	ErrMissingEquals_retired       Error = "10014"
+	ErrMissingArrow_retired        Error = "10015"
+	ErrMissingType_retired         Error = "10016"
+	ErrMissingNewline_retired      Error = "10017"
+	ErrMissingIndent               Error = "10018"
+	ErrUnexpectedIndent_retired    Error = "10019"
+	ErrUnterminatedString          Error = "10020"
+	ErrMissingOperator             Error = "10021"
+	ErrKeywordMisuse               Error = "10022"
 
 	// 2xxxx Runtime Errors
 	ErrGenericRuntime       Error = "20000"
@@ -100,15 +100,15 @@ const (
 	ErrParseDate                  = "20044"
 
 	// 3xxxx Type Errors
-	ErrTypeMismatch     Error = "30001"
-	ErrInvalidTypeForOp Error = "30002"
-	ErrCannotFormat     Error = "30003"
-	ErrCannotIndex      Error = "30004"
-	ErrCannotAssign     Error = "30005"
-	ErrInvalidArgType   Error = "30006"
-	ErrWrongArgCount    Error = "30007"
-	ErrCannotCompare    Error = "30008"
-	ErrCannotConvert    Error = "30009"
+	ErrTypeMismatch              Error = "30001"
+	ErrInvalidTypeForOp          Error = "30002"
+	ErrCannotFormat              Error = "30003"
+	ErrCannotIndex               Error = "30004"
+	ErrCannotAssign              Error = "30005"
+	ErrInvalidArgType            Error = "30006"
+	ErrWrongArgCount             Error = "30007"
+	ErrCannotCompare             Error = "30008"
+	ErrCannotConvert             Error = "30009"
 	ErrCollectionElementMismatch Error = "30010"
 
 	// 4xxxx Validation Errors

--- a/rts/rl/errors.go
+++ b/rts/rl/errors.go
@@ -125,6 +125,7 @@ const (
 	ErrDuplicateTypedDeclaration        Error = "40011"
 	ErrUnreachableCase                  Error = "40012"
 	ErrCaseKeyNotInDiscriminantType     Error = "40013"
+	ErrUnknownMapKey                    Error = "40014"
 )
 
 func (e Error) String() string {

--- a/rts/rl/typing.go
+++ b/rts/rl/typing.go
@@ -2,6 +2,7 @@ package rl
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 )
 
@@ -501,11 +502,41 @@ func NewStructType(named map[MapNamedKey]TypingT) *TypingStructT {
 	}
 }
 
+// Field looks up a declared key by name, returning its type, whether
+// it's optional, and whether it exists at all. Used by the type
+// checker to resolve `m.key` / `m["key"]` access against a known
+// struct shape (e.g. a builtin's typed-map return value).
+func (t *TypingStructT) Field(name string) (typ TypingT, optional bool, found bool) {
+	for mapKey, fieldT := range t.named {
+		if mapKey.Name == name {
+			return fieldT, mapKey.IsOptional, true
+		}
+	}
+	return nil, false, false
+}
+
+// Fields exposes the declared keys for enumeration (LSP completion,
+// hover). The returned map is the live backing store - callers must
+// not mutate it.
+func (t *TypingStructT) Fields() map[MapNamedKey]TypingT {
+	return t.named
+}
+
 func (t *TypingStructT) Name() string {
+	// Sort keys so the rendered name is deterministic - it surfaces
+	// in diagnostics, hover, and snapshot output, all of which need
+	// stable ordering (Go map iteration is randomized). We don't
+	// retain declaration order: `named` is a map, so it's already
+	// lost by here; alphabetical is the stable choice available.
+	keys := make([]MapNamedKey, 0, len(t.named))
+	for mapKey := range t.named {
+		keys = append(keys, mapKey)
+	}
+	sort.Slice(keys, func(i, j int) bool { return keys[i].Name < keys[j].Name })
+
 	var sb strings.Builder
 	sb.WriteString("{ ")
-	i := 0
-	for mapKey, typ := range t.named {
+	for i, mapKey := range keys {
 		if i > 0 {
 			sb.WriteString(", ")
 		}
@@ -514,8 +545,14 @@ func (t *TypingStructT) Name() string {
 			sb.WriteString("?")
 		}
 		sb.WriteString(": ")
-		sb.WriteString(typ.Name())
-		i++
+		// Guard against a nil field type: a struct built with a nil
+		// value (not reachable via the type resolver today, but the
+		// NewStructType API permits it) would otherwise panic here.
+		if typ := t.named[mapKey]; typ != nil {
+			sb.WriteString(typ.Name())
+		} else {
+			sb.WriteString(T_ANY)
+		}
 	}
 	sb.WriteString(" }")
 	return sb.String()

--- a/rts/rl/typing.go
+++ b/rts/rl/typing.go
@@ -384,7 +384,7 @@ func parenWrapIfUnion(t TypingT) string {
 	return t.Name()
 }
 
-// Elem returns the list'\''s element type. Exposed for narrowing -
+// Elem returns the list'\”s element type. Exposed for narrowing -
 // the for-loop walker uses it to type the loop variable.
 func (t *TypingListT) Elem() TypingT {
 	return t.elem
@@ -572,7 +572,7 @@ func (t *TypingMapT) Name() string {
 	return fmt.Sprintf("{ %s: %s }", t.keyT.Name(), t.valT.Name())
 }
 
-// KeyT and ValT expose the map'\''s key and value types. Used by the
+// KeyT and ValT expose the map'\”s key and value types. Used by the
 // for-loop walker: a single-var iteration over a map binds the var
 // to the key type; a two-var iteration binds (key, value).
 func (t *TypingMapT) KeyT() TypingT { return t.keyT }

--- a/rts/rl/typing_assignable_test.go
+++ b/rts/rl/typing_assignable_test.go
@@ -226,7 +226,7 @@ func TestAssign_ListsCovariantOverUnions(t *testing.T) {
 	boolT := rl.NewBoolType()
 	intOrStr := rl.NewUnionType(intT, strT)
 	intStrBoolFlat := rl.NewUnionType(intT, strT, boolT)
-	intStrBoolNestedLeft := rl.NewUnionType(intOrStr, boolT)                   // ((int|str)|bool)
+	intStrBoolNestedLeft := rl.NewUnionType(intOrStr, boolT)                     // ((int|str)|bool)
 	intStrBoolNestedRight := rl.NewUnionType(intT, rl.NewUnionType(strT, boolT)) // (int|(str|bool))
 
 	// `xs: (int|str)[] = [1, 2, 3]` — the common int[] -> (int|str)[] widening.
@@ -370,6 +370,6 @@ func TestAssign_UnionBranchMatch(t *testing.T) {
 
 	// Union-to-union: every branch of source must fit somewhere in target.
 	intOrFloatTarget := rl.NewUnionType(rl.NewFloatType(), rl.NewStrType()) // accepts float (and int via widening), str
-	assert.True(t, intOrFloatTarget.IsAssignableFrom(intOrFloat))            // int->float, float->float, both fit
-	assert.False(t, intOrStr.IsAssignableFrom(intOrFloat))                   // float doesn't fit in int|str
+	assert.True(t, intOrFloatTarget.IsAssignableFrom(intOrFloat))           // int->float, float->float, both fit
+	assert.False(t, intOrStr.IsAssignableFrom(intOrFloat))                  // float doesn't fit in int|str
 }

--- a/tools/gen-funcs-go/main.go
+++ b/tools/gen-funcs-go/main.go
@@ -185,4 +185,3 @@ func pruneTarget(target string, sourceFiles []*funcDocFile, dryRun bool) (int, e
 	}
 	return removed, nil
 }
-

--- a/tools/gen-funcs-page/main.go
+++ b/tools/gen-funcs-page/main.go
@@ -204,4 +204,3 @@ func countCategories(docs []*rts.FuncDoc) int {
 	}
 	return len(seen)
 }
-

--- a/tools/gen-funcs-sigs/main.go
+++ b/tools/gen-funcs-sigs/main.go
@@ -178,4 +178,3 @@ func strconvQuote(s string) string {
 	b.WriteByte('"')
 	return b.String()
 }
-


### PR DESCRIPTION
## What

Adds static checking and LSP support for **typed maps** - maps whose
type declares a known, closed set of keys (e.g. `get_path`'s return
value).

- **New diagnostic RAD40014**: reading a key the map's type doesn't
  declare is now a hard error, instead of passing the checker and
  failing only at runtime (RAD20041). Includes a `did you mean ...?`
  fuzzy suggestion and the sorted list of valid keys.
- **LSP dot-completion** of a typed map's keys: typing `gp.` lists the
  declared keys (with their types; optional keys flagged), resolving
  the receiver through enclosing-function scope including locals
  declared inside `if`/`for` blocks.

## How

- Threads the receiver type through `VarPath` segments in the checker
  (`synthVarPath`), so struct-shaped maps existence-check dot and
  string-literal-key access. As a bonus, var-path expressions now
  carry real types (hover lights up) instead of `Dynamic`.
- Read vs write: the **final** segment of an assignment target is
  exempt (`gp.newkey = 5` is a legal runtime add), while intermediate
  reads (`gp.unknown.x = 5`) still fire.
- UFCS calls (`gp.keys()`) remain distinct from key access.
- Optional keys resolve to their type silently (no "may be absent"
  noise) per design.

## Notable side fix

`TypingStructT.Name()` is now deterministic (sorted keys). It surfaces
in diagnostics, hover, and snapshots, where Go map-iteration order was
previously nondeterministic - latent flakiness this feature would have
exposed.

## Testing

- New checker snapshots (`rts/check/snapshots/map_keys/`): unknown
  key (dot + bracket), known/optional keys, UFCS, write-exempt vs
  intermediate-read, dynamic key.
- New LSP completion snapshots (file-scope, function-local, and
  block-local receivers).
- Full suite green; gofmt/vet clean.
- Reviewed by code-reviewer, ux-reviewer, and bug-hunter; all
  actionable findings applied (did-you-mean, message trim, nil
  guards, span precision, block-local resolution).

## Note for reviewer

This PR also carries a pre-existing unpushed commit, **"style:
reformat code"** (`7be7122`), which sat between `main` and this work.
Shout if you'd rather it land separately.
