### PR TITLE
fix(check): certainty-based type mismatch severity

### DIFF
--- a/core/error_docs/30011.md
+++ b/core/error_docs/30011.md
@@ -1,0 +1,49 @@
+# RAD30011: Unhandled Fallible Call
+
+Calling a function that can fail (returns `... | error`) without handling the
+error case.
+
+```rad
+port_str = "8080"
+port = parse_int(port_str)   // RAD30011: this call can fail; the error isn't handled
+print(port + 1)
+```
+
+## Why this happens
+
+Functions like `parse_int`, `parse_float`, and `parse_json` return a union of a
+success type and `error` (e.g. `int | error`). At runtime, if the call fails and
+nothing handles the error, the script halts. The checker points this out so the
+failure path is a deliberate choice rather than an accident.
+
+Note this is a hint, not an error: the script still runs, and succeeds whenever
+the call succeeds. The success type flows on (`port` above is `int`), so later
+uses type-check normally.
+
+## How to fix it
+
+Handle the error with `catch` to supply a fallback value:
+
+```rad
+port_str = "8080"
+port = parse_int(port_str) catch 8080
+print(port + 1)
+```
+
+Or use `??` for the same effect more tersely:
+
+```rad
+port_str = "8080"
+port = parse_int(port_str) ?? 8080
+print(port + 1)
+```
+
+Use a `catch` block when the recovery needs more than a single fallback value:
+
+```rad
+port_str = "8080"
+port = parse_int(port_str) catch:
+    print("invalid port, using default")
+    yield 8080
+print(port + 1)
+```

--- a/core/testing/docs_snippet_tolerances.go
+++ b/core/testing/docs_snippet_tolerances.go
@@ -31,6 +31,18 @@ type Tolerance struct {
 	Reason string
 }
 
+// globallyToleratedCodes are advisory diagnostics accepted in ANY doc
+// snippet, without a per-snippet entry. RAD30011 (unhandled fallible
+// call) is a pervasive teaching-style hint: docs and examples call
+// parse_int / read_file / etc. terse by design, to keep the focus on
+// the feature being shown rather than on error scaffolding. Pinning it
+// per-snippet would add dozens of no-signal entries. It's a Hint and
+// never gates execution, so tolerating it globally hides no real error
+// - the snippets still run.
+var globallyToleratedCodes = map[string]bool{
+	"RAD30011": true,
+}
+
 // docSnippetTolerances maps snippet IDs to their accepted diagnostic profile.
 // Add entries via copy-paste from the test failure output - each failure
 // prints a ready-to-paste stub.
@@ -209,25 +221,26 @@ var docSnippetTolerances = map[string]Tolerance{
 	},
 
 	// hm.md
-	"docs-web/docs/examples/hm.md#4eb5a0f8": {
-		ExpectedCodes: []string{"RAD30001"},
-		Reason:        "checker false positive: `state.load(...)` UFCS-resolves to `load(state, ...)` where state is `error|map`; the first param is `map`, so the checker hints. The script is correct in practice because errdefer + state handling cover the error case at runtime.",
-	},
+	// #4eb5a0f8 (the final-form script + its preview duplicate) no longer
+	// needs an entry: load_state() now strips its error arm at the call
+	// (Gap 2), so `state` is `map` and the old `error|map` UFCS false
+	// positive is gone. The unhandled-fallible hint it now carries is
+	// globally tolerated.
 	"docs-web/docs/examples/hm.md#19e0e50a": {
 		ExpectedCodes: []string{"RAD40003"},
 		Reason:        "intermediate tutorial step: command callbacks `do_show`/`do_edit`/`do_list` are added in the following tutorial steps. The RAD40003 warning surfaces because the tracking only sees top-level fns.",
 	},
 	"docs-web/docs/examples/hm.md#03e13698": {
-		ExpectedCodes: []string{"RAD30001", "RAD40003"},
-		Reason:        "intermediate tutorial step: `do_edit`/`do_list` not yet defined (added in later steps), plus the same `error|map` hint as #4eb5a0f8.",
+		ExpectedCodes: []string{"RAD40003"},
+		Reason:        "intermediate tutorial step: `do_edit`/`do_list` not yet defined (added in later steps). The old `error|map` RAD30001 hint is gone now that load_state() strips its error arm (Gap 2).",
 	},
 	"docs-web/docs/examples/hm.md#0b53f387": {
-		ExpectedCodes: []string{"RAD30001", "RAD40003"},
-		Reason:        "intermediate tutorial step: `do_list` not yet defined; same `error|map` hint pattern.",
+		ExpectedCodes: []string{"RAD40003"},
+		Reason:        "intermediate tutorial step: `do_list` not yet defined. Old `error|map` RAD30001 hint gone after Gap 2 error-strip.",
 	},
 	"docs-web/docs/examples/hm.md#abb66476": {
-		ExpectedCodes: []string{"RAD30001", "RAD40003"},
-		Reason:        "intermediate tutorial step: `do_list` not yet defined; same `error|map` hint pattern.",
+		ExpectedCodes: []string{"RAD40003"},
+		Reason:        "intermediate tutorial step: `do_list` not yet defined. Old `error|map` RAD30001 hint gone after Gap 2 error-strip.",
 	},
 
 	// ---- docs-web/docs/reference/syntax.md -------------------------
@@ -369,18 +382,20 @@ var docSnippetTolerances = map[string]Tolerance{
 		Skip:   true,
 		Reason: "guide fragment: ?? chaining with placeholder 'user' / 'config_path'.",
 	},
-	"docs-web/docs/guide/error-handling.md#82491324": {
-		ExpectedCodes: []string{"RAD30002"},
-		Reason:        "checker hint: 'float|error * float' in the user's error-flow example. The doc is teaching error propagation; the hint surfaces because the checker doesn't see that the error short-circuit happens before the arithmetic.",
-	},
+	// #82491324 no longer needs an entry: `parse_float(...)` now strips
+	// its error arm at the call (Gap 2), so `price` is `float` and the
+	// old `float|error * float` RAD30002 hint is gone - the very false
+	// positive that hint represented. It now carries the globally-
+	// tolerated unhandled-fallible hint instead.
 	"docs-web/docs/guide/error-handling.md#8ce3fff7": {
 		Skip:   true,
 		Reason: "guide fragment: catch-chaining with placeholder 'risky_call' / 'fallback_call'.",
 	},
-	"docs-web/docs/guide/error-handling.md#b558bc7f": {
-		ExpectedCodes: []string{"RAD30001"},
-		Reason:        "checker hint: `port = parse_int(port_str) ?? 8080` should narrow to `int`, but `??` doesn't fully narrow `int|error ?? int` today, so the subsequent `validate_port(port)` call sees a residual `int|error|int`.",
-	},
+	// #b558bc7f no longer needs an entry: `parse_int(port_str) ?? 8080`
+	// now yields `int` because the call strips its error arm before `??`
+	// (Gap 2), so the residual-`int|error|int` RAD30001 hint into
+	// validate_port is gone. This is exactly the narrowing the old
+	// comment wished for.
 	"docs-web/docs/guide/error-handling.md#e380902c": {
 		Skip:   true,
 		Reason: "guide fragment: nested-access with placeholder 'response'.",
@@ -503,37 +518,27 @@ var docSnippetTolerances = map[string]Tolerance{
 	},
 
 	// ---- docs-web/docs/guide/stashes.md -----------------------------
-	"docs-web/docs/guide/stashes.md#18fa9b0a": {
-		ExpectedCodes: []string{"RAD30001"},
-		Reason:        "checker hint: load_state() returns error|map and the doc shows direct use; the doc teaches the state-management pattern, error handling is covered separately.",
-	},
-	"docs-web/docs/guide/stashes.md#43a279d8": {
-		ExpectedCodes: []string{"RAD30001"},
-		Reason:        "same load_state() error|map pattern as #18fa9b0a.",
-	},
+	// Most load_state() snippets no longer need entries: load_state()
+	// strips its error arm at the call (Gap 2), so `state` is `map` and
+	// the old error|map RAD30001 hints are gone; they now carry only the
+	// globally-tolerated unhandled-fallible hint.
 	"docs-web/docs/guide/stashes.md#ed4e81de": {
-		ExpectedCodes: []string{"RAD30001", "RAD30002"},
-		Reason:        "same load_state() pattern + arithmetic on error|int. The error case is handled by the surrounding flow at runtime but the static checker can't yet see that.",
+		ExpectedCodes: []string{"RAD30002"},
+		Reason:        "checker hint: `count = state[\"count\"] ?? 0` is `dynamic|int` (untyped map index), so `count++` flags `dynamic|int + int`. The script is correct at runtime. Was RAD30001 pre-Gap-2 (load_state's error|map); the error arm now strips, surfacing the underlying dynamic-map-index hint instead.",
 	},
 
 	// ---- docs-web/docs/guide/type-annotations.md --------------------
 	// Type-annotation examples often demonstrate function signatures
-	// against literal returns. Many of these snippets hit the
-	// structural-literal fidelity gap noted in commit 1's severity
-	// promotion: list/struct/tuple literals synthesise as their
-	// surface shape rather than the declared annotated shape, so
-	// the static check fires a Hint even when the code is correct
-	// at runtime. Pinned to RAD30001 (Hint) so language changes
-	// that surface a different code show up.
+	// against typed returns. The remaining pins here hit an *inference*
+	// fidelity gap: the returned value is a variable built up in a loop
+	// (`counts = {}; counts[k] = 1; return counts`), so its synthesised
+	// type stays wider than the declared annotated shape and the static
+	// check fires a Hint even though the code is correct at runtime.
+	// (The literal-at-site cases - returning a map/list literal directly -
+	// are now handled structurally by check and no longer fire.) Pinned
+	// to RAD30001 (Hint) so language changes that surface a different
+	// code show up.
 
-	"docs-web/docs/guide/type-annotations.md#71864ce1": {
-		ExpectedCodes: []string{"RAD30001"},
-		Reason:        "literal-fidelity hint on nested struct-literal return.",
-	},
-	"docs-web/docs/guide/type-annotations.md#77d291e0": {
-		ExpectedCodes: []string{"RAD30001"},
-		Reason:        "literal-fidelity hint on struct-literal return.",
-	},
 	"docs-web/docs/guide/type-annotations.md#8bcb60a4": {
 		ExpectedCodes: []string{"RAD30001", "RAD30002"},
 		Reason:        "checker hint: vararg `*data_points: int|float` doesn't refine into `sum()`'s `float[]` or `join()`'s `str|list|map` parameters. RAD30002 cascades on the division because total/len both produce union types.",
@@ -553,10 +558,6 @@ var docSnippetTolerances = map[string]Tolerance{
 	"docs-web/docs/guide/type-annotations.md#ca9eb821": {
 		ExpectedCodes: []string{"RAD30002"},
 		Reason:        "literal-fidelity hint on words.join(' ') return type vs declared str.",
-	},
-	"docs-web/docs/guide/type-annotations.md#d4f47260": {
-		ExpectedCodes: []string{"RAD30001"},
-		Reason:        "literal-fidelity hint on optional-field struct return shape.",
 	},
 	"docs-web/docs/guide/type-annotations.md#defd0b86": {
 		ExpectedCodes: []string{"RAD30001"},

--- a/core/testing/docs_snippets_test.go
+++ b/core/testing/docs_snippets_test.go
@@ -293,6 +293,11 @@ func evaluateDiagnostics(diags []check.Diagnostic, tol Tolerance) []string {
 	var fails []string
 	for _, d := range diags {
 		code := diagCode(d)
+		// Globally-tolerated advisory codes are accepted everywhere,
+		// independent of any per-snippet tolerance.
+		if code != "" && globallyToleratedCodes[code] {
+			continue
+		}
 		// Severity tolerance: diagnostics at or below MaxSeverity are accepted.
 		// (Note: the Severity iota goes Hint < Warning < Info < Error.)
 		if hasMax && d.Severity <= maxSev {

--- a/core/testing/misc_test.go
+++ b/core/testing/misc_test.go
@@ -80,18 +80,19 @@ func globalFlagHelpWithout(s string) string {
 
 func Test_Misc_StackTraceShownInNestedFunctionError(t *testing.T) {
 	// The trigger is a runtime type-mismatch on a typed function
-	// return. The previous version used an undefined variable, but
-	// that's now caught statically by the binder so the runtime
-	// stack-trace path was never exercised. Type errors that fall
-	// out of static-checkable territory (return-of-wrong-type from
-	// a typed fn) emit via emitDiagnostic, which auto-attaches the
-	// call stack.
+	// return, which emits via emitDiagnostic and auto-attaches the
+	// call stack. It must stay out of static-checkable territory or
+	// the binder gates it before runtime (an undefined variable and a
+	// literal wrong-typed return were both previous versions that the
+	// checker grew to catch). Routing the value through an `any`
+	// parameter hides its type from the checker, so the mismatch only
+	// surfaces when `inner` actually returns at runtime.
 	script := `
-fn inner() -> int:
-    return "not an int"
+fn inner(x: any) -> int:
+    return x
 
 fn outer():
-    inner()
+    inner("not an int")
 
 outer()
 `

--- a/core/testing/sleep_test.go
+++ b/core/testing/sleep_test.go
@@ -113,7 +113,7 @@ func TestSleep_ErrorsIfTooManyPositionalArgs(t *testing.T) {
 func TestSleep_ErrorsIfIncorrectArgType(t *testing.T) {
 	setupAndRunCode(t, `sleep(true)`, "--color=never")
 	assertDidNotSleep(t)
-	expected := `error[RAD30001]: Value 'true' (bool) is not compatible with expected type 'int|float|str'
+	expected := `error[RAD30001]: Argument type 'bool' is not assignable to expected type 'int|float|str'
   --> TestCase:1:7
   |
 1 | sleep(true)

--- a/core/testing/snapshots/functions/ceil.snap
+++ b/core/testing/snapshots/functions/ceil.snap
@@ -31,7 +31,7 @@ Ceil errors with string
 ### INPUT ###
 print(ceil("ab"))
 ### STDERR ###
-error[RAD30001]: Value '"ab"' (str) is not compatible with expected type 'float'
+error[RAD30001]: Argument type 'str' is not assignable to expected type 'float'
   --> <script>:1:12
   |
 1 | print(ceil("ab"))

--- a/core/testing/snapshots/functions/clamp.snap
+++ b/core/testing/snapshots/functions/clamp.snap
@@ -33,7 +33,7 @@ Clamp errors for non-numeric elements
 ### INPUT ###
 print(clamp(1, "ab", 2))
 ### STDERR ###
-error[RAD30001]: Value '"ab"' (str) is not compatible with expected type 'int|float'
+error[RAD30001]: Argument type 'str' is not assignable to expected type 'int|float'
   --> <script>:1:16
   |
 1 | print(clamp(1, "ab", 2))

--- a/core/testing/snapshots/functions/floor.snap
+++ b/core/testing/snapshots/functions/floor.snap
@@ -31,7 +31,7 @@ Floor errors with string
 ### INPUT ###
 print(floor("ab"))
 ### STDERR ###
-error[RAD30001]: Value '"ab"' (str) is not compatible with expected type 'float'
+error[RAD30001]: Argument type 'str' is not assignable to expected type 'float'
   --> <script>:1:13
   |
 1 | print(floor("ab"))

--- a/core/testing/snapshots/functions/fn.snap
+++ b/core/testing/snapshots/functions/fn.snap
@@ -302,14 +302,14 @@ fn f():
 	pass
 f() + 1
 ### STDERR ###
-error[RAD20038]: Cannot use void value in expression
+error[RAD30002]: Invalid operand types: cannot do 'void + int'
   --> <script>:3:1
   |
 2 | 	pass
 3 | f() + 1
-  | ^^^
+  | ^^^^^^^
   |
-   = info: rad explain RAD20038
+   = info: rad explain RAD30002
 
 
 ### EXIT ###
@@ -380,14 +380,14 @@ fn f():
 	pass
 -f()
 ### STDERR ###
-error[RAD20038]: Cannot use void value in expression
-  --> <script>:3:2
+error[RAD30002]: Invalid operand type 'void' for unary '-'
+  --> <script>:3:1
   |
 2 | 	pass
 3 | -f()
-  |  ^^^
+  | ^^^^
   |
-   = info: rad explain RAD20038
+   = info: rad explain RAD30002
 
 
 ### EXIT ###

--- a/core/testing/snapshots/functions/hash.snap
+++ b/core/testing/snapshots/functions/hash.snap
@@ -18,7 +18,7 @@ Hash errors for unknown algorithm
 ### INPUT ###
 hash("hello friend!", algo="does not exist")
 ### STDERR ###
-error[RAD30001]: Value '"does not exist"' (str) is not compatible with expected type '["sha1", "sha256", "sha512", "md5"]'
+error[RAD30001]: Argument type 'str' is not assignable to expected type '["sha1", "sha256", "sha512", "md5"]'
   --> <script>:1:28
   |
 1 | hash("hello friend!", algo="does not exist")

--- a/core/testing/snapshots/functions/keys.snap
+++ b/core/testing/snapshots/functions/keys.snap
@@ -16,7 +16,7 @@ Keys errors if given string
 ### INPUT ###
 keys("foo")
 ### STDERR ###
-error[RAD30001]: Value '"foo"' (str) is not compatible with expected type 'map'
+error[RAD30001]: Argument type 'str' is not assignable to expected type 'map'
   --> <script>:1:6
   |
 1 | keys("foo")

--- a/core/testing/snapshots/functions/map.snap
+++ b/core/testing/snapshots/functions/map.snap
@@ -42,7 +42,7 @@ the signature `fn(any) -> any | fn(any, any) -> any` enforces fn-only.
 a = ["alice", "bob"]
 a.map("not a fn")
 ### STDERR ###
-error[RAD30001]: Value '"not a fn"' (str) is not compatible with expected type 'fn(any) -> any|fn(any, any) -> any'
+error[RAD30001]: Argument type 'str' is not assignable to expected type 'fn(any) -> any|fn(any, any) -> any'
   --> <script>:2:7
   |
 1 | a = ["alice", "bob"]

--- a/core/testing/snapshots/functions/parse_json.snap
+++ b/core/testing/snapshots/functions/parse_json.snap
@@ -69,7 +69,7 @@ Errors on invalid type
 ### INPUT ###
 parse_json(10)
 ### STDERR ###
-error[RAD30001]: Value '10' (int) is not compatible with expected type 'str'
+error[RAD30001]: Argument type 'int' is not assignable to expected type 'str'
   --> <script>:1:12
   |
 1 | parse_json(10)

--- a/core/testing/snapshots/functions/pow.snap
+++ b/core/testing/snapshots/functions/pow.snap
@@ -66,7 +66,7 @@ Pow errors with string base
 ### INPUT ###
 print(pow("abc", 2))
 ### STDERR ###
-error[RAD30001]: Value '"abc"' (str) is not compatible with expected type 'float'
+error[RAD30001]: Argument type 'str' is not assignable to expected type 'float'
   --> <script>:1:11
   |
 1 | print(pow("abc", 2))
@@ -82,7 +82,7 @@ Pow errors with string exponent
 ### INPUT ###
 print(pow(2, "abc"))
 ### STDERR ###
-error[RAD30001]: Value '"abc"' (str) is not compatible with expected type 'float'
+error[RAD30001]: Argument type 'str' is not assignable to expected type 'float'
   --> <script>:1:14
   |
 1 | print(pow(2, "abc"))

--- a/core/testing/snapshots/functions/reverse.snap
+++ b/core/testing/snapshots/functions/reverse.snap
@@ -29,7 +29,7 @@ Reverse with nums
 a = 123
 print(reverse(a))
 ### STDERR ###
-error[RAD30001]: Value '123' (int) is not compatible with expected type 'str|list'
+error[RAD30001]: Argument type 'int' is not assignable to expected type 'str|list'
   --> <script>:2:15
   |
 1 | a = 123

--- a/core/testing/snapshots/functions/round.snap
+++ b/core/testing/snapshots/functions/round.snap
@@ -69,7 +69,7 @@ a = 1
 b = "ab"
 print(round(a, b))
 ### STDERR ###
-error[RAD30001]: Value '"ab"' (str) is not compatible with expected type 'int'
+error[RAD30001]: Argument type 'str' is not assignable to expected type 'int'
   --> <script>:3:16
   |
 2 | b = "ab"
@@ -88,7 +88,7 @@ a = "ab"
 b = 1
 print(round(a, b))
 ### STDERR ###
-error[RAD30001]: Value '"ab"' (str) is not compatible with expected type 'float'
+error[RAD30001]: Argument type 'str' is not assignable to expected type 'float'
   --> <script>:3:13
   |
 2 | b = 1

--- a/core/testing/snapshots/functions/sum.snap
+++ b/core/testing/snapshots/functions/sum.snap
@@ -20,7 +20,7 @@ Sum errors for non-numeric elements
 a = [1, "ab", 3]
 print(sum(a))
 ### STDERR ###
-error[RAD30001]: Value '[ 1, "ab", 3 ]' (list) is not compatible with expected type 'float[]'
+error[RAD30001]: Argument type '(int|str)[]' is not assignable to expected type 'float[]'
   --> <script>:2:11
   |
 1 | a = [1, "ab", 3]

--- a/core/testing/snapshots/functions/values.snap
+++ b/core/testing/snapshots/functions/values.snap
@@ -16,7 +16,7 @@ Values errors if given string
 ### INPUT ###
 values("foo")
 ### STDERR ###
-error[RAD30001]: Value '"foo"' (str) is not compatible with expected type 'map'
+error[RAD30001]: Argument type 'str' is not assignable to expected type 'map'
   --> <script>:1:8
   |
 1 | values("foo")

--- a/core/testing/snapshots/misc/misc.snap
+++ b/core/testing/snapshots/misc/misc.snap
@@ -194,7 +194,7 @@ Misc_Abs_ErrorsOnAlphabetical
 
 a = abs("asd")
 ### STDERR ###
-error[RAD30001]: Value '"asd"' (str) is not compatible with expected type 'int|float'
+error[RAD30001]: Argument type 'str' is not assignable to expected type 'int|float'
   --> <script>:2:9
   |
 1 |

--- a/core/testing/snapshots/misc/stash.snap
+++ b/core/testing/snapshots/misc/stash.snap
@@ -145,10 +145,19 @@ result = save_state({ "test": "value" }) catch:
 	pass
 print(type_of(result))
 print("Error contains 'Script ID':", "Script ID" in result)
-### STDOUT ###
-error
-Error contains 'Script ID': true
+### STDERR ###
+error[RAD30002]: Invalid operand types: cannot do 'str in error?'
+  --> <script>:5:38
+  |
+4 | print(type_of(result))
+5 | print("Error contains 'Script ID':", "Script ID" in result)
+  |                                      ^^^^^^^^^^^^^^^^^^^^^
+  |
+   = info: rad explain RAD30002
 
+
+### EXIT ###
+1
 ### TITLE ###
 Stash_WriteStashFileReturnsErrorOnFailure
 ### INPUT ###
@@ -157,7 +166,16 @@ result = write_stash_file("test.txt", "content") catch:
 	pass
 print(type_of(result))
 print("Error contains 'Script ID':", "Script ID" in result)
-### STDOUT ###
-error
-Error contains 'Script ID': true
+### STDERR ###
+error[RAD30002]: Invalid operand types: cannot do 'str in error?'
+  --> <script>:5:38
+  |
+4 | print(type_of(result))
+5 | print("Error contains 'Script ID':", "Script ID" in result)
+  |                                      ^^^^^^^^^^^^^^^^^^^^^
+  |
+   = info: rad explain RAD30002
 
+
+### EXIT ###
+1

--- a/core/testing/snapshots/misc/stash.snap
+++ b/core/testing/snapshots/misc/stash.snap
@@ -145,19 +145,10 @@ result = save_state({ "test": "value" }) catch:
 	pass
 print(type_of(result))
 print("Error contains 'Script ID':", "Script ID" in result)
-### STDERR ###
-error[RAD30002]: Invalid operand types: cannot do 'str in error?'
-  --> <script>:5:38
-  |
-4 | print(type_of(result))
-5 | print("Error contains 'Script ID':", "Script ID" in result)
-  |                                      ^^^^^^^^^^^^^^^^^^^^^
-  |
-   = info: rad explain RAD30002
+### STDOUT ###
+error
+Error contains 'Script ID': true
 
-
-### EXIT ###
-1
 ### TITLE ###
 Stash_WriteStashFileReturnsErrorOnFailure
 ### INPUT ###
@@ -166,16 +157,7 @@ result = write_stash_file("test.txt", "content") catch:
 	pass
 print(type_of(result))
 print("Error contains 'Script ID':", "Script ID" in result)
-### STDERR ###
-error[RAD30002]: Invalid operand types: cannot do 'str in error?'
-  --> <script>:5:38
-  |
-4 | print(type_of(result))
-5 | print("Error contains 'Script ID':", "Script ID" in result)
-  |                                      ^^^^^^^^^^^^^^^^^^^^^
-  |
-   = info: rad explain RAD30002
+### STDOUT ###
+error
+Error contains 'Script ID': true
 
-
-### EXIT ###
-1

--- a/core/testing/snapshots/operators/compound_assign.snap
+++ b/core/testing/snapshots/operators/compound_assign.snap
@@ -76,7 +76,7 @@ Subtract from array errors
 a = [1]
 a -= 2
 ### STDERR ###
-error[RAD30002]: Invalid operand types: cannot do 'list -= int'
+error[RAD30002]: Invalid operand types: cannot do 'int[] -= int'
   --> <script>:2:1
   |
 1 | a = [1]
@@ -94,7 +94,7 @@ Divide from array errors
 a = [1]
 a /= 2
 ### STDERR ###
-error[RAD30002]: Invalid operand types: cannot do 'list /= int'
+error[RAD30002]: Invalid operand types: cannot do 'int[] /= int'
   --> <script>:2:1
   |
 1 | a = [1]
@@ -112,7 +112,7 @@ Multiply from array errors
 a = [1]
 a *= 2
 ### STDERR ###
-error[RAD30002]: Invalid operand types: cannot do 'list *= int'
+error[RAD30002]: Invalid operand types: cannot do 'int[] *= int'
   --> <script>:2:1
   |
 1 | a = [1]
@@ -130,7 +130,7 @@ Errors if append not array
 a = [1]
 a += 2
 ### STDERR ###
-error[RAD30002]: Invalid operand types: cannot do 'list += int'. Did you mean to wrap the right side in a list in order to append?
+error[RAD30002]: Invalid operand types: cannot do 'int[] += int'
   --> <script>:2:1
   |
 1 | a = [1]

--- a/core/testing/snapshots/operators/compound_assign.snap
+++ b/core/testing/snapshots/operators/compound_assign.snap
@@ -137,6 +137,7 @@ error[RAD30002]: Invalid operand types: cannot do 'int[] += int'
 2 | a += 2
   | ^^^^^^
   |
+   = help: Did you mean to wrap the right side in a list in order to append? e.g. `myList + [item]`
    = info: rad explain RAD30002
 
 

--- a/core/testing/snapshots/types/null.snap
+++ b/core/testing/snapshots/types/null.snap
@@ -16,7 +16,7 @@ Null errors if used in wrong function
 ### INPUT ###
 split(null, ",")
 ### STDERR ###
-error[RAD30001]: Value 'null' (null) is not compatible with expected type 'str'
+error[RAD30001]: Argument type 'null' is not assignable to expected type 'str'
   --> <script>:1:7
   |
 1 | split(null, ",")

--- a/core/testing/snapshots/types/typing.snap
+++ b/core/testing/snapshots/types/typing.snap
@@ -331,6 +331,15 @@ foo(1, x=2)
 fn foo(x: float, y?) -> float:
 	return x / y
 ### STDERR ###
+error[RAD30002]: Invalid operand types: cannot do 'float / any?'
+  --> <script>:3:9
+  |
+2 | fn foo(x: float, y?) -> float:
+3 | 	return x / y
+  |         ^^^^^
+  |
+   = info: rad explain RAD30002
+
 error[RAD30006]: Argument 'x' already specified
   --> <script>:1:8
   |
@@ -351,6 +360,15 @@ foo(1, y = 2, y = 3)
 fn foo(x: float, y?) -> float:
 	return x / y
 ### STDERR ###
+error[RAD30002]: Invalid operand types: cannot do 'float / any?'
+  --> <script>:3:9
+  |
+2 | fn foo(x: float, y?) -> float:
+3 | 	return x / y
+  |         ^^^^^
+  |
+   = info: rad explain RAD30002
+
 error[RAD30006]: Argument 'y' already specified
   --> <script>:1:15
   |

--- a/core/testing/snapshots/types/typing.snap
+++ b/core/testing/snapshots/types/typing.snap
@@ -14,7 +14,7 @@ add(1, "2").print()
 fn add(x: float, y: float) -> float:
 	return x + y
 ### STDERR ###
-error[RAD30001]: Value '"2"' (str) is not compatible with expected type 'float'
+error[RAD30001]: Argument type 'str' is not assignable to expected type 'float'
   --> <script>:1:8
   |
 1 | add(1, "2").print()
@@ -34,16 +34,13 @@ add(1, 2).print()
 fn add(x: float, y: float) -> float:
 	return "hi"
 ### STDERR ###
-error[RAD30001]: Value '"hi"' (str) is not compatible with expected type 'float'
-  --> <script>:1:1
+error[RAD30001]: Return value of type 'str' is not assignable to declared return type 'float'
+  --> <script>:3:9
   |
-1 | add(1, 2).print()
-  | ^^^^^^^^^
 2 | fn add(x: float, y: float) -> float:
 3 | 	return "hi"
+  |         ^^^^
   |
-   = stack:
-     at add (TestCase:1:1)
    = info: rad explain RAD30001
 
 
@@ -82,7 +79,7 @@ foo(x=1, y="2").print()
 fn foo(x: float, y: float) -> float:
 	return x / y
 ### STDERR ###
-error[RAD30001]: Value '"2"' (str) is not compatible with expected type 'float'
+error[RAD30001]: Argument type 'str' is not assignable to expected type 'float'
   --> <script>:1:12
   |
 1 | foo(x=1, y="2").print()
@@ -398,7 +395,7 @@ foo(2)
 fn foo(x: str):
 	print("|{x}|")
 ### STDERR ###
-error[RAD30001]: Value '2' (int) is not compatible with expected type 'str'
+error[RAD30001]: Argument type 'int' is not assignable to expected type 'str'
   --> <script>:1:5
   |
 1 | foo(2)
@@ -427,16 +424,13 @@ foo().print()
 fn foo() -> str:
 	return 2
 ### STDERR ###
-error[RAD30001]: Value '2' (int) is not compatible with expected type 'str'
-  --> <script>:1:1
+error[RAD30001]: Return value of type 'int' is not assignable to declared return type 'str'
+  --> <script>:3:9
   |
-1 | foo().print()
-  | ^^^^^
 2 | fn foo() -> str:
 3 | 	return 2
+  |         ^
   |
-   = stack:
-     at foo (TestCase:1:1)
    = info: rad explain RAD30001
 
 
@@ -458,7 +452,7 @@ foo("2")
 fn foo(x: int):
 	print("|{x}|")
 ### STDERR ###
-error[RAD30001]: Value '"2"' (str) is not compatible with expected type 'int'
+error[RAD30001]: Argument type 'str' is not assignable to expected type 'int'
   --> <script>:1:5
   |
 1 | foo("2")
@@ -478,7 +472,7 @@ foo(null)
 fn foo(x: int):
 	print("|{x}|")
 ### STDERR ###
-error[RAD30001]: Value 'null' (null) is not compatible with expected type 'int'
+error[RAD30001]: Argument type 'null' is not assignable to expected type 'int'
   --> <script>:1:5
   |
 1 | foo(null)
@@ -507,16 +501,13 @@ foo().print()
 fn foo() -> int:
 	return "2"
 ### STDERR ###
-error[RAD30001]: Value '"2"' (str) is not compatible with expected type 'int'
-  --> <script>:1:1
+error[RAD30001]: Return value of type 'str' is not assignable to declared return type 'int'
+  --> <script>:3:9
   |
-1 | foo().print()
-  | ^^^^^
 2 | fn foo() -> int:
 3 | 	return "2"
+  |         ^^^
   |
-   = stack:
-     at foo (TestCase:1:1)
    = info: rad explain RAD30001
 
 
@@ -538,7 +529,7 @@ foo(1)
 fn foo(x: bool):
 	print("|{x}|")
 ### STDERR ###
-error[RAD30001]: Value '1' (int) is not compatible with expected type 'bool'
+error[RAD30001]: Argument type 'int' is not assignable to expected type 'bool'
   --> <script>:1:5
   |
 1 | foo(1)
@@ -567,16 +558,13 @@ foo().print()
 fn foo() -> bool:
 	return 1
 ### STDERR ###
-error[RAD30001]: Value '1' (int) is not compatible with expected type 'bool'
-  --> <script>:1:1
+error[RAD30001]: Return value of type 'int' is not assignable to declared return type 'bool'
+  --> <script>:3:9
   |
-1 | foo().print()
-  | ^^^^^
 2 | fn foo() -> bool:
 3 | 	return 1
+  |         ^
   |
-   = stack:
-     at foo (TestCase:1:1)
    = info: rad explain RAD30001
 
 
@@ -598,7 +586,7 @@ foo(1)
 fn foo(x: error):
 	print("|{x}|")
 ### STDERR ###
-error[RAD30001]: Value '1' (int) is not compatible with expected type 'error'
+error[RAD30001]: Argument type 'int' is not assignable to expected type 'error'
   --> <script>:1:5
   |
 1 | foo(1)
@@ -628,16 +616,13 @@ foo().print()
 fn foo() -> error:
 	return 1
 ### STDERR ###
-error[RAD30001]: Value '1' (int) is not compatible with expected type 'error'
-  --> <script>:1:1
+error[RAD30001]: Return value of type 'int' is not assignable to declared return type 'error'
+  --> <script>:3:9
   |
-1 | foo().print()
-  | ^^^^^
 2 | fn foo() -> error:
 3 | 	return 1
+  |         ^
   |
-   = stack:
-     at foo (TestCase:1:1)
    = info: rad explain RAD30001
 
 
@@ -727,7 +712,7 @@ foo(1)
 fn foo(x: list):
 	print("|{x}|")
 ### STDERR ###
-error[RAD30001]: Value '1' (int) is not compatible with expected type 'list'
+error[RAD30001]: Argument type 'int' is not assignable to expected type 'list'
   --> <script>:1:5
   |
 1 | foo(1)
@@ -747,6 +732,16 @@ foo(1, 2)
 fn foo(x: list):
 	print("|{x}|")
 ### STDERR ###
+error[RAD30001]: Argument type 'int' is not assignable to expected type 'list'
+  --> <script>:1:5
+  |
+1 | foo(1, 2)
+  |     ^
+2 | fn foo(x: list):
+3 | 	print("|{x}|")
+  |
+   = info: rad explain RAD30001
+
 error[RAD30007]: Expected at most 1 args, but was invoked with 2
   --> <script>:1:1
   |
@@ -785,16 +780,13 @@ foo().print()
 fn foo() -> list:
 	return 1
 ### STDERR ###
-error[RAD30001]: Value '1' (int) is not compatible with expected type 'list'
-  --> <script>:1:1
+error[RAD30001]: Return value of type 'int' is not assignable to declared return type 'list'
+  --> <script>:3:9
   |
-1 | foo().print()
-  | ^^^^^
 2 | fn foo() -> list:
 3 | 	return 1
+  |         ^
   |
-   = stack:
-     at foo (TestCase:1:1)
    = info: rad explain RAD30001
 
 
@@ -816,11 +808,11 @@ foo(["hi", 1])
 fn foo(x: [int, str]):
 	print("|{x}|")
 ### STDERR ###
-error[RAD30001]: Value '[ "hi", 1 ]' (list) is not compatible with expected type '[int, str]'
-  --> <script>:1:5
+error[RAD30001]: Argument type 'str' is not assignable to expected type 'int'
+  --> <script>:1:6
   |
 1 | foo(["hi", 1])
-  |     ^^^^^^^^^
+  |      ^^^^
 2 | fn foo(x: [int, str]):
 3 | 	print("|{x}|")
   |
@@ -845,16 +837,13 @@ foo().print()
 fn foo() -> [int, str]:
 	return [1, 2]
 ### STDERR ###
-error[RAD30001]: Value '[ 1, 2 ]' (list) is not compatible with expected type '[int, str]'
-  --> <script>:1:1
+error[RAD30001]: Return value of type 'int' is not assignable to declared return type 'str'
+  --> <script>:3:13
   |
-1 | foo().print()
-  | ^^^^^
 2 | fn foo() -> [int, str]:
 3 | 	return [1, 2]
+  |             ^
   |
-   = stack:
-     at foo (TestCase:1:1)
    = info: rad explain RAD30001
 
 
@@ -878,11 +867,11 @@ foo([1, "hi"])
 fn foo(x: int[]):
 	print("|{x}|")
 ### STDERR ###
-error[RAD30001]: Value '[ 1, "hi" ]' (list) is not compatible with expected type 'int[]'
-  --> <script>:1:5
+error[RAD30001]: Argument type 'str' is not assignable to expected type 'int'
+  --> <script>:1:9
   |
 1 | foo([1, "hi"])
-  |     ^^^^^^^^^
+  |         ^^^^
 2 | fn foo(x: int[]):
 3 | 	print("|{x}|")
   |
@@ -907,16 +896,13 @@ foo().print()
 fn foo() -> int[]:
 	return [1, "2"]
 ### STDERR ###
-error[RAD30001]: Value '[ 1, "2" ]' (list) is not compatible with expected type 'int[]'
-  --> <script>:1:1
+error[RAD30001]: Return value of type 'str' is not assignable to declared return type 'int'
+  --> <script>:3:13
   |
-1 | foo().print()
-  | ^^^^^
 2 | fn foo() -> int[]:
 3 | 	return [1, "2"]
+  |             ^^^
   |
-   = stack:
-     at foo (TestCase:1:1)
    = info: rad explain RAD30001
 
 
@@ -938,7 +924,7 @@ foo("quz")
 fn foo(x: ["foo", "bar"]):
 	print("|{x}|")
 ### STDERR ###
-error[RAD30001]: Value '"quz"' (str) is not compatible with expected type '["foo", "bar"]'
+error[RAD30001]: Argument type 'str' is not assignable to expected type '["foo", "bar"]'
   --> <script>:1:5
   |
 1 | foo("quz")
@@ -967,16 +953,13 @@ foo().print()
 fn foo() -> ["foo", "bar"]:
 	return "quz"
 ### STDERR ###
-error[RAD30001]: Value '"quz"' (str) is not compatible with expected type '["foo", "bar"]'
-  --> <script>:1:1
+error[RAD30001]: Return value of type 'str' is not assignable to declared return type '["foo", "bar"]'
+  --> <script>:3:9
   |
-1 | foo().print()
-  | ^^^^^
 2 | fn foo() -> ["foo", "bar"]:
 3 | 	return "quz"
+  |         ^^^^^
   |
-   = stack:
-     at foo (TestCase:1:1)
    = info: rad explain RAD30001
 
 
@@ -998,7 +981,7 @@ foo(2)
 fn foo(x: map):
 	print("|{x}|")
 ### STDERR ###
-error[RAD30001]: Value '2' (int) is not compatible with expected type 'map'
+error[RAD30001]: Argument type 'int' is not assignable to expected type 'map'
   --> <script>:1:5
   |
 1 | foo(2)
@@ -1027,16 +1010,13 @@ foo().print()
 fn foo() -> map:
 	return 1
 ### STDERR ###
-error[RAD30001]: Value '1' (int) is not compatible with expected type 'map'
-  --> <script>:1:1
+error[RAD30001]: Return value of type 'int' is not assignable to declared return type 'map'
+  --> <script>:3:9
   |
-1 | foo().print()
-  | ^^^^^
 2 | fn foo() -> map:
 3 | 	return 1
+  |         ^
   |
-   = stack:
-     at foo (TestCase:1:1)
    = info: rad explain RAD30001
 
 
@@ -1058,7 +1038,7 @@ foo({"key2": 10})
 fn foo(x: {"key1": int}):
 	print("|{x}|")
 ### STDERR ###
-error[RAD30001]: Value '{ "key2": 10 }' (map) is not compatible with expected type '{ "key1": int }'
+error[RAD30001]: Argument type '{ str: int }' is not assignable to expected type '{ "key1": int }'
   --> <script>:1:5
   |
 1 | foo({"key2": 10})
@@ -1087,16 +1067,13 @@ foo().print()
 fn foo() -> {"key1": int}:
 	return {"key2": 10}
 ### STDERR ###
-error[RAD30001]: Value '{ "key2": 10 }' (map) is not compatible with expected type '{ "key1": int }'
-  --> <script>:1:1
+error[RAD30001]: Return value of type '{ str: int }' is not assignable to declared return type '{ "key1": int }'
+  --> <script>:3:9
   |
-1 | foo().print()
-  | ^^^^^
 2 | fn foo() -> {"key1": int}:
 3 | 	return {"key2": 10}
+  |         ^^^^^^^^^^^^
   |
-   = stack:
-     at foo (TestCase:1:1)
    = info: rad explain RAD30001
 
 
@@ -1109,16 +1086,13 @@ foo().print()
 fn foo() -> {"key1": int}:
 	return {"key2": "hi"}
 ### STDERR ###
-error[RAD30001]: Value '{ "key2": "hi" }' (map) is not compatible with expected type '{ "key1": int }'
-  --> <script>:1:1
+error[RAD30001]: Return value of type '{ str: str }' is not assignable to declared return type '{ "key1": int }'
+  --> <script>:3:9
   |
-1 | foo().print()
-  | ^^^^^
 2 | fn foo() -> {"key1": int}:
 3 | 	return {"key2": "hi"}
+  |         ^^^^^^^^^^^^^^
   |
-   = stack:
-     at foo (TestCase:1:1)
    = info: rad explain RAD30001
 
 
@@ -1140,11 +1114,11 @@ foo({"key1": "hi"})
 fn foo(x: {str: int}):
 	print("|{x}|")
 ### STDERR ###
-error[RAD30001]: Value '{ "key1": "hi" }' (map) is not compatible with expected type '{ str: int }'
-  --> <script>:1:5
+error[RAD30001]: Argument type 'str' is not assignable to expected type 'int'
+  --> <script>:1:14
   |
 1 | foo({"key1": "hi"})
-  |     ^^^^^^^^^^^^^^
+  |              ^^^^
 2 | fn foo(x: {str: int}):
 3 | 	print("|{x}|")
   |
@@ -1169,16 +1143,13 @@ foo().print()
 fn foo() -> {str: int}:
 	return {"key1": "hi"}
 ### STDERR ###
-error[RAD30001]: Value '{ "key1": "hi" }' (map) is not compatible with expected type '{ str: int }'
-  --> <script>:1:1
+error[RAD30001]: Return value of type 'str' is not assignable to declared return type 'int'
+  --> <script>:3:18
   |
-1 | foo().print()
-  | ^^^^^
 2 | fn foo() -> {str: int}:
 3 | 	return {"key1": "hi"}
+  |                  ^^^^
   |
-   = stack:
-     at foo (TestCase:1:1)
    = info: rad explain RAD30001
 
 
@@ -1274,7 +1245,7 @@ foo("hi")
 fn foo(x: int?):
 	print("|{x}|")
 ### STDERR ###
-error[RAD30001]: Value '"hi"' (str) is not compatible with expected type 'int?'
+error[RAD30001]: Argument type 'str' is not assignable to expected type 'int'
   --> <script>:1:5
   |
 1 | foo("hi")
@@ -1307,16 +1278,13 @@ foo().print()
 fn foo() -> int?:
 	return "hi"
 ### STDERR ###
-error[RAD30001]: Value '"hi"' (str) is not compatible with expected type 'int?'
-  --> <script>:1:1
+error[RAD30001]: Return value of type 'str' is not assignable to declared return type 'int'
+  --> <script>:3:9
   |
-1 | foo().print()
-  | ^^^^^
 2 | fn foo() -> int?:
 3 | 	return "hi"
+  |         ^^^^
   |
-   = stack:
-     at foo (TestCase:1:1)
    = info: rad explain RAD30001
 
 
@@ -1340,7 +1308,7 @@ foo(1.2)
 fn foo(x: int|str):
 	print("|{x}|")
 ### STDERR ###
-error[RAD30001]: Value '1.2' (float) is not compatible with expected type 'int|str'
+error[RAD30001]: Argument type 'float' is not assignable to expected type 'int|str'
   --> <script>:1:5
   |
 1 | foo(1.2)
@@ -1376,16 +1344,13 @@ foo(2).print()
 fn foo(x) -> int|str:
 	return 1.2
 ### STDERR ###
-error[RAD30001]: Value '1.2' (float) is not compatible with expected type 'int|str'
-  --> <script>:1:1
+error[RAD30001]: Return value of type 'float' is not assignable to declared return type 'int|str'
+  --> <script>:4:9
   |
-1 | foo(1).print()
-  | ^^^^^^
-2 | foo(2).print()
 3 | fn foo(x) -> int|str:
+4 | 	return 1.2
+  |         ^^^
   |
-   = stack:
-     at foo (TestCase:1:1)
    = info: rad explain RAD30001
 
 

--- a/core/testing/snapshots/types/typing.snap
+++ b/core/testing/snapshots/types/typing.snap
@@ -328,15 +328,6 @@ foo(1, x=2)
 fn foo(x: float, y?) -> float:
 	return x / y
 ### STDERR ###
-error[RAD30002]: Invalid operand types: cannot do 'float / any?'
-  --> <script>:3:9
-  |
-2 | fn foo(x: float, y?) -> float:
-3 | 	return x / y
-  |         ^^^^^
-  |
-   = info: rad explain RAD30002
-
 error[RAD30006]: Argument 'x' already specified
   --> <script>:1:8
   |
@@ -357,15 +348,6 @@ foo(1, y = 2, y = 3)
 fn foo(x: float, y?) -> float:
 	return x / y
 ### STDERR ###
-error[RAD30002]: Invalid operand types: cannot do 'float / any?'
-  --> <script>:3:9
-  |
-2 | fn foo(x: float, y?) -> float:
-3 | 	return x / y
-  |         ^^^^^
-  |
-   = info: rad explain RAD30002
-
 error[RAD30006]: Argument 'y' already specified
   --> <script>:1:15
   |
@@ -1038,7 +1020,7 @@ foo({"key2": 10})
 fn foo(x: {"key1": int}):
 	print("|{x}|")
 ### STDERR ###
-error[RAD30001]: Argument type '{ str: int }' is not assignable to expected type '{ "key1": int }'
+error[RAD30001]: Argument type '{ str: int }' is not assignable to expected type '{ "key1": int }' (missing required field 'key1')
   --> <script>:1:5
   |
 1 | foo({"key2": 10})
@@ -1067,7 +1049,7 @@ foo().print()
 fn foo() -> {"key1": int}:
 	return {"key2": 10}
 ### STDERR ###
-error[RAD30001]: Return value of type '{ str: int }' is not assignable to declared return type '{ "key1": int }'
+error[RAD30001]: Return value of type '{ str: int }' is not assignable to declared return type '{ "key1": int }' (missing required field 'key1')
   --> <script>:3:9
   |
 2 | fn foo() -> {"key1": int}:
@@ -1086,7 +1068,7 @@ foo().print()
 fn foo() -> {"key1": int}:
 	return {"key2": "hi"}
 ### STDERR ###
-error[RAD30001]: Return value of type '{ str: str }' is not assignable to declared return type '{ "key1": int }'
+error[RAD30001]: Return value of type '{ str: str }' is not assignable to declared return type '{ "key1": int }' (missing required field 'key1')
   --> <script>:3:9
   |
 2 | fn foo() -> {"key1": int}:

--- a/core/testing/snapshots/types/typing_nested.snap
+++ b/core/testing/snapshots/types/typing_nested.snap
@@ -9,11 +9,11 @@ foo([[1, 2], [3, "bad"]])
 fn foo(x: int[][]):
 	print(x)
 ### STDERR ###
-error[RAD30001]: Value '[ [ 1, 2 ], [ 3, "bad" ] ]' (list) is not compatible with expected type 'int[][]'
-  --> <script>:1:5
+error[RAD30001]: Argument type 'str' is not assignable to expected type 'int'
+  --> <script>:1:18
   |
 1 | foo([[1, 2], [3, "bad"]])
-  |     ^^^^^^^^^^^^^^^^^^^^
+  |                  ^^^^^
 2 | fn foo(x: int[][]):
 3 | 	print(x)
   |
@@ -38,11 +38,11 @@ foo([1, [2, "bad"]])
 fn foo(x: [int, int[]]):
 	print(x)
 ### STDERR ###
-error[RAD30001]: Value '[ 1, [ 2, "bad" ] ]' (list) is not compatible with expected type '[int, int[]]'
-  --> <script>:1:5
+error[RAD30001]: Argument type 'str' is not assignable to expected type 'int'
+  --> <script>:1:13
   |
 1 | foo([1, [2, "bad"]])
-  |     ^^^^^^^^^^^^^^^
+  |             ^^^^^
 2 | fn foo(x: [int, int[]]):
 3 | 	print(x)
   |
@@ -67,11 +67,11 @@ foo({ "a": [1, "bad"] })
 fn foo(x: { str: int[] }):
 	print(x)
 ### STDERR ###
-error[RAD30001]: Value '{ "a": [ 1, "bad" ] }' (map) is not compatible with expected type '{ str: int[] }'
-  --> <script>:1:5
+error[RAD30001]: Argument type 'str' is not assignable to expected type 'int'
+  --> <script>:1:16
   |
 1 | foo({ "a": [1, "bad"] })
-  |     ^^^^^^^^^^^^^^^^^^^
+  |                ^^^^^
 2 | fn foo(x: { str: int[] }):
 3 | 	print(x)
   |
@@ -87,11 +87,11 @@ foo({ "outer": { "inner": "no" } })
 fn foo(x: { "outer": { "inner": int } }):
 	print(x)
 ### STDERR ###
-error[RAD30001]: Value '{ "outer": { "inner": "no" } }' (map) is not compatible with expected type '{ "outer": { "inner": int } }'
-  --> <script>:1:5
+error[RAD30001]: Argument type 'str' is not assignable to expected type 'int'
+  --> <script>:1:27
   |
 1 | foo({ "outer": { "inner": "no" } })
-  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |                           ^^^^
 2 | fn foo(x: { "outer": { "inner": int } }):
 3 | 	print(x)
   |
@@ -119,11 +119,11 @@ foo([1, null, 2])
 fn foo(x: int[]):
 	print(x)
 ### STDERR ###
-error[RAD30001]: Value '[ 1, null, 2 ]' (list) is not compatible with expected type 'int[]'
-  --> <script>:1:5
+error[RAD30001]: Argument type 'null' is not assignable to expected type 'int'
+  --> <script>:1:9
   |
 1 | foo([1, null, 2])
-  |     ^^^^^^^^^^^^
+  |         ^^^^
 2 | fn foo(x: int[]):
 3 | 	print(x)
   |
@@ -145,12 +145,12 @@ foo([1, helper, 2])
 fn foo(x: int[]):
 	print(x)
 ### STDERR ###
-error[RAD30001]: Value '[ 1, <fn>, 2 ]' (list) is not compatible with expected type 'int[]'
-  --> <script>:3:5
+error[RAD30001]: Argument type 'fn() -> void' is not assignable to expected type 'int'
+  --> <script>:3:9
   |
 2 | 	print("hi")
 3 | foo([1, helper, 2])
-  |     ^^^^^^^^^^^^^^
+  |         ^^^^^^
 4 | fn foo(x: int[]):
 5 | 	print(x)
   |

--- a/radls/analysis/hover.go
+++ b/radls/analysis/hover.go
@@ -202,11 +202,11 @@ func symbolTypeString(sym *check.Symbol, info *check.TypeInfo) string {
 	}
 	if info != nil {
 		if t, ok := info.SymbolTypes[sym]; ok && t != nil {
-			return t.Name()
+			return rl.DisplayName(t)
 		}
 	}
 	if sym.Declared != nil {
-		return sym.Declared.Name()
+		return rl.DisplayName(sym.Declared)
 	}
 	return "?"
 }

--- a/rts/check/check_lit.go
+++ b/rts/check/check_lit.go
@@ -1,6 +1,8 @@
 package check
 
 import (
+	"fmt"
+
 	"github.com/amterp/rad/rts/rl"
 )
 
@@ -27,6 +29,18 @@ type checkResult struct {
 	got       rl.TypingT
 	want      rl.TypingT
 	gateable  bool
+	// detail is an optional clarifying note appended to a call site's
+	// diagnostic message, for failures the got/want pair alone doesn't
+	// explain (e.g. which required struct field was missing).
+	detail string
+}
+
+// detailSuffix renders detail as a parenthetical message suffix, or "".
+func (r checkResult) detailSuffix() string {
+	if r.detail == "" {
+		return ""
+	}
+	return " (" + r.detail + ")"
 }
 
 // check is the structural companion to synth: it decides whether a value
@@ -102,7 +116,7 @@ func (tc *typeChecker) check(node rl.Node, expected rl.TypingT) checkResult {
 		return tc.checkMapLit(lit, expected, got)
 	case *rl.LitString:
 		if enum, isEnum := expected.(*rl.TypingStrEnumT); isEnum && lit.Simple {
-			if strEnumContains(enum, lit.Value) {
+			if enum.Contains(lit.Value) {
 				return accept(node, got, expected)
 			}
 			// A simple literal not among the members is provably wrong.
@@ -184,7 +198,9 @@ func (tc *typeChecker) checkMapLit(lit *rl.LitMap, expected, got rl.TypingT) che
 		if !hasComputedKey {
 			for key := range exp.Fields() {
 				if !key.IsOptional && !seen[key.Name] {
-					return reject(lit, got, expected)
+					res := reject(lit, got, expected)
+					res.detail = fmt.Sprintf("missing required field '%s'", key.Name)
+					return res
 				}
 			}
 		}
@@ -219,15 +235,6 @@ func simpleStringKey(key rl.Node) (string, bool) {
 		return "", false
 	}
 	return lit.Value, true
-}
-
-func strEnumContains(enum *rl.TypingStrEnumT, value string) bool {
-	for _, v := range enum.Values() {
-		if v == value {
-			return true
-		}
-	}
-	return false
 }
 
 func accept(node rl.Node, got, want rl.TypingT) checkResult {
@@ -304,13 +311,20 @@ func isGradualContainer(t rl.TypingT) bool {
 	return false
 }
 
-// typeIsGateable reports whether a synthesized type is concrete enough that
-// a mismatch against it is provable. Used by the non-structural return path
-// (void / multi-value returns) where there's no value node to walk: a type
-// carrying an open gradual container anywhere stays a Hint.
+// typeIsGateable reports whether a synthesized type is concrete enough
+// that a mismatch against it is provable - the fallback the return path
+// uses when there's no value node to walk (a bare return, or a
+// multi-value shape we can't decompose position-wise). It's false
+// whenever the type carries a component whose runtime value the checker
+// can't pin down: an open gradual container, or a union/optional whose
+// arms might include the compatible one. Such a mismatch stays a Hint,
+// the same provable-only rule gateableMismatch applies at the leaves.
 func typeIsGateable(t rl.TypingT) bool {
 	switch v := t.(type) {
 	case *rl.TypingAnyListT, *rl.TypingAnyMapT:
+		return false
+	case *rl.TypingUnionT, *rl.TypingOptionalT:
+		// An arm might be the compatible one at runtime - not provable.
 		return false
 	case *rl.TypingTupleT:
 		for _, e := range v.Types() {

--- a/rts/check/check_lit.go
+++ b/rts/check/check_lit.go
@@ -13,11 +13,20 @@ import (
 // offending is the node itself and got/want equal the synthesized and
 // expected types, so the message reads exactly as the old
 // synth + IsAssignableFrom path did.
+//
+// gateable records whether a *failure* is provable enough to block runtime
+// (Error) rather than merely suspected (Hint). It's false when the real
+// value is unknown to the checker - an open gradual container (`list` /
+// `map`) whose contents we can't see, or a non-literal string flowing into
+// a str-enum (the string's runtime value decides membership). Gating those
+// would brick valid programs, which the severity policy forbids. Meaningless
+// when ok is true.
 type checkResult struct {
 	ok        bool
 	offending rl.Node
 	got       rl.TypingT
 	want      rl.TypingT
+	gateable  bool
 }
 
 // check is the structural companion to synth: it decides whether a value
@@ -71,12 +80,18 @@ func (tc *typeChecker) check(node rl.Node, expected rl.TypingT) checkResult {
 		// Assignable if the value fits any arm. We recurse rather than
 		// stop at the fast path so a literal can match a *structured*
 		// arm (tuple, struct, str-enum) that IsAssignableFrom rejects.
+		// A union miss is only gateable when *every* arm was provably
+		// missed - if any arm's miss was uncertain, the value might fit
+		// it at runtime.
+		allGateable := true
 		for _, arm := range exp.Types() {
-			if res := tc.check(node, arm); res.ok {
+			res := tc.check(node, arm)
+			if res.ok {
 				return accept(node, got, expected)
 			}
+			allGateable = allGateable && res.gateable
 		}
-		return reject(node, got, expected)
+		return rejectWith(node, got, expected, allGateable)
 	}
 
 	// Structural literal rules.
@@ -86,12 +101,17 @@ func (tc *typeChecker) check(node rl.Node, expected rl.TypingT) checkResult {
 	case *rl.LitMap:
 		return tc.checkMapLit(lit, expected, got)
 	case *rl.LitString:
-		if enum, isEnum := expected.(*rl.TypingStrEnumT); isEnum && lit.Simple && strEnumContains(enum, lit.Value) {
-			return accept(node, got, expected)
+		if enum, isEnum := expected.(*rl.TypingStrEnumT); isEnum && lit.Simple {
+			if strEnumContains(enum, lit.Value) {
+				return accept(node, got, expected)
+			}
+			// A simple literal not among the members is provably wrong.
+			return reject(node, got, expected)
 		}
 	}
 
-	return reject(node, got, expected)
+	// Leaf mismatch: gateable unless the real value is unknown to us.
+	return rejectWith(node, got, expected, gateableMismatch(got, expected))
 }
 
 // checkListLit checks a list literal against a tuple, list, or open-list
@@ -130,34 +150,42 @@ func (tc *typeChecker) checkListLit(lit *rl.LitList, expected, got rl.TypingT) c
 }
 
 // checkMapLit checks a map literal against a struct or map target. A struct
-// target requires every entry key to be a plain string literal naming a
-// declared field, each value to fit its field type, and every required
-// field to be present. A map target checks all keys against K and all
-// values against V. Other targets fall back to assignability.
+// target requires every declared field's value to fit its type and every
+// required field to be present; extra keys are allowed (the runtime ignores
+// keys beyond the declared shape, so `{ "a": 1, "b": 2 }` satisfies
+// `{ "a": int }`). A map target checks all keys against K and all values
+// against V. Other targets fall back to assignability.
 func (tc *typeChecker) checkMapLit(lit *rl.LitMap, expected, got rl.TypingT) checkResult {
 	switch exp := expected.(type) {
 	case *rl.TypingStructT:
 		seen := make(map[string]bool, len(lit.Entries))
+		hasComputedKey := false
 		for _, entry := range lit.Entries {
 			name, isStr := simpleStringKey(entry.Key)
 			if !isStr {
-				// A computed/interpolated key can't be matched to a named
-				// field statically. Point at the key.
-				return reject(entry.Key, got, expected)
+				// A computed/interpolated key might name any field - we
+				// can't tell which, and it might satisfy a required one.
+				// (Extra keys are valid anyway.) Defer judgement.
+				hasComputedKey = true
+				continue
 			}
 			fieldT, _, found := exp.Field(name)
 			if !found {
-				return reject(entry.Key, got, expected)
+				// Extra field beyond the declared shape - runtime ignores it.
+				continue
 			}
 			if res := tc.check(entry.Value, fieldT); !res.ok {
 				return res
 			}
 			seen[name] = true
 		}
-		// Every required (non-optional) field must be supplied.
-		for key := range exp.Fields() {
-			if !key.IsOptional && !seen[key.Name] {
-				return reject(lit, got, expected)
+		// Every required (non-optional) field must be present - but only
+		// gate the absence when no computed key could be supplying it.
+		if !hasComputedKey {
+			for key := range exp.Fields() {
+				if !key.IsOptional && !seen[key.Name] {
+					return reject(lit, got, expected)
+				}
 			}
 		}
 		return accept(lit, got, expected)
@@ -203,9 +231,103 @@ func strEnumContains(enum *rl.TypingStrEnumT, value string) bool {
 }
 
 func accept(node rl.Node, got, want rl.TypingT) checkResult {
-	return checkResult{ok: true, offending: node, got: got, want: want}
+	return checkResult{ok: true, offending: node, got: got, want: want, gateable: true}
 }
 
+// reject builds a provably-wrong (gateable) failure - the default for a
+// concrete structural conflict. Use rejectWith when the confidence is
+// conditional.
 func reject(node rl.Node, got, want rl.TypingT) checkResult {
-	return checkResult{ok: false, offending: node, got: got, want: want}
+	return rejectWith(node, got, want, true)
+}
+
+func rejectWith(node rl.Node, got, want rl.TypingT, gateable bool) checkResult {
+	return checkResult{ok: false, offending: node, got: got, want: want, gateable: gateable}
+}
+
+// gateableMismatch reports whether a leaf (scalar / non-structured)
+// mismatch is provable enough to gate as an Error. It is true only when
+// *every* possible runtime value of got is definitely incompatible with
+// want. It's false - merely a Hint - whenever some runtime value could
+// fit, i.e. the checker can't see the real value:
+//
+//   - an open gradual container (`list` / `map`) whose contents are hidden;
+//   - a non-literal string into a str-enum (a simple literal would have
+//     been resolved by membership upstream, so a bare `str` here is an
+//     interpolation/variable whose value decides membership at runtime);
+//   - a union or optional whose arms include one that would fit (e.g.
+//     `int|str` into `int`, or `str?` into `str` - the value might be the
+//     compatible arm).
+func gateableMismatch(got, want rl.TypingT) bool {
+	if isGradualContainer(got) {
+		return false
+	}
+	switch g := got.(type) {
+	case *rl.TypingUnionT:
+		return allArmsGateable(g.Types(), want)
+	case *rl.TypingOptionalT:
+		// T? is T | null: gateable only if neither could fit.
+		return allArmsGateable([]rl.TypingT{g.Inner(), rl.NewNullType()}, want)
+	}
+	if _, isEnum := want.(*rl.TypingStrEnumT); isEnum {
+		if _, isStr := got.(*rl.TypingStrT); isStr {
+			return false
+		}
+	}
+	return true
+}
+
+// allArmsGateable reports whether every arm of a union/optional source is
+// a provable mismatch against want. If any arm is assignable (a runtime
+// value of that arm would fit) or is itself an uncertain mismatch, the
+// whole thing is uncertain.
+func allArmsGateable(arms []rl.TypingT, want rl.TypingT) bool {
+	for _, arm := range arms {
+		if want.IsAssignableFrom(arm) {
+			return false
+		}
+		if !gateableMismatch(arm, want) {
+			return false
+		}
+	}
+	return true
+}
+
+// isGradualContainer reports whether t is one of the open gradual
+// collection types (`list` / `map`) - the gradual-typing escape hatch
+// whose element/value contents the checker doesn't track.
+func isGradualContainer(t rl.TypingT) bool {
+	switch t.(type) {
+	case *rl.TypingAnyListT, *rl.TypingAnyMapT:
+		return true
+	}
+	return false
+}
+
+// typeIsGateable reports whether a synthesized type is concrete enough that
+// a mismatch against it is provable. Used by the non-structural return path
+// (void / multi-value returns) where there's no value node to walk: a type
+// carrying an open gradual container anywhere stays a Hint.
+func typeIsGateable(t rl.TypingT) bool {
+	switch v := t.(type) {
+	case *rl.TypingAnyListT, *rl.TypingAnyMapT:
+		return false
+	case *rl.TypingTupleT:
+		for _, e := range v.Types() {
+			if !typeIsGateable(e) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// mismatchSeverity maps a failed checkResult to the severity its call site
+// should emit: a blocking Error when the failure is provable, a non-gating
+// Hint when the real value is unknown (see checkResult.gateable).
+func mismatchSeverity(res checkResult) IssueSeverity {
+	if res.gateable {
+		return IssueError
+	}
+	return IssueHint
 }

--- a/rts/check/check_lit.go
+++ b/rts/check/check_lit.go
@@ -1,0 +1,211 @@
+package check
+
+import (
+	"github.com/amterp/rad/rts/rl"
+)
+
+// checkResult is the verdict of a scoped bidirectional check (see check).
+// On success, ok is true and the remaining fields describe the whole node.
+// On failure, offending pinpoints the deepest literal element that doesn't
+// fit, with got/want the concrete types at that point - so a call site can
+// emit a localized diagnostic ("element 2: int is not assignable to str")
+// instead of a whole-literal one. For a top-level (non-nested) mismatch
+// offending is the node itself and got/want equal the synthesized and
+// expected types, so the message reads exactly as the old
+// synth + IsAssignableFrom path did.
+type checkResult struct {
+	ok        bool
+	offending rl.Node
+	got       rl.TypingT
+	want      rl.TypingT
+}
+
+// check is the structural companion to synth: it decides whether a value
+// node is assignable to an expected type, looking *through* the literal
+// shapes that synth widens away. synth turns `[1, "2"]` into `(int|str)[]`
+// and `{ "k": 1 }` into `{ str: int }`, neither of which matches a
+// tuple/struct target under the invariant collection rules - even when the
+// literal is a perfectly valid inhabitant. check recovers that fidelity by
+// walking the literal against the target recursively: `[1, "2"]` checks
+// position-wise against `[int, str]`, `{ "k": 1 }` field-wise against
+// `{ "k": int }`, and a plain string against a str-enum by membership.
+//
+// It always calls synth(node) first so ExprTypes/hover stay coherent (the
+// widened type is still what's cached and shown on hover); the structural
+// verdict layers on top without writing anything new to the index. synth
+// never calls check, so there is no recursion cycle.
+//
+// Non-literal nodes, and literals whose target isn't a structured type,
+// fall through to synth + IsAssignableFrom, making check a strict superset
+// of the old `expected.IsAssignableFrom(synth(node))` test.
+func (tc *typeChecker) check(node rl.Node, expected rl.TypingT) checkResult {
+	got := tc.synth(node)
+	// Unknown / already-poisoned source types accept anything, mirroring
+	// the short-circuits the call sites used before delegating here.
+	if got == nil || isErrorType(got) || isDynamicLike(got) {
+		return accept(node, got, expected)
+	}
+	if expected == nil {
+		return accept(node, got, expected)
+	}
+
+	// Fast path: a synthesized type that's already assignable is accepted
+	// outright. IsAssignableFrom is sound - it never accepts an invalid
+	// value - and only *under*-approximates for literals flowing into
+	// structured types (a tuple, struct, or str-enum target). Everything
+	// below exists solely to recover those false negatives, so anything
+	// IsAssignableFrom already admits (including `int?` into `int?` and
+	// `int|error` into `int|error`) must short-circuit here first.
+	if expected.IsAssignableFrom(got) {
+		return accept(node, got, expected)
+	}
+
+	// Peel the expected type to recover the literal-into-structured cases.
+	switch exp := expected.(type) {
+	case *rl.TypingOptionalT:
+		// The whole value didn't fit `T?` (so it isn't null - the fast
+		// path would have caught that); try the inner type so a literal
+		// can still match it structurally.
+		return tc.check(node, exp.Inner())
+	case *rl.TypingUnionT:
+		// Assignable if the value fits any arm. We recurse rather than
+		// stop at the fast path so a literal can match a *structured*
+		// arm (tuple, struct, str-enum) that IsAssignableFrom rejects.
+		for _, arm := range exp.Types() {
+			if res := tc.check(node, arm); res.ok {
+				return accept(node, got, expected)
+			}
+		}
+		return reject(node, got, expected)
+	}
+
+	// Structural literal rules.
+	switch lit := node.(type) {
+	case *rl.LitList:
+		return tc.checkListLit(lit, expected, got)
+	case *rl.LitMap:
+		return tc.checkMapLit(lit, expected, got)
+	case *rl.LitString:
+		if enum, isEnum := expected.(*rl.TypingStrEnumT); isEnum && lit.Simple && strEnumContains(enum, lit.Value) {
+			return accept(node, got, expected)
+		}
+	}
+
+	return reject(node, got, expected)
+}
+
+// checkListLit checks a list literal against a tuple, list, or open-list
+// target. Tuple targets check position-wise (arity must match); list
+// targets check every element against the declared element type. Any other
+// target falls back to the synthesized list type's assignability.
+func (tc *typeChecker) checkListLit(lit *rl.LitList, expected, got rl.TypingT) checkResult {
+	switch exp := expected.(type) {
+	case *rl.TypingTupleT:
+		types := exp.Types()
+		if len(types) != len(lit.Elements) {
+			// Arity mismatch: nothing finer to point at than the literal.
+			return reject(lit, got, expected)
+		}
+		for i, elem := range lit.Elements {
+			if res := tc.check(elem, types[i]); !res.ok {
+				return res
+			}
+		}
+		return accept(lit, got, expected)
+	case *rl.TypingListT:
+		elemT := exp.Elem()
+		for _, elem := range lit.Elements {
+			if res := tc.check(elem, elemT); !res.ok {
+				return res
+			}
+		}
+		return accept(lit, got, expected)
+	case *rl.TypingAnyListT:
+		// Open `list` annotation - any list literal satisfies it.
+		return accept(lit, got, expected)
+	}
+	// check's fast path already ruled out plain assignability before
+	// dispatching here, so any non-structured target is a genuine miss.
+	return reject(lit, got, expected)
+}
+
+// checkMapLit checks a map literal against a struct or map target. A struct
+// target requires every entry key to be a plain string literal naming a
+// declared field, each value to fit its field type, and every required
+// field to be present. A map target checks all keys against K and all
+// values against V. Other targets fall back to assignability.
+func (tc *typeChecker) checkMapLit(lit *rl.LitMap, expected, got rl.TypingT) checkResult {
+	switch exp := expected.(type) {
+	case *rl.TypingStructT:
+		seen := make(map[string]bool, len(lit.Entries))
+		for _, entry := range lit.Entries {
+			name, isStr := simpleStringKey(entry.Key)
+			if !isStr {
+				// A computed/interpolated key can't be matched to a named
+				// field statically. Point at the key.
+				return reject(entry.Key, got, expected)
+			}
+			fieldT, _, found := exp.Field(name)
+			if !found {
+				return reject(entry.Key, got, expected)
+			}
+			if res := tc.check(entry.Value, fieldT); !res.ok {
+				return res
+			}
+			seen[name] = true
+		}
+		// Every required (non-optional) field must be supplied.
+		for key := range exp.Fields() {
+			if !key.IsOptional && !seen[key.Name] {
+				return reject(lit, got, expected)
+			}
+		}
+		return accept(lit, got, expected)
+	case *rl.TypingMapT:
+		keyT, valT := exp.KeyT(), exp.ValT()
+		for _, entry := range lit.Entries {
+			if res := tc.check(entry.Key, keyT); !res.ok {
+				return res
+			}
+			if res := tc.check(entry.Value, valT); !res.ok {
+				return res
+			}
+		}
+		return accept(lit, got, expected)
+	case *rl.TypingAnyMapT:
+		// Open `map` annotation - any map literal satisfies it.
+		return accept(lit, got, expected)
+	}
+	// check's fast path already ruled out plain assignability before
+	// dispatching here, so any non-structured target is a genuine miss.
+	return reject(lit, got, expected)
+}
+
+// simpleStringKey returns the value of a plain (non-interpolated) string
+// literal key and true; anything else (interpolated string, identifier,
+// computed expression) returns false - it can't be matched to a named
+// struct field statically.
+func simpleStringKey(key rl.Node) (string, bool) {
+	lit, isStr := key.(*rl.LitString)
+	if !isStr || !lit.Simple {
+		return "", false
+	}
+	return lit.Value, true
+}
+
+func strEnumContains(enum *rl.TypingStrEnumT, value string) bool {
+	for _, v := range enum.Values() {
+		if v == value {
+			return true
+		}
+	}
+	return false
+}
+
+func accept(node rl.Node, got, want rl.TypingT) checkResult {
+	return checkResult{ok: true, offending: node, got: got, want: want}
+}
+
+func reject(node rl.Node, got, want rl.TypingT) checkResult {
+	return checkResult{ok: false, offending: node, got: got, want: want}
+}

--- a/rts/check/snapshots/collection_mut/indexed_assign.snap
+++ b/rts/check/snapshots/collection_mut/indexed_assign.snap
@@ -218,7 +218,7 @@ xs[0] = 1 + "not a number"
   xs (local): int[]
 
 # Diagnostics
-  [hint] RAD30002 @ 2:9 - Invalid operand types: cannot do 'int + str'
+  [error] RAD30002 @ 2:9 - Invalid operand types: cannot do 'int + str'
     help: In v0.9, + no longer coerces types. Use string interpolation instead. See: https://amterp.dev/rad/migrations/v0.9/
 ### TITLE ###
 NarrowedOptionalListChecks

--- a/rts/check/snapshots/collection_mut/indexed_assign.snap
+++ b/rts/check/snapshots/collection_mut/indexed_assign.snap
@@ -34,7 +34,7 @@ xs[0] = "wrong"
   xs (local): int[]
 
 # Diagnostics
-  [hint] RAD30010 @ 2:9 - Value of type 'str' is not assignable to element type 'int'
+  [error] RAD30010 @ 2:9 - Value of type 'str' is not assignable to element type 'int'
 ### TITLE ###
 TypedMapIndexedAssignOk
 ### DESCRIPTION ###
@@ -69,7 +69,7 @@ m["b"] = "wrong"
   m (local): { str: int }
 
 # Diagnostics
-  [hint] RAD30010 @ 2:10 - Value of type 'str' is not assignable to element type 'int'
+  [error] RAD30010 @ 2:10 - Value of type 'str' is not assignable to element type 'int'
 ### TITLE ###
 ParamIndexedAssignMismatch
 ### DESCRIPTION ###
@@ -87,7 +87,7 @@ fn f(xs: int[]):
   xs (param): int[]
 
 # Diagnostics
-  [hint] RAD30010 @ 2:13 - Value of type 'str' is not assignable to element type 'int'
+  [error] RAD30010 @ 2:13 - Value of type 'str' is not assignable to element type 'int'
 ### TITLE ###
 UntypedListSkipsCheck
 ### DESCRIPTION ###
@@ -240,4 +240,4 @@ fn f(xs: int[]?):
   xs (param): int[]?
 
 # Diagnostics
-  [hint] RAD30010 @ 3:17 - Value of type 'str' is not assignable to element type 'int'
+  [error] RAD30010 @ 3:17 - Value of type 'str' is not assignable to element type 'int'

--- a/rts/check/snapshots/fallible.snap
+++ b/rts/check/snapshots/fallible.snap
@@ -1,0 +1,160 @@
+### TITLE ###
+UnguardedFallibleStripsAndHints
+### DESCRIPTION ###
+An unhandled fallible call (parse_int) strips its error arm to the
+success type (int), so `a + 1` type-checks. The call carries a hint
+nudging the user to handle the error. Gap 2 panic-promotion model.
+### INPUT ###
+a = parse_int("2")
+print(a + 1)
+### STDOUT ###
+# Identifier types
+  a @ 1:1 -> <no-type>
+  parse_int @ 1:5 -> dynamic
+  print @ 2:1 -> dynamic
+  a @ 2:7 -> int
+
+# Symbol types
+  a (local): int
+
+# Diagnostics
+  [hint] RAD30011 @ 1:5 - This call can fail; the error isn't handled and would halt the script
+    help: Handle it with `catch` or `??`, e.g. `x = <call> catch <fallback>`
+### TITLE ###
+CatchExpressionSuppressesHint
+### DESCRIPTION ###
+A `catch` expression handles the error, so no unhandled-fallible
+hint fires and the result is int.
+### INPUT ###
+a = parse_int("2") catch 0
+print(a + 1)
+### STDOUT ###
+# Identifier types
+  a @ 1:1 -> <no-type>
+  parse_int @ 1:5 -> dynamic
+  print @ 2:1 -> dynamic
+  a @ 2:7 -> int
+
+# Symbol types
+  a (local): int
+
+# Diagnostics
+  (none)
+### TITLE ###
+FallbackOperatorSuppressesHint
+### DESCRIPTION ###
+The `??` operator catches the error-panic at runtime, so it counts
+as a guard: no hint, result is int.
+### INPUT ###
+a = parse_int("2") ?? 0
+print(a + 1)
+### STDOUT ###
+# Identifier types
+  a @ 1:1 -> <no-type>
+  parse_int @ 1:5 -> dynamic
+  print @ 2:1 -> dynamic
+  a @ 2:7 -> int
+
+# Symbol types
+  a (local): int
+
+# Diagnostics
+  (none)
+### TITLE ###
+FallibleInsideGuardedExprNoOpError
+### DESCRIPTION ###
+A fallible call inside a guarded expression must not flag the
+operator OR the call. The error panics before the `+` runs and the
+catch handles the whole `(parse_int(..) + 1)` expression, so neither
+RAD30011 nor RAD30002 may fire. Regression lock on always-strip +
+guard tracking. (Parens are required: `catch` binds tighter than
+`+`, so without them the call sits outside the catch and is
+genuinely unguarded.)
+### INPUT ###
+r = (parse_int("2") + 1) catch 0
+print(r)
+### STDOUT ###
+# Identifier types
+  r @ 1:1 -> <no-type>
+  parse_int @ 1:6 -> dynamic
+  print @ 2:1 -> dynamic
+  r @ 2:7 -> int
+
+# Symbol types
+  r (local): int
+
+# Diagnostics
+  (none)
+### TITLE ###
+StatementCatchBindsErrorInBody
+### DESCRIPTION ###
+A statement-level catch suppresses the hint; inside the catch body
+the assignment target carries type error, while the assigned value
+is int outside.
+### INPUT ###
+a = parse_int("2") catch:
+    print(a)
+    yield 0
+### STDOUT ###
+# Identifier types
+  a @ 1:1 -> <no-type>
+  parse_int @ 1:5 -> dynamic
+  print @ 2:5 -> dynamic
+  a @ 2:11 -> error
+
+# Symbol types
+  a (local): int
+
+# Diagnostics
+  (none)
+### TITLE ###
+ErrorBuiltinKeepsErrorValue
+### DESCRIPTION ###
+The error() builtin is the one call the runtime does not panic-
+promote, so its result stays type error and no unhandled-fallible
+hint fires.
+### INPUT ###
+e = error("boom")
+print(e)
+### STDOUT ###
+# Identifier types
+  e @ 1:1 -> <no-type>
+  error @ 1:5 -> dynamic
+  print @ 2:1 -> dynamic
+  e @ 2:7 -> error
+
+# Symbol types
+  e (local): error
+
+# Diagnostics
+  (none)
+### TITLE ###
+UserFnUnionStripsAndHints
+### DESCRIPTION ###
+A user fn declaring -> int|error panic-promotes like any call, so
+an unguarded call strips to int and gets the hint; the parse_int
+inside the fn body is guarded by its own catch.
+### INPUT ###
+fn maybe(s: str) -> int|error:
+    return parse_int(s) catch error("nope")
+
+x = maybe("2")
+print(x + 1)
+### STDOUT ###
+# Identifier types
+  parse_int @ 2:12 -> dynamic
+  s @ 2:22 -> str
+  error @ 2:31 -> dynamic
+  x @ 4:1 -> <no-type>
+  maybe @ 4:5 -> fn(str) -> int|error
+  print @ 5:1 -> dynamic
+  x @ 5:7 -> int
+
+# Symbol types
+  maybe (fn): fn(str) -> int|error
+  s (param): str
+  x (local): int
+
+# Diagnostics
+  [hint] RAD30011 @ 4:5 - This call can fail; the error isn't handled and would halt the script
+    help: Handle it with `catch` or `??`, e.g. `x = <call> catch <fallback>`

--- a/rts/check/snapshots/fn_value/declared_return.snap
+++ b/rts/check/snapshots/fn_value/declared_return.snap
@@ -14,7 +14,7 @@ fn cb(x: int) -> bool:
   cb (fn): fn(int) -> bool
 
 # Diagnostics
-  [hint] RAD30001 @ 2:5 - Return value of type 'str' is not assignable to declared return type 'bool'
+  [hint] RAD30001 @ 2:12 - Return value of type 'str' is not assignable to declared return type 'bool'
 ### TITLE ###
 HoistedFnMultipleReturnsEachChecked
 ### DESCRIPTION ###
@@ -34,8 +34,8 @@ fn cb(x: int) -> bool:
   x (param): int
 
 # Diagnostics
-  [hint] RAD30001 @ 3:9 - Return value of type 'int' is not assignable to declared return type 'bool'
-  [hint] RAD30001 @ 4:5 - Return value of type 'str' is not assignable to declared return type 'bool'
+  [hint] RAD30001 @ 3:16 - Return value of type 'int' is not assignable to declared return type 'bool'
+  [hint] RAD30001 @ 4:12 - Return value of type 'str' is not assignable to declared return type 'bool'
 ### TITLE ###
 HoistedFnReturnMatchesDeclared
 ### DESCRIPTION ###

--- a/rts/check/snapshots/fn_value/declared_return.snap
+++ b/rts/check/snapshots/fn_value/declared_return.snap
@@ -77,6 +77,26 @@ fn cb(x: int) -> bool:
 # Diagnostics
   (none)
 ### TITLE ###
+DeclaredAnyArrayReturnAcceptsInferredList
+### DESCRIPTION ###
+A fn declared `-> any[]` returning an empty `[]` literal (which
+infers to the generic `list`) must type-check clean. Regression
+lock: `any[]` collapses to `list`, so the inferred list satisfies
+it. Before the fix, `any[]` was a distinct TypingListT that
+rejected the generic list and fired a spurious mismatch.
+### INPUT ###
+fn f() -> any[]:
+    return []
+### STDOUT ###
+# Identifier types
+  (none)
+
+# Symbol types
+  f (fn): fn() -> list
+
+# Diagnostics
+  (none)
+### TITLE ###
 NestedFnReturnIsolated
 ### DESCRIPTION ###
 A return inside a nested fn belongs to the nested fn, not the

--- a/rts/check/snapshots/fn_value/declared_return.snap
+++ b/rts/check/snapshots/fn_value/declared_return.snap
@@ -14,7 +14,7 @@ fn cb(x: int) -> bool:
   cb (fn): fn(int) -> bool
 
 # Diagnostics
-  [hint] RAD30001 @ 2:12 - Return value of type 'str' is not assignable to declared return type 'bool'
+  [error] RAD30001 @ 2:12 - Return value of type 'str' is not assignable to declared return type 'bool'
 ### TITLE ###
 HoistedFnMultipleReturnsEachChecked
 ### DESCRIPTION ###
@@ -34,8 +34,8 @@ fn cb(x: int) -> bool:
   x (param): int
 
 # Diagnostics
-  [hint] RAD30001 @ 3:16 - Return value of type 'int' is not assignable to declared return type 'bool'
-  [hint] RAD30001 @ 4:12 - Return value of type 'str' is not assignable to declared return type 'bool'
+  [error] RAD30001 @ 3:16 - Return value of type 'int' is not assignable to declared return type 'bool'
+  [error] RAD30001 @ 4:12 - Return value of type 'str' is not assignable to declared return type 'bool'
 ### TITLE ###
 HoistedFnReturnMatchesDeclared
 ### DESCRIPTION ###

--- a/rts/check/snapshots/fn_value/structural_match.snap
+++ b/rts/check/snapshots/fn_value/structural_match.snap
@@ -54,7 +54,7 @@ process(cb)
   process (fn): fn(fn(int) -> bool) -> void
 
 # Diagnostics
-  [hint] RAD30001 @ 7:9 - Argument type 'fn(int) -> str' is not assignable to expected type 'fn(int) -> bool'
+  [error] RAD30001 @ 7:9 - Argument type 'fn(int) -> str' is not assignable to expected type 'fn(int) -> bool'
 ### TITLE ###
 FnValueParamTypeMismatchFires
 ### DESCRIPTION ###
@@ -83,7 +83,7 @@ process(cb)
   x (param): str
 
 # Diagnostics
-  [hint] RAD30001 @ 7:9 - Argument type 'fn(str) -> bool' is not assignable to expected type 'fn(int) -> bool'
+  [error] RAD30001 @ 7:9 - Argument type 'fn(str) -> bool' is not assignable to expected type 'fn(int) -> bool'
 ### TITLE ###
 FnValueWiderParamOkContravariance
 ### DESCRIPTION ###
@@ -141,7 +141,7 @@ process(cb)
   y (param): int
 
 # Diagnostics
-  [hint] RAD30001 @ 7:9 - Argument type 'fn(int, int) -> bool' is not assignable to expected type 'fn(int) -> bool'
+  [error] RAD30001 @ 7:9 - Argument type 'fn(int, int) -> bool' is not assignable to expected type 'fn(int) -> bool'
 ### TITLE ###
 FnValueUntypedParamAcceptsAnything
 ### DESCRIPTION ###
@@ -193,7 +193,7 @@ process(fn(x) "hi")
   process (fn): fn(fn(int) -> bool) -> void
 
 # Diagnostics
-  [hint] RAD30001 @ 4:9 - Argument type 'fn(any) -> str' is not assignable to expected type 'fn(int) -> bool'
+  [error] RAD30001 @ 4:9 - Argument type 'fn(any) -> str' is not assignable to expected type 'fn(int) -> bool'
 ### TITLE ###
 LambdaExprRightShapeOk
 ### DESCRIPTION ###
@@ -246,7 +246,7 @@ process(fn(x):
   x (param): <no-type>
 
 # Diagnostics
-  [hint] RAD30001 @ 4:9 - Argument type 'fn(any) -> int|str' is not assignable to expected type 'fn(int) -> bool'
+  [error] RAD30001 @ 4:9 - Argument type 'fn(any) -> int|str' is not assignable to expected type 'fn(int) -> bool'
 ### TITLE ###
 LambdaBlockNoReturnIsVoid
 ### DESCRIPTION ###
@@ -272,7 +272,7 @@ process(fn(x):
   x (param): <no-type>
 
 # Diagnostics
-  [hint] RAD30001 @ 4:9 - Argument type 'fn(any) -> void' is not assignable to expected type 'fn(int) -> bool'
+  [error] RAD30001 @ 4:9 - Argument type 'fn(any) -> void' is not assignable to expected type 'fn(int) -> bool'
 ### TITLE ###
 LambdaDeclaredReturnMismatchFiresAtReturn
 ### DESCRIPTION ###
@@ -297,4 +297,4 @@ process(fn(x) -> bool: return "hi")
 
 # Diagnostics
   [error] RAD10001 @ 4:24 - Invalid function syntax
-  [hint] RAD30001 @ 4:31 - Return value of type 'str' is not assignable to declared return type 'bool'
+  [error] RAD30001 @ 4:31 - Return value of type 'str' is not assignable to declared return type 'bool'

--- a/rts/check/snapshots/fn_value/tuple_return.snap
+++ b/rts/check/snapshots/fn_value/tuple_return.snap
@@ -45,7 +45,7 @@ process(fn(x):
   process (fn): fn(fn(int) -> [int, str]) -> void
 
 # Diagnostics
-  [hint] RAD30001 @ 4:9 - Argument type 'fn(any) -> [int, int]' is not assignable to expected type 'fn(int) -> [int, str]'
+  [error] RAD30001 @ 4:9 - Argument type 'fn(any) -> [int, int]' is not assignable to expected type 'fn(int) -> [int, str]'
 ### TITLE ###
 LambdaTupleArityMismatchFires
 ### DESCRIPTION ###
@@ -69,7 +69,7 @@ process(fn(x):
   process (fn): fn(fn(int) -> [int, str]) -> void
 
 # Diagnostics
-  [hint] RAD30001 @ 4:9 - Argument type 'fn(any) -> [int, str, bool]' is not assignable to expected type 'fn(int) -> [int, str]'
+  [error] RAD30001 @ 4:9 - Argument type 'fn(any) -> [int, str, bool]' is not assignable to expected type 'fn(int) -> [int, str]'
 ### TITLE ###
 HoistedFnTupleReturnAnnotationHonored
 ### DESCRIPTION ###

--- a/rts/check/snapshots/lit_check/gateable_boundary.snap
+++ b/rts/check/snapshots/lit_check/gateable_boundary.snap
@@ -1,0 +1,133 @@
+### TITLE ###
+OpenListIntoTypedParamStaysHint
+### DESCRIPTION ###
+A value typed as the open gradual `list` flowing into a structured
+`int[]` parameter cannot be proven wrong - the runtime contents
+might all be ints - so the mismatch is a non-gating Hint, never an
+Error. Guards the gateableMismatch gradual-container rule.
+### INPUT ###
+fn outer(x: list):
+    want_ints(x)
+
+fn want_ints(xs: int[]):
+    print(xs)
+### STDOUT ###
+# Identifier types
+  want_ints @ 2:5 -> fn(int[]) -> void
+  x @ 2:15 -> list
+  print @ 5:5 -> dynamic
+  xs @ 5:11 -> int[]
+
+# Symbol types
+  outer (fn): fn(list) -> void
+  want_ints (fn): fn(int[]) -> void
+  x (param): list
+  xs (param): int[]
+
+# Diagnostics
+  [hint] RAD30001 @ 2:15 - Argument type 'list' is not assignable to expected type 'int[]'
+### TITLE ###
+StrVariableIntoStrEnumStaysHint
+### DESCRIPTION ###
+A plain `str` variable (value unknown to the checker) flowing into
+a str-enum parameter stays a Hint: its runtime value decides
+membership. Only a simple string *literal* outside the members is
+provably wrong (see structural.snap StrLiteralIntoStrEnum cases).
+### INPUT ###
+fn pick(mode: ["read", "write"]):
+    print(mode)
+
+fn outer(s: str):
+    pick(s)
+### STDOUT ###
+# Identifier types
+  print @ 2:5 -> dynamic
+  mode @ 2:11 -> ["read", "write"]
+  pick @ 5:5 -> fn(["read", "write"]) -> void
+  s @ 5:10 -> str
+
+# Symbol types
+  mode (param): ["read", "write"]
+  outer (fn): fn(str) -> void
+  pick (fn): fn(["read", "write"]) -> void
+  s (param): str
+
+# Diagnostics
+  [hint] RAD30001 @ 5:10 - Argument type 'str' is not assignable to expected type '["read", "write"]'
+### TITLE ###
+UnionWithFittingArmStaysHint
+### DESCRIPTION ###
+An `int|str` argument into an `int` parameter stays a Hint: one arm
+(int) would fit at runtime, so the mismatch isn't provable. Guards
+gateableMismatch's union-arm recursion.
+### INPUT ###
+fn want_int(n: int):
+    print(n)
+
+fn outer(x: int|str):
+    want_int(x)
+### STDOUT ###
+# Identifier types
+  print @ 2:5 -> dynamic
+  n @ 2:11 -> int
+  want_int @ 5:5 -> fn(int) -> void
+  x @ 5:14 -> int|str
+
+# Symbol types
+  n (param): int
+  outer (fn): fn(int|str) -> void
+  want_int (fn): fn(int) -> void
+  x (param): int|str
+
+# Diagnostics
+  [hint] RAD30001 @ 5:14 - Argument type 'int|str' is not assignable to expected type 'int'
+### TITLE ###
+OptionalWithFittingInnerStaysHint
+### DESCRIPTION ###
+A `str?` argument into a `str` parameter stays a Hint: the value
+might be the present (str) arm rather than null. Guards the optional
+branch of gateableMismatch.
+### INPUT ###
+fn want_str(s: str):
+    print(s)
+
+fn outer(x: str?):
+    want_str(x)
+### STDOUT ###
+# Identifier types
+  print @ 2:5 -> dynamic
+  s @ 2:11 -> str
+  want_str @ 5:5 -> fn(str) -> void
+  x @ 5:14 -> str?
+
+# Symbol types
+  outer (fn): fn(str?) -> void
+  s (param): str
+  want_str (fn): fn(str) -> void
+  x (param): str?
+
+# Diagnostics
+  [hint] RAD30001 @ 5:14 - Argument type 'str?' is not assignable to expected type 'str'
+### TITLE ###
+ConcreteMismatchGates
+### DESCRIPTION ###
+The contrast case: a provably-incompatible concrete argument (int
+into str) IS an Error. Confirms the boundary - uncertainty downgrades
+to Hint, certainty gates.
+### INPUT ###
+fn want_str(s: str):
+    print(s)
+
+want_str(42)
+### STDOUT ###
+# Identifier types
+  print @ 2:5 -> dynamic
+  s @ 2:11 -> str
+  want_str @ 4:1 -> fn(str) -> void
+
+# Symbol types
+  s (param): str
+  want_str (fn): fn(str) -> void
+
+# Diagnostics
+  [error] RAD30001 @ 4:10 - Argument type 'int' is not assignable to expected type 'str'

--- a/rts/check/snapshots/lit_check/structural.snap
+++ b/rts/check/snapshots/lit_check/structural.snap
@@ -117,7 +117,7 @@ print(f())
   f (fn): fn() -> { "a": int, "b": str }
 
 # Diagnostics
-  [error] RAD30001 @ 2:12 - Return value of type '{ str: int }' is not assignable to declared return type '{ "a": int, "b": str }'
+  [error] RAD30001 @ 2:12 - Return value of type '{ str: int }' is not assignable to declared return type '{ "a": int, "b": str }' (missing required field 'b')
 ### TITLE ###
 StructExtraFieldAccepted
 ### DESCRIPTION ###

--- a/rts/check/snapshots/lit_check/structural.snap
+++ b/rts/check/snapshots/lit_check/structural.snap
@@ -38,7 +38,7 @@ print(f())
   f (fn): fn() -> [int, str]
 
 # Diagnostics
-  [hint] RAD30001 @ 2:16 - Return value of type 'int' is not assignable to declared return type 'str'
+  [error] RAD30001 @ 2:16 - Return value of type 'int' is not assignable to declared return type 'str'
 ### TITLE ###
 MapLiteralIntoStructAccepts
 ### DESCRIPTION ###
@@ -77,7 +77,7 @@ print(f())
   f (fn): fn() -> { "k": int }
 
 # Diagnostics
-  [hint] RAD30001 @ 2:19 - Return value of type 'str' is not assignable to declared return type 'int'
+  [error] RAD30001 @ 2:19 - Return value of type 'str' is not assignable to declared return type 'int'
 ### TITLE ###
 StructOptionalFieldOmittedAccepts
 ### DESCRIPTION ###
@@ -117,12 +117,13 @@ print(f())
   f (fn): fn() -> { "a": int, "b": str }
 
 # Diagnostics
-  [hint] RAD30001 @ 2:12 - Return value of type '{ str: int }' is not assignable to declared return type '{ "a": int, "b": str }'
+  [error] RAD30001 @ 2:12 - Return value of type '{ str: int }' is not assignable to declared return type '{ "a": int, "b": str }'
 ### TITLE ###
-StructUnknownFieldFires
+StructExtraFieldAccepted
 ### DESCRIPTION ###
-A field name not present in the struct target fires, localized to
-the offending key.
+Extra keys beyond the declared struct shape are allowed - the
+runtime ignores them, so `{ "a": 1, "b": 2 }` satisfies
+`{ "a": int }`. No diagnostic.
 ### INPUT ###
 fn f() -> { "a": int }:
     return { "a": 1, "b": 2 }
@@ -137,7 +138,7 @@ print(f())
   f (fn): fn() -> { "a": int }
 
 # Diagnostics
-  [hint] RAD30001 @ 2:22 - Return value of type '{ str: int }' is not assignable to declared return type '{ "a": int }'
+  (none)
 ### TITLE ###
 StrLiteralIntoStrEnumArgAccepts
 ### DESCRIPTION ###
@@ -180,7 +181,7 @@ pick("delete")
   pick (fn): fn(["read", "write"]) -> void
 
 # Diagnostics
-  [hint] RAD30001 @ 4:6 - Argument type 'str' is not assignable to expected type '["read", "write"]'
+  [error] RAD30001 @ 4:6 - Argument type 'str' is not assignable to expected type '["read", "write"]'
 ### TITLE ###
 NestedMapListIntoStructTupleAccepts
 ### DESCRIPTION ###
@@ -220,7 +221,7 @@ print(f())
   f (fn): fn() -> { "k": [int, str] }
 
 # Diagnostics
-  [hint] RAD30001 @ 2:23 - Return value of type 'int' is not assignable to declared return type 'str'
+  [error] RAD30001 @ 2:23 - Return value of type 'int' is not assignable to declared return type 'str'
 ### TITLE ###
 AssignListLiteralIntoTupleLocalAccepts
 ### DESCRIPTION ###
@@ -259,4 +260,4 @@ print(xs)
   xs (local): int[]
 
 # Diagnostics
-  [hint] RAD30010 @ 2:9 - Value of type 'str' is not assignable to element type 'int'
+  [error] RAD30010 @ 2:9 - Value of type 'str' is not assignable to element type 'int'

--- a/rts/check/snapshots/lit_check/structural.snap
+++ b/rts/check/snapshots/lit_check/structural.snap
@@ -1,0 +1,262 @@
+### TITLE ###
+ListLiteralIntoTupleAccepts
+### DESCRIPTION ###
+Gap-1 structural check: a list literal whose elements match a
+tuple type position-wise is accepted, even though its synthesized
+type `(int|str)[]` can't satisfy the invariant tuple type.
+### INPUT ###
+fn f() -> [int, str]:
+    return [1, "2"]
+
+print(f())
+### STDOUT ###
+# Identifier types
+  print @ 4:1 -> dynamic
+  f @ 4:7 -> fn() -> [int, str]
+
+# Symbol types
+  f (fn): fn() -> [int, str]
+
+# Diagnostics
+  (none)
+### TITLE ###
+ListLiteralIntoTupleElementMismatchLocalized
+### DESCRIPTION ###
+A genuine element mismatch still fires, localized to the offending
+element (the second value) rather than the whole literal.
+### INPUT ###
+fn f() -> [int, str]:
+    return [1, 2]
+
+print(f())
+### STDOUT ###
+# Identifier types
+  print @ 4:1 -> dynamic
+  f @ 4:7 -> fn() -> [int, str]
+
+# Symbol types
+  f (fn): fn() -> [int, str]
+
+# Diagnostics
+  [hint] RAD30001 @ 2:16 - Return value of type 'int' is not assignable to declared return type 'str'
+### TITLE ###
+MapLiteralIntoStructAccepts
+### DESCRIPTION ###
+A map literal with the right field name and value type matches a
+named-key struct target field-wise.
+### INPUT ###
+fn f() -> { "k": int }:
+    return { "k": 10 }
+
+print(f())
+### STDOUT ###
+# Identifier types
+  print @ 4:1 -> dynamic
+  f @ 4:7 -> fn() -> { "k": int }
+
+# Symbol types
+  f (fn): fn() -> { "k": int }
+
+# Diagnostics
+  (none)
+### TITLE ###
+MapLiteralIntoStructValueMismatchLocalized
+### DESCRIPTION ###
+A wrong field value fires, localized to the offending value node.
+### INPUT ###
+fn f() -> { "k": int }:
+    return { "k": "x" }
+
+print(f())
+### STDOUT ###
+# Identifier types
+  print @ 4:1 -> dynamic
+  f @ 4:7 -> fn() -> { "k": int }
+
+# Symbol types
+  f (fn): fn() -> { "k": int }
+
+# Diagnostics
+  [hint] RAD30001 @ 2:19 - Return value of type 'str' is not assignable to declared return type 'int'
+### TITLE ###
+StructOptionalFieldOmittedAccepts
+### DESCRIPTION ###
+Optional struct fields may be absent; required fields present is
+enough to accept.
+### INPUT ###
+fn f() -> { "a": int, "b"?: str }:
+    return { "a": 1 }
+
+print(f())
+### STDOUT ###
+# Identifier types
+  print @ 4:1 -> dynamic
+  f @ 4:7 -> fn() -> { "a": int, "b"?: str }
+
+# Symbol types
+  f (fn): fn() -> { "a": int, "b"?: str }
+
+# Diagnostics
+  (none)
+### TITLE ###
+StructMissingRequiredFieldFires
+### DESCRIPTION ###
+A required field that's absent fires (at the whole literal - there
+is no single offending node to point at for an omission).
+### INPUT ###
+fn f() -> { "a": int, "b": str }:
+    return { "a": 1 }
+
+print(f())
+### STDOUT ###
+# Identifier types
+  print @ 4:1 -> dynamic
+  f @ 4:7 -> fn() -> { "a": int, "b": str }
+
+# Symbol types
+  f (fn): fn() -> { "a": int, "b": str }
+
+# Diagnostics
+  [hint] RAD30001 @ 2:12 - Return value of type '{ str: int }' is not assignable to declared return type '{ "a": int, "b": str }'
+### TITLE ###
+StructUnknownFieldFires
+### DESCRIPTION ###
+A field name not present in the struct target fires, localized to
+the offending key.
+### INPUT ###
+fn f() -> { "a": int }:
+    return { "a": 1, "b": 2 }
+
+print(f())
+### STDOUT ###
+# Identifier types
+  print @ 4:1 -> dynamic
+  f @ 4:7 -> fn() -> { "a": int }
+
+# Symbol types
+  f (fn): fn() -> { "a": int }
+
+# Diagnostics
+  [hint] RAD30001 @ 2:22 - Return value of type '{ str: int }' is not assignable to declared return type '{ "a": int }'
+### TITLE ###
+StrLiteralIntoStrEnumArgAccepts
+### DESCRIPTION ###
+A plain string literal that's a member of a str-enum parameter is
+accepted (folds in the former litMatchesStrEnum special case).
+### INPUT ###
+fn pick(mode: ["read", "write"]):
+    print(mode)
+
+pick("read")
+### STDOUT ###
+# Identifier types
+  print @ 2:5 -> dynamic
+  mode @ 2:11 -> ["read", "write"]
+  pick @ 4:1 -> fn(["read", "write"]) -> void
+
+# Symbol types
+  mode (param): ["read", "write"]
+  pick (fn): fn(["read", "write"]) -> void
+
+# Diagnostics
+  (none)
+### TITLE ###
+StrLiteralIntoStrEnumArgNonMemberFires
+### DESCRIPTION ###
+A string literal outside the str-enum members fires.
+### INPUT ###
+fn pick(mode: ["read", "write"]):
+    print(mode)
+
+pick("delete")
+### STDOUT ###
+# Identifier types
+  print @ 2:5 -> dynamic
+  mode @ 2:11 -> ["read", "write"]
+  pick @ 4:1 -> fn(["read", "write"]) -> void
+
+# Symbol types
+  mode (param): ["read", "write"]
+  pick (fn): fn(["read", "write"]) -> void
+
+# Diagnostics
+  [hint] RAD30001 @ 4:6 - Argument type 'str' is not assignable to expected type '["read", "write"]'
+### TITLE ###
+NestedMapListIntoStructTupleAccepts
+### DESCRIPTION ###
+Nesting composes: a map literal holding a list literal checks
+field-wise then position-wise against `{ "k": [int, str] }`.
+### INPUT ###
+fn f() -> { "k": [int, str] }:
+    return { "k": [1, "2"] }
+
+print(f())
+### STDOUT ###
+# Identifier types
+  print @ 4:1 -> dynamic
+  f @ 4:7 -> fn() -> { "k": [int, str] }
+
+# Symbol types
+  f (fn): fn() -> { "k": [int, str] }
+
+# Diagnostics
+  (none)
+### TITLE ###
+NestedMismatchLocalizedToInnerElement
+### DESCRIPTION ###
+A mismatch buried two levels deep is localized to the innermost
+offending element.
+### INPUT ###
+fn f() -> { "k": [int, str] }:
+    return { "k": [1, 2] }
+
+print(f())
+### STDOUT ###
+# Identifier types
+  print @ 4:1 -> dynamic
+  f @ 4:7 -> fn() -> { "k": [int, str] }
+
+# Symbol types
+  f (fn): fn() -> { "k": [int, str] }
+
+# Diagnostics
+  [hint] RAD30001 @ 2:23 - Return value of type 'int' is not assignable to declared return type 'str'
+### TITLE ###
+AssignListLiteralIntoTupleLocalAccepts
+### DESCRIPTION ###
+The declared-local assignment site runs through the same check.
+### INPUT ###
+x: [int, str] = [1, "2"]
+print(x)
+### STDOUT ###
+# Identifier types
+  x @ 1:1 -> <no-type>
+  print @ 2:1 -> dynamic
+  x @ 2:7 -> [int, str]
+
+# Symbol types
+  x (local): [int, str]
+
+# Diagnostics
+  (none)
+### TITLE ###
+IndexedAssignElementLiteralChecks
+### DESCRIPTION ###
+The indexed-assign site checks the written value against the
+declared element type via the same structural path.
+### INPUT ###
+xs: int[] = [1]
+xs[0] = "x"
+print(xs)
+### STDOUT ###
+# Identifier types
+  xs @ 1:1 -> <no-type>
+  xs @ 2:1 -> int[]
+  print @ 3:1 -> dynamic
+  xs @ 3:7 -> int[]
+
+# Symbol types
+  xs (local): int[]
+
+# Diagnostics
+  [hint] RAD30010 @ 2:9 - Value of type 'str' is not assignable to element type 'int'

--- a/rts/check/snapshots/narrow/args_block.snap
+++ b/rts/check/snapshots/narrow/args_block.snap
@@ -24,7 +24,7 @@ greet(name)
   name (arg): str
 
 # Diagnostics
-  [hint] RAD30001 @ 7:7 - Argument type 'str' is not assignable to expected type 'int'
+  [error] RAD30001 @ 7:7 - Argument type 'str' is not assignable to expected type 'int'
 ### TITLE ###
 ArgsBlockListUseCleanWhenSlotMatches
 ### DESCRIPTION ###
@@ -82,7 +82,7 @@ fn consume_int(label: int):
   on_build (fn): fn() -> void
 
 # Diagnostics
-  [hint] RAD30001 @ 6:17 - Argument type 'str' is not assignable to expected type 'int'
+  [error] RAD30001 @ 6:17 - Argument type 'str' is not assignable to expected type 'int'
 ### TITLE ###
 ArgsBlockOptionalIsNullable
 ### DESCRIPTION ###

--- a/rts/check/snapshots/narrow/catch.snap
+++ b/rts/check/snapshots/narrow/catch.snap
@@ -17,11 +17,11 @@ y = x
   print @ 2:5 -> dynamic
   x @ 2:11 -> error
   y @ 4:1 -> <no-type>
-  x @ 4:5 -> int|error
+  x @ 4:5 -> int
 
 # Symbol types
-  x (local): int|error
-  y (local): int|error
+  x (local): int
+  y (local): int
 
 # Diagnostics
   (none)
@@ -63,10 +63,10 @@ print(x)
   x @ 1:1 -> <no-type>
   parse_int @ 1:5 -> dynamic
   print @ 3:1 -> dynamic
-  x @ 3:7 -> int|error
+  x @ 3:7 -> int
 
 # Symbol types
-  x (local): int|error
+  x (local): int
 
 # Diagnostics
   (none)

--- a/rts/check/snapshots/narrow/for_loop.snap
+++ b/rts/check/snapshots/narrow/for_loop.snap
@@ -165,7 +165,7 @@ fn consume_str(s: str):
   v (loop): int
 
 # Diagnostics
-  [hint] RAD30001 @ 3:21 - Argument type 'int' is not assignable to expected type 'str'
+  [error] RAD30001 @ 3:21 - Argument type 'int' is not assignable to expected type 'str'
 ### TITLE ###
 ForTwoVarOverMapValueIsTyped
 ### DESCRIPTION ###

--- a/rts/check/snapshots/narrow/str_enum.snap
+++ b/rts/check/snapshots/narrow/str_enum.snap
@@ -157,7 +157,7 @@ open("append")
   open (fn): fn(["read", "write"]) -> void
 
 # Diagnostics
-  [hint] RAD30001 @ 6:6 - Argument type 'str' is not assignable to expected type '["read", "write"]'
+  [error] RAD30001 @ 6:6 - Argument type 'str' is not assignable to expected type '["read", "write"]'
 ### TITLE ###
 InLiteralListUpgradesPlainStrToEnum
 ### DESCRIPTION ###

--- a/rts/check/snapshots/narrow/typed_local.snap
+++ b/rts/check/snapshots/narrow/typed_local.snap
@@ -67,7 +67,7 @@ y = x
   y (local): int
 
 # Diagnostics
-  [hint] RAD30001 @ 1:10 - Value of type 'str' is not assignable to declared type 'int'
+  [error] RAD30001 @ 1:10 - Value of type 'str' is not assignable to declared type 'int'
 ### TITLE ###
 TypedLocalUntypedReassignIsClean
 ### DESCRIPTION ###
@@ -110,7 +110,7 @@ bb: str = "hi"
 
 # Diagnostics
   [error] RAD40011 @ 3:1 - Cannot re-declare 'bb' with a type annotation (originally declared on line 1); drop ': str' to reassign
-  [hint] RAD30001 @ 3:11 - Value of type 'str' is not assignable to declared type 'int'
+  [error] RAD30001 @ 3:11 - Value of type 'str' is not assignable to declared type 'int'
 ### TITLE ###
 TypedLocalRedeclarationSameTypeIsRejected
 ### DESCRIPTION ###
@@ -234,7 +234,7 @@ xs: int[] = ["a"]
   xs (local): int[]
 
 # Diagnostics
-  [hint] RAD30001 @ 1:14 - Value of type 'str' is not assignable to declared type 'int'
+  [error] RAD30001 @ 1:14 - Value of type 'str' is not assignable to declared type 'int'
 ### TITLE ###
 ParenTypeGroupOptionalWraps
 ### DESCRIPTION ###

--- a/rts/check/snapshots/narrow/typed_local.snap
+++ b/rts/check/snapshots/narrow/typed_local.snap
@@ -234,7 +234,7 @@ xs: int[] = ["a"]
   xs (local): int[]
 
 # Diagnostics
-  [hint] RAD30001 @ 1:13 - Value of type 'str[]' is not assignable to declared type 'int[]'
+  [hint] RAD30001 @ 1:14 - Value of type 'str' is not assignable to declared type 'int'
 ### TITLE ###
 ParenTypeGroupOptionalWraps
 ### DESCRIPTION ###

--- a/rts/check/type_check.go
+++ b/rts/check/type_check.go
@@ -157,13 +157,17 @@ func (tc *typeChecker) popReturnFrame() []rl.TypingT {
 // `-> [int, str]` is accepted: check walks the literal against the
 // tuple position-wise even though it synths to `(int|str)[]`.
 //
-// valNode is the single return-value expression when there is exactly
-// one (so check can localize a nested mismatch); it's nil for a `void`
-// return or a multi-value `return a, b` (whose synthesized tuple has no
-// single literal node to walk), in which case we fall back to a
-// whole-statement assignability check at spanNode, gating only when the
-// synthesized type carries no gradual container.
-func (tc *typeChecker) recordReturn(t rl.TypingT, spanNode rl.Node, valNode rl.Node) {
+// valNodes are the return-value expressions: one for `return x`, N for
+// `return a, b`, none for a bare `void` return. A single value is walked
+// structurally so a literal can match a structured target and a nested
+// mismatch localizes. A multi-value return against a tuple of matching
+// arity is walked position-wise, so `return 1, 2` satisfies
+// `[int|str, int]` and one bad element localizes - the same
+// provable-only gating used everywhere else. With nothing to walk (bare
+// return, or a shape we can't decompose) we fall back to a whole-type
+// assignability check at spanNode, gating only when the synthesized type
+// is concrete enough to be provably wrong (typeIsGateable).
+func (tc *typeChecker) recordReturn(t rl.TypingT, spanNode rl.Node, valNodes []rl.Node) {
 	n := len(tc.returnStack)
 	if n == 0 {
 		return
@@ -176,18 +180,14 @@ func (tc *typeChecker) recordReturn(t rl.TypingT, spanNode rl.Node, valNode rl.N
 	if isErrorType(t) || isDynamicLike(t) {
 		return
 	}
-	if valNode != nil {
-		res := tc.check(valNode, expected)
-		if res.ok {
-			return
+	if len(valNodes) == 1 {
+		tc.emitReturnMismatch(valNodes[0], expected)
+		return
+	}
+	if tup, ok := expected.(*rl.TypingTupleT); ok && len(tup.Types()) == len(valNodes) {
+		for i, vn := range valNodes {
+			tc.emitReturnMismatch(vn, tup.Types()[i])
 		}
-		tc.info.Issues = append(tc.info.Issues, BindIssue{
-			Span:     res.offending.Span(),
-			Severity: mismatchSeverity(res),
-			Code:     rl.ErrTypeMismatch,
-			Message: fmt.Sprintf("Return value of type '%s' is not assignable to declared return type '%s'",
-				res.got.Name(), res.want.Name()),
-		})
 		return
 	}
 	if expected.IsAssignableFrom(t) {
@@ -203,6 +203,23 @@ func (tc *typeChecker) recordReturn(t rl.TypingT, spanNode rl.Node, valNode rl.N
 		Code:     rl.ErrTypeMismatch,
 		Message: fmt.Sprintf("Return value of type '%s' is not assignable to declared return type '%s'",
 			t.Name(), expected.Name()),
+	})
+}
+
+// emitReturnMismatch structurally checks one return-value node against
+// the type its position expects, emitting a localized diagnostic (Error
+// or Hint per the value's provability) when it doesn't fit.
+func (tc *typeChecker) emitReturnMismatch(valNode rl.Node, expected rl.TypingT) {
+	res := tc.check(valNode, expected)
+	if res.ok {
+		return
+	}
+	tc.info.Issues = append(tc.info.Issues, BindIssue{
+		Span:     res.offending.Span(),
+		Severity: mismatchSeverity(res),
+		Code:     rl.ErrTypeMismatch,
+		Message: fmt.Sprintf("Return value of type '%s' is not assignable to declared return type '%s'",
+			res.got.Name(), res.want.Name()) + res.detailSuffix(),
 	})
 }
 
@@ -770,13 +787,11 @@ func (tc *typeChecker) walkStmt(n rl.Node) {
 		// `return a, b` builds a tuple so the static return type
 		// matches what the unpack-side `x, y = f()` would expect.
 		var t rl.TypingT
-		var valNode rl.Node
 		switch len(v.Values) {
 		case 0:
 			t = rl.NewVoidType()
 		case 1:
 			t = tc.synth(v.Values[0])
-			valNode = v.Values[0]
 		default:
 			elems := make([]rl.TypingT, len(v.Values))
 			for i, val := range v.Values {
@@ -784,7 +799,7 @@ func (tc *typeChecker) walkStmt(n rl.Node) {
 			}
 			t = rl.NewTupleType(elems...)
 		}
-		tc.recordReturn(t, v, valNode)
+		tc.recordReturn(t, v, v.Values)
 	default:
 		// Generic descent. Later sub-commits replace these with
 		// kind-specific handlers (for loops, switch, return, etc.).
@@ -2337,7 +2352,7 @@ func (tc *typeChecker) checkAssignAgainstDeclared(valNode rl.Node, valType, decl
 		Severity: mismatchSeverity(res),
 		Code:     rl.ErrTypeMismatch,
 		Message: fmt.Sprintf("Value of type '%s' is not assignable to declared type '%s'",
-			res.got.Name(), res.want.Name()),
+			res.got.Name(), res.want.Name()) + res.detailSuffix(),
 		Suggestion: suggestion,
 	})
 }
@@ -2420,7 +2435,7 @@ func (tc *typeChecker) checkIndexedAssignTarget(target *rl.VarPath, valNode rl.N
 		Severity: mismatchSeverity(res),
 		Code:     rl.ErrCollectionElementMismatch,
 		Message: fmt.Sprintf("Value of type '%s' is not assignable to element type '%s'",
-			res.got.Name(), res.want.Name()),
+			res.got.Name(), res.want.Name()) + res.detailSuffix(),
 	})
 }
 
@@ -2939,7 +2954,7 @@ func (tc *typeChecker) checkArgType(argNode rl.Node, param rl.TypingFnParam) {
 		Severity: mismatchSeverity(res),
 		Code:     rl.ErrTypeMismatch,
 		Message: fmt.Sprintf("Argument type '%s' is not assignable to expected type '%s'",
-			res.got.Name(), res.want.Name()),
+			res.got.Name(), res.want.Name()) + res.detailSuffix(),
 	})
 }
 
@@ -3133,8 +3148,16 @@ func binaryOpResult(op rl.Operator, l, r rl.TypingT) (rl.TypingT, bool) {
 		return unionOf(l, r), true
 	case rl.OpIn, rl.OpNotIn:
 		// Result is always bool; the right side must be a container
-		// (str / list / map). Left can be anything.
+		// (str / list / map). Left can be anything. The runtime also
+		// probes a bare error's details map (`x in err`, core/expr_ops.go),
+		// so a bare error right operand is valid too - it survives
+		// stripping when it comes straight from error() or out of a catch.
+		// An `error?` right operand falls through to the uncertain path (it
+		// could be null at runtime), so its rejection is a Hint not a gate.
 		if isStr(r) || isList(r) || isMap(r) {
+			return rl.NewBoolType(), true
+		}
+		if _, isErr := r.(*rl.TypingErrorT); isErr {
 			return rl.NewBoolType(), true
 		}
 		return nil, false
@@ -3342,16 +3365,41 @@ func unionOf(a, b rl.TypingT) rl.TypingT {
 // the same actionable follow-up as `rad <script>` users do.
 const strPlusMigrationHint = "In v0.9, + no longer coerces types. Use string interpolation instead. See: https://amterp.dev/rad/migrations/v0.9/"
 
+// listAppendHint mirrors the runtime nudge (core/expr_ops.go) shown when
+// a script adds a non-list to a list - almost always a missed `+ [item]`.
+const listAppendHint = "Did you mean to wrap the right side in a list in order to append? e.g. `myList + [item]`"
+
+// opMismatchSeverity decides whether a rejected operator pair gates as
+// an Error or only nudges as a Hint. The checker's rule everywhere is
+// that an Error must be provable: every possible runtime value of the
+// operands is incompatible. A union or optional operand breaks that -
+// one of its arms (the int in `int|str`, the present value in `any?`,
+// the error in `error?`) could be exactly what the operator accepts at
+// runtime, so the rejection is merely suspected and stays a Hint. We
+// gate only concrete pairs the runtime always rejects (`"hi" + 1`,
+// `-"x"`). This under-gates a fully-incompatible union like `bool|str +
+// int`, the safe direction: a missed Error never bricks a working
+// script, a false one does. (Mirrors gateableMismatch's union/optional
+// handling for the literal-check sites.)
+func opMismatchSeverity(operands ...rl.TypingT) IssueSeverity {
+	for _, t := range operands {
+		switch t.(type) {
+		case *rl.TypingUnionT, *rl.TypingOptionalT:
+			return IssueHint
+		}
+	}
+	return IssueError
+}
+
 // addOpIssue emits a binary-op type diagnostic.
 //
-// Severity is Error: by the time an op sees its operands, fallible
-// calls have already had their error arm stripped at the call site
-// (maybeStripFallible), so the old `int|error + int` false positive
-// can't occur - `a = parse_int(...); a + 1` types `a` as int. What
-// reaches here is a provably-wrong operand pair (e.g. `"hi" + 1`),
-// which the runtime always rejects (ErrInvalidTypeForOp). The
-// Never/Dynamic/ErrorType short-circuits in synthOpBinary keep this
-// from firing on poisoned or opted-out operands.
+// Fallible error arms are stripped at the call site (maybeStripFallible)
+// and the Never/Dynamic/ErrorType short-circuits in synthOpBinary keep
+// this from firing on poisoned or opted-out operands, so what reaches
+// here is a genuine operand-table miss. opMismatchSeverity then sets the
+// severity: a concrete miss the runtime always rejects (`"hi" + 1`)
+// gates as Error, a union/optional operand that might be a compatible
+// arm stays a Hint.
 func (tc *typeChecker) addOpIssue(span rl.Span, op rl.Operator, left, right rl.TypingT, isCompound bool) {
 	opStr := op.String()
 	if isCompound {
@@ -3359,13 +3407,16 @@ func (tc *typeChecker) addOpIssue(span rl.Span, op rl.Operator, left, right rl.T
 	}
 	issue := BindIssue{
 		Span:     span,
-		Severity: IssueError,
+		Severity: opMismatchSeverity(left, right),
 		Code:     rl.ErrInvalidTypeForOp,
 		Message: fmt.Sprintf("Invalid operand types: cannot do '%s %s %s'",
 			left.Name(), opStr, right.Name()),
 	}
-	if op == rl.OpAdd && isStrPlusCoercible(left, right) {
+	switch {
+	case op == rl.OpAdd && isStrPlusCoercible(left, right):
 		issue.Suggestion = strPlusMigrationHint
+	case op == rl.OpAdd && isList(left) && !isList(right):
+		issue.Suggestion = listAppendHint
 	}
 	tc.info.Issues = append(tc.info.Issues, issue)
 }
@@ -3386,14 +3437,14 @@ func isBool(t rl.TypingT) bool {
 	return ok
 }
 
-// addUnaryOpIssue emits a unary-op type diagnostic. Severity is Error
-// for the same reason as addOpIssue - fallible-call error arms are
-// stripped before the operand reaches here, so only a provably-wrong
-// operand (e.g. unary `-` on a str) survives to fire.
+// addUnaryOpIssue emits a unary-op type diagnostic. Severity follows the
+// same provable-only rule as addOpIssue (opMismatchSeverity): a concrete
+// operand the runtime always rejects (`-"x"`) gates as Error, a
+// union/optional operand that might be a compatible arm stays a Hint.
 func (tc *typeChecker) addUnaryOpIssue(span rl.Span, op rl.Operator, operand rl.TypingT) {
 	tc.info.Issues = append(tc.info.Issues, BindIssue{
 		Span:     span,
-		Severity: IssueError,
+		Severity: opMismatchSeverity(operand),
 		Code:     rl.ErrInvalidTypeForOp,
 		Message: fmt.Sprintf("Invalid operand type '%s' for unary '%s'",
 			operand.Name(), op.String()),
@@ -3478,7 +3529,7 @@ func (tc *typeChecker) synthLambda(n *rl.Lambda) rl.TypingT {
 			if stmt == nil {
 				continue
 			}
-			tc.recordReturn(tc.synth(stmt), stmt, stmt)
+			tc.recordReturn(tc.synth(stmt), stmt, []rl.Node{stmt})
 		}
 	} else {
 		tc.walkStmts(n.Body)

--- a/rts/check/type_check.go
+++ b/rts/check/type_check.go
@@ -60,7 +60,8 @@ func TypeCheck(file *rl.SourceFile, resolved *Resolved) *TypeInfo {
 			SymbolTypes: map[*Symbol]rl.TypingT{},
 			ExprTypes:   map[rl.Node]rl.TypingT{},
 		},
-		frame: NewFrame(),
+		frame:        NewFrame(),
+		guardedCalls: map[rl.Node]bool{},
 	}
 	// Seed SymbolTypes from any pre-pinned declared annotations the
 	// binder recorded (function parameters with type annotations,
@@ -83,6 +84,7 @@ func TypeCheck(file *rl.SourceFile, resolved *Resolved) *TypeInfo {
 			tc.info.SymbolTypes[sym] = sym.Declared
 		}
 	}
+	tc.markGuardedCalls(file)
 	tc.walkFile(file)
 	return tc.info
 }
@@ -118,6 +120,14 @@ type typeChecker struct {
 	// fn / lambda entry (save & swap), restored on exit. Empty
 	// map = no reassignments to worry about.
 	reassignedInScope map[*Symbol][]rl.Span
+	// guardedCalls marks every *rl.Call whose error-panic is caught by
+	// an enclosing guard (`??`, a `catch` expression, or a statement-
+	// level catch). Populated by markGuardedCalls before any synth, so
+	// it's independent of walk/cache order. It gates only the
+	// unhandled-fallible hint: the error-arm strip in synthCall is
+	// unconditional, since the runtime panic-promotes the error either
+	// way and it can never flow past the call as a value.
+	guardedCalls map[rl.Node]bool
 }
 
 type returnFrame struct {
@@ -142,28 +152,50 @@ func (tc *typeChecker) popReturnFrame() []rl.TypingT {
 // return outside any fn (validation-error elsewhere) is a no-op.
 //
 // Severity is Hint, not Error - same structural-literal fidelity
-// gap as checkArgType. `return [1, "2"]` for `-> [int, str]` is
-// valid at runtime, but the list literal synths to `int|str[]`
-// which doesn't structurally match the tuple type. Promoting here
-// would block legitimate scripts. Kan: promote-type-check.
-func (tc *typeChecker) recordReturn(t rl.TypingT, retNode rl.Node) {
+// gap as checkArgType: `return [1, "2"]` for `-> [int, str]` is valid
+// at runtime, but the list literal synths to `int|str[]` which doesn't
+// structurally match the tuple type. check closes that gap by walking
+// the value node against the declared return type structurally.
+//
+// valNode is the single return-value expression when there is exactly
+// one (so check can localize a nested mismatch); it's nil for a `void`
+// return or a multi-value `return a, b` (whose synthesized tuple has no
+// single literal node to walk), in which case we fall back to a
+// whole-statement assignability check at spanNode.
+//
+// Severity is Hint pending the promote-type-check rollout (Phase D).
+func (tc *typeChecker) recordReturn(t rl.TypingT, spanNode rl.Node, valNode rl.Node) {
 	n := len(tc.returnStack)
 	if n == 0 {
 		return
 	}
 	tc.returnStack[n-1].collected = append(tc.returnStack[n-1].collected, t)
 	expected := tc.returnStack[n-1].expected
-	if expected == nil || retNode == nil || t == nil {
+	if expected == nil || spanNode == nil || t == nil {
 		return
 	}
 	if isErrorType(t) || isDynamicLike(t) {
+		return
+	}
+	if valNode != nil {
+		res := tc.check(valNode, expected)
+		if res.ok {
+			return
+		}
+		tc.info.Issues = append(tc.info.Issues, BindIssue{
+			Span:     res.offending.Span(),
+			Severity: IssueHint,
+			Code:     rl.ErrTypeMismatch,
+			Message: fmt.Sprintf("Return value of type '%s' is not assignable to declared return type '%s'",
+				res.got.Name(), res.want.Name()),
+		})
 		return
 	}
 	if expected.IsAssignableFrom(t) {
 		return
 	}
 	tc.info.Issues = append(tc.info.Issues, BindIssue{
-		Span:     retNode.Span(),
+		Span:     spanNode.Span(),
 		Severity: IssueHint,
 		Code:     rl.ErrTypeMismatch,
 		Message: fmt.Sprintf("Return value of type '%s' is not assignable to declared return type '%s'",
@@ -203,6 +235,92 @@ func (tc *typeChecker) walkFile(file *rl.SourceFile) {
 	}
 	for _, cmd := range file.Cmds {
 		tc.walkCmd(cmd)
+	}
+}
+
+// markGuardedCalls records every call whose error-panic an enclosing
+// guard would catch, so the unhandled-fallible hint can skip them. The
+// guards are `??` (Fallback), a `catch` expression (CatchExpr), and a
+// statement-level catch (Assign/ExprStmt/Shell .Catch). Descent stops
+// at fn and lambda bodies: a call defined there runs in its own
+// context, not under the outer guard.
+func (tc *typeChecker) markGuardedCalls(file *rl.SourceFile) {
+	for _, s := range file.Stmts {
+		tc.markGuarded(s, false)
+	}
+	for _, c := range file.Cmds {
+		tc.markGuarded(c, false)
+	}
+}
+
+func (tc *typeChecker) markGuarded(n rl.Node, guarded bool) {
+	if n == nil {
+		return
+	}
+	switch v := n.(type) {
+	case *rl.FnDef:
+		for _, b := range v.Body {
+			tc.markGuarded(b, false)
+		}
+		return
+	case *rl.Lambda:
+		for _, b := range v.Body {
+			tc.markGuarded(b, false)
+		}
+		return
+	case *rl.Fallback:
+		tc.markGuarded(v.Left, true)
+		tc.markGuarded(v.Right, guarded)
+		return
+	case *rl.CatchExpr:
+		tc.markGuarded(v.Left, true)
+		tc.markGuarded(v.Right, guarded)
+		return
+	case *rl.Assign:
+		valsGuarded := guarded || v.Catch != nil
+		for _, val := range v.Values {
+			tc.markGuarded(val, valsGuarded)
+		}
+		for _, tgt := range v.Targets {
+			tc.markGuarded(tgt, guarded)
+		}
+		if v.Catch != nil {
+			for _, s := range v.Catch.Stmts {
+				tc.markGuarded(s, false)
+			}
+		}
+		return
+	case *rl.ExprStmt:
+		tc.markGuarded(v.Expr, guarded || v.Catch != nil)
+		if v.Catch != nil {
+			for _, s := range v.Catch.Stmts {
+				tc.markGuarded(s, false)
+			}
+		}
+		return
+	case *rl.Shell:
+		cmdGuarded := guarded || v.Catch != nil
+		tc.markGuarded(v.Cmd, cmdGuarded)
+		for _, tgt := range v.Targets {
+			tc.markGuarded(tgt, guarded)
+		}
+		if v.Catch != nil {
+			for _, s := range v.Catch.Stmts {
+				tc.markGuarded(s, false)
+			}
+		}
+		return
+	case *rl.Call:
+		if guarded {
+			tc.guardedCalls[v] = true
+		}
+		for _, c := range v.Children() {
+			tc.markGuarded(c, guarded)
+		}
+		return
+	}
+	for _, c := range n.Children() {
+		tc.markGuarded(c, guarded)
 	}
 }
 
@@ -649,11 +767,13 @@ func (tc *typeChecker) walkStmt(n rl.Node) {
 		// `return a, b` builds a tuple so the static return type
 		// matches what the unpack-side `x, y = f()` would expect.
 		var t rl.TypingT
+		var valNode rl.Node
 		switch len(v.Values) {
 		case 0:
 			t = rl.NewVoidType()
 		case 1:
 			t = tc.synth(v.Values[0])
+			valNode = v.Values[0]
 		default:
 			elems := make([]rl.TypingT, len(v.Values))
 			for i, val := range v.Values {
@@ -661,7 +781,7 @@ func (tc *typeChecker) walkStmt(n rl.Node) {
 			}
 			t = rl.NewTupleType(elems...)
 		}
-		tc.recordReturn(t, v)
+		tc.recordReturn(t, v, valNode)
 	default:
 		// Generic descent. Later sub-commits replace these with
 		// kind-specific handlers (for loops, switch, return, etc.).
@@ -2201,21 +2321,28 @@ func (tc *typeChecker) checkAssignAgainstDeclared(valNode rl.Node, valType, decl
 	if valType == nil || isErrorType(valType) || isDynamicLike(valType) {
 		return
 	}
-	if declared.IsAssignableFrom(valType) {
+	res := tc.check(valNode, declared)
+	if res.ok {
 		return
 	}
 	severity := IssueHint
 	var suggestion string
-	if _, isNull := valType.(*rl.TypingNullT); isNull {
+	// A bare `null` assigned to a non-nullable slot is provably wrong -
+	// null has a single inhabitant, no synthesis shortcut hides a valid
+	// program. Promote that one case to Error (with a fix-it). We gate on
+	// the offending node being the whole value, so this stays scoped to
+	// `x: int = null` and doesn't sweep in nested nulls, which the
+	// promote-type-check rollout (Phase D) handles uniformly.
+	if _, isNull := res.got.(*rl.TypingNullT); isNull && res.offending == valNode {
 		severity = IssueError
-		suggestion = fmt.Sprintf("To allow null here, declare the slot as '%s?'", declared.Name())
+		suggestion = fmt.Sprintf("To allow null here, declare the slot as '%s?'", res.want.Name())
 	}
 	tc.info.Issues = append(tc.info.Issues, BindIssue{
-		Span:     valNode.Span(),
+		Span:     res.offending.Span(),
 		Severity: severity,
 		Code:     rl.ErrTypeMismatch,
 		Message: fmt.Sprintf("Value of type '%s' is not assignable to declared type '%s'",
-			valType.Name(), declared.Name()),
+			res.got.Name(), res.want.Name()),
 		Suggestion: suggestion,
 	})
 }
@@ -2288,15 +2415,16 @@ func (tc *typeChecker) checkIndexedAssignTarget(target *rl.VarPath, valNode rl.N
 	if isErrorType(expected) || isDynamicLike(expected) {
 		return
 	}
-	if expected.IsAssignableFrom(valType) {
+	res := tc.check(valNode, expected)
+	if res.ok {
 		return
 	}
 	tc.info.Issues = append(tc.info.Issues, BindIssue{
-		Span:     valNode.Span(),
+		Span:     res.offending.Span(),
 		Severity: IssueHint,
 		Code:     rl.ErrCollectionElementMismatch,
 		Message: fmt.Sprintf("Value of type '%s' is not assignable to element type '%s'",
-			valType.Name(), expected.Name()),
+			res.got.Name(), res.want.Name()),
 	})
 }
 
@@ -2420,9 +2548,58 @@ func (tc *typeChecker) synthCall(call *rl.Call, implicitReceiverCount int) rl.Ty
 	tc.checkCall(call, typing, implicitReceiverCount)
 
 	if typing.ReturnT != nil {
-		return tc.record(call, *typing.ReturnT)
+		return tc.record(call, tc.maybeStripFallible(call, *typing.ReturnT))
 	}
 	return tc.record(call, rl.NewDynamicType())
+}
+
+// maybeStripFallible models Rad's panic-promotion. Every call except
+// the error() builtin raises a RadPanic instead of returning an error
+// arm as a value (core/funcs.go: panicIfError), so a fallible call's
+// error can never flow past the call in normal control flow - it
+// either succeeds or unwinds. We therefore drop the error arm from the
+// call's static result, leaving the success type. When the call isn't
+// guarded by `??`/`catch`, we also nudge the user to handle the
+// failure they've left implicit (it would otherwise halt the script).
+func (tc *typeChecker) maybeStripFallible(call *rl.Call, ret rl.TypingT) rl.TypingT {
+	if tc.isErrorBuiltinCall(call) {
+		// error() is the one call that returns its error as a value;
+		// stripping it would collapse the result to Never.
+		return ret
+	}
+	stripped := stripErrorFrom(ret)
+	if stripped == nil {
+		return ret // no error arm: not a fallible call
+	}
+	if !tc.guardedCalls[call] {
+		tc.emitUnhandledFallible(call)
+	}
+	return stripped
+}
+
+// isErrorBuiltinCall reports whether call is a direct invocation of the
+// error() builtin - the sole call the runtime does not panic-promote.
+// Mirrors core/funcs.go's `funcName == FUNC_ERROR && isBuiltIn`.
+func (tc *typeChecker) isErrorBuiltinCall(call *rl.Call) bool {
+	ident, ok := call.Func.(*rl.Identifier)
+	if !ok || ident.Name != "error" {
+		return false
+	}
+	sym, ok := tc.resolved.Uses[ident]
+	return ok && sym != nil && sym.Kind == SymBuiltin
+}
+
+// emitUnhandledFallible flags a fallible call whose error isn't caught.
+// Stays a Hint by policy: the script runs fine when the call succeeds,
+// so this is a nudge toward explicit handling, never a gate.
+func (tc *typeChecker) emitUnhandledFallible(call *rl.Call) {
+	tc.info.Issues = append(tc.info.Issues, BindIssue{
+		Span:       call.Span(),
+		Severity:   IssueHint,
+		Code:       rl.ErrUnhandledFallibleCall,
+		Message:    "This call can fail; the error isn't handled and would halt the script",
+		Suggestion: "Handle it with `catch` or `??`, e.g. `x = <call> catch <fallback>`",
+	})
 }
 
 // synthVarPath walks a chained path expression (e.g. `a.b[c].d`,
@@ -2742,63 +2919,31 @@ func (tc *typeChecker) checkCall(call *rl.Call, typing *rl.TypingFnT, implicitRe
 // unannotated (nil declared type) - that's the "any" parameter case
 // and we let the runtime catch any mismatch.
 //
-// Severity is Hint, not Error - intentionally less strict than the
-// rest of the assignability checks. The call site is where users pass
-// literals into structured typed slots ({ "outer": { "inner": int } },
-// fn() -> void[], etc.), and today's literal-type synth loses fidelity:
-// `{ "outer": { "inner": 42 } }` synths to `{ str: { str: int } }`,
-// which structurally can't match the named-key form even though the
-// runtime would accept it. Promoting to Error would block legitimate
-// scripts on day one. The runtime still catches genuine mismatches
-// with its value-aware error message. Kan: promote-type-check.
+// The assignability decision runs through check, which sees through
+// literal shapes synth widens away: `{ "outer": { "inner": 42 } }`
+// passed into `{ "outer": { "inner": int } }` matches field-wise even
+// though its synthesized type is `{ str: { str: int } }`. On a genuine
+// mismatch check pinpoints the offending element, so the diagnostic
+// lands on the bad value rather than the whole argument.
+//
+// Severity is Hint pending the promote-type-check rollout (Phase D);
+// the structural-fidelity gap that previously forced Hint here is now
+// closed by check.
 func (tc *typeChecker) checkArgType(argNode rl.Node, param rl.TypingFnParam) {
 	if param.Type == nil {
 		return
 	}
-	expected := *param.Type
-	argType := tc.synth(argNode)
-	if argType == nil {
-		return
-	}
-	if expected.IsAssignableFrom(argType) {
-		return
-	}
-	// Literal-aware exception: a plain string literal synths to
-	// TypingStrT, which IsAssignableFrom rejects for a StrEnum
-	// param even when the literal's value is in the enum. Until the
-	// synth layer carries literal types, peek at the AST here so
-	// f("read") against ["read","write"] doesn't false-flag.
-	if litMatchesStrEnum(argNode, expected) {
+	res := tc.check(argNode, *param.Type)
+	if res.ok {
 		return
 	}
 	tc.info.Issues = append(tc.info.Issues, BindIssue{
-		Span:     argNode.Span(),
+		Span:     res.offending.Span(),
 		Severity: IssueHint,
 		Code:     rl.ErrTypeMismatch,
 		Message: fmt.Sprintf("Argument type '%s' is not assignable to expected type '%s'",
-			argType.Name(), expected.Name()),
+			res.got.Name(), res.want.Name()),
 	})
-}
-
-// litMatchesStrEnum returns true when argNode is a plain (non-
-// interpolated) string literal whose value is a member of the
-// expected StrEnum. Used to bridge the gap between today's plain-
-// TypingStrT synth and the literal-aware check the enum needs.
-func litMatchesStrEnum(argNode rl.Node, expected rl.TypingT) bool {
-	enum, ok := expected.(*rl.TypingStrEnumT)
-	if !ok {
-		return false
-	}
-	lit, ok := argNode.(*rl.LitString)
-	if !ok || !lit.Simple {
-		return false
-	}
-	for _, v := range enum.Values() {
-		if v == lit.Value {
-			return true
-		}
-	}
-	return false
 }
 
 func (tc *typeChecker) addCallIssue(span rl.Span, code rl.Error, msg string) {
@@ -3202,11 +3347,14 @@ const strPlusMigrationHint = "In v0.9, + no longer coerces types. Use string int
 
 // addOpIssue emits a binary-op type diagnostic.
 //
-// Severity is Hint, not Error - fallible builtins like `parse_int`
-// return `int|error`, and users routinely write `a = parse_int(...)`
-// followed by `a + 1` without narrowing. The runtime succeeds when
-// the parse does, so promoting here would block valid scripts.
-// Kan: promote-type-check (union-narrowing path).
+// Severity is Error: by the time an op sees its operands, fallible
+// calls have already had their error arm stripped at the call site
+// (maybeStripFallible), so the old `int|error + int` false positive
+// can't occur - `a = parse_int(...); a + 1` types `a` as int. What
+// reaches here is a provably-wrong operand pair (e.g. `"hi" + 1`),
+// which the runtime always rejects (ErrInvalidTypeForOp). The
+// Never/Dynamic/ErrorType short-circuits in synthOpBinary keep this
+// from firing on poisoned or opted-out operands.
 func (tc *typeChecker) addOpIssue(span rl.Span, op rl.Operator, left, right rl.TypingT, isCompound bool) {
 	opStr := op.String()
 	if isCompound {
@@ -3214,7 +3362,7 @@ func (tc *typeChecker) addOpIssue(span rl.Span, op rl.Operator, left, right rl.T
 	}
 	issue := BindIssue{
 		Span:     span,
-		Severity: IssueHint,
+		Severity: IssueError,
 		Code:     rl.ErrInvalidTypeForOp,
 		Message: fmt.Sprintf("Invalid operand types: cannot do '%s %s %s'",
 			left.Name(), opStr, right.Name()),
@@ -3241,13 +3389,14 @@ func isBool(t rl.TypingT) bool {
 	return ok
 }
 
-// addUnaryOpIssue emits a unary-op type diagnostic. Severity is Hint
-// for the same reason as addOpIssue - union types from fallible
-// builtins flow through unary ops too. Kan: promote-type-check.
+// addUnaryOpIssue emits a unary-op type diagnostic. Severity is Error
+// for the same reason as addOpIssue - fallible-call error arms are
+// stripped before the operand reaches here, so only a provably-wrong
+// operand (e.g. unary `-` on a str) survives to fire.
 func (tc *typeChecker) addUnaryOpIssue(span rl.Span, op rl.Operator, operand rl.TypingT) {
 	tc.info.Issues = append(tc.info.Issues, BindIssue{
 		Span:     span,
-		Severity: IssueHint,
+		Severity: IssueError,
 		Code:     rl.ErrInvalidTypeForOp,
 		Message: fmt.Sprintf("Invalid operand type '%s' for unary '%s'",
 			operand.Name(), op.String()),
@@ -3332,7 +3481,7 @@ func (tc *typeChecker) synthLambda(n *rl.Lambda) rl.TypingT {
 			if stmt == nil {
 				continue
 			}
-			tc.recordReturn(tc.synth(stmt), stmt)
+			tc.recordReturn(tc.synth(stmt), stmt, stmt)
 		}
 	} else {
 		tc.walkStmts(n.Body)

--- a/rts/check/type_check.go
+++ b/rts/check/type_check.go
@@ -148,22 +148,21 @@ func (tc *typeChecker) popReturnFrame() []rl.TypingT {
 
 // recordReturn appends a return-value type to the innermost fn
 // scope's accumulator and, if that scope has a declared return
-// type, checks the value against it at the return's own span. A
-// return outside any fn (validation-error elsewhere) is a no-op.
+// type, checks the value against it. A return outside any fn
+// (validation-error elsewhere) is a no-op.
 //
-// Severity is Hint, not Error - same structural-literal fidelity
-// gap as checkArgType: `return [1, "2"]` for `-> [int, str]` is valid
-// at runtime, but the list literal synths to `int|str[]` which doesn't
-// structurally match the tuple type. check closes that gap by walking
-// the value node against the declared return type structurally.
+// The runtime enforces declared return types, so a provable mismatch
+// is an Error; check downgrades to a Hint when the real value is
+// unknown (see checkResult.gateable). `return [1, "2"]` for
+// `-> [int, str]` is accepted: check walks the literal against the
+// tuple position-wise even though it synths to `(int|str)[]`.
 //
 // valNode is the single return-value expression when there is exactly
 // one (so check can localize a nested mismatch); it's nil for a `void`
 // return or a multi-value `return a, b` (whose synthesized tuple has no
 // single literal node to walk), in which case we fall back to a
-// whole-statement assignability check at spanNode.
-//
-// Severity is Hint pending the promote-type-check rollout (Phase D).
+// whole-statement assignability check at spanNode, gating only when the
+// synthesized type carries no gradual container.
 func (tc *typeChecker) recordReturn(t rl.TypingT, spanNode rl.Node, valNode rl.Node) {
 	n := len(tc.returnStack)
 	if n == 0 {
@@ -184,7 +183,7 @@ func (tc *typeChecker) recordReturn(t rl.TypingT, spanNode rl.Node, valNode rl.N
 		}
 		tc.info.Issues = append(tc.info.Issues, BindIssue{
 			Span:     res.offending.Span(),
-			Severity: IssueHint,
+			Severity: mismatchSeverity(res),
 			Code:     rl.ErrTypeMismatch,
 			Message: fmt.Sprintf("Return value of type '%s' is not assignable to declared return type '%s'",
 				res.got.Name(), res.want.Name()),
@@ -194,9 +193,13 @@ func (tc *typeChecker) recordReturn(t rl.TypingT, spanNode rl.Node, valNode rl.N
 	if expected.IsAssignableFrom(t) {
 		return
 	}
+	severity := IssueHint
+	if typeIsGateable(t) {
+		severity = IssueError
+	}
 	tc.info.Issues = append(tc.info.Issues, BindIssue{
 		Span:     spanNode.Span(),
-		Severity: IssueHint,
+		Severity: severity,
 		Code:     rl.ErrTypeMismatch,
 		Message: fmt.Sprintf("Return value of type '%s' is not assignable to declared return type '%s'",
 			t.Name(), expected.Name()),
@@ -2300,19 +2303,16 @@ func (tc *typeChecker) walkAssign(a *rl.Assign) {
 // checkAssignAgainstDeclared emits a type-mismatch when the assigned
 // value can't flow into the declared slot.
 //
-// Default severity is Hint - same structural-literal fidelity gap as
-// checkArgType. `x: ["a", "b"] = "a"` is valid at runtime, but the
-// str literal synths to plain TypingStrT (litMatchesStrEnum lives
-// only at the call site today, not here). Similar story for tuple
-// and struct literals against named-shape declared types. Promoting
-// the general case would block legitimate scripts. Kan:
-// promote-type-check.
+// The declared type is the user's contract for the binding, so a
+// provable violation is an Error - matching how typed languages reject
+// `x: int = "hi"` even though Rad's runtime is lenient about local
+// assignment. check sees through literal shapes (`x: [int, str] =
+// [1, "2"]` is accepted) and downgrades to a Hint when the real value
+// is unknown - a gradual `list`/`map`, or an interpolated string into a
+// str-enum (see checkResult.gateable).
 //
-// Exception: a bare TypingNullT value flowing into a non-nullable
-// slot is promoted to Error. The structural-literal fidelity caveat
-// doesn't apply - `null` has exactly one inhabitant, no synthesis
-// shortcut hides a valid program here. The severity matches the
-// project policy: provably wrong = Error, gate runtime.
+// A bare `null` into a non-nullable slot additionally carries a fix-it
+// suggesting the `T?` form.
 //
 // ErrorType / Dynamic short-circuit: a poisoned RHS already produced
 // a diagnostic and any-likes are universally assignable, so no extra
@@ -2325,21 +2325,16 @@ func (tc *typeChecker) checkAssignAgainstDeclared(valNode rl.Node, valType, decl
 	if res.ok {
 		return
 	}
-	severity := IssueHint
+	// A bare `null` assigned to a non-nullable slot earns a fix-it
+	// nudging the `T?` form. (The severity is already Error - null into a
+	// non-nullable type is a provable mismatch.)
 	var suggestion string
-	// A bare `null` assigned to a non-nullable slot is provably wrong -
-	// null has a single inhabitant, no synthesis shortcut hides a valid
-	// program. Promote that one case to Error (with a fix-it). We gate on
-	// the offending node being the whole value, so this stays scoped to
-	// `x: int = null` and doesn't sweep in nested nulls, which the
-	// promote-type-check rollout (Phase D) handles uniformly.
-	if _, isNull := res.got.(*rl.TypingNullT); isNull && res.offending == valNode {
-		severity = IssueError
+	if _, isNull := res.got.(*rl.TypingNullT); isNull {
 		suggestion = fmt.Sprintf("To allow null here, declare the slot as '%s?'", res.want.Name())
 	}
 	tc.info.Issues = append(tc.info.Issues, BindIssue{
 		Span:     res.offending.Span(),
-		Severity: severity,
+		Severity: mismatchSeverity(res),
 		Code:     rl.ErrTypeMismatch,
 		Message: fmt.Sprintf("Value of type '%s' is not assignable to declared type '%s'",
 			res.got.Name(), res.want.Name()),
@@ -2367,10 +2362,11 @@ func (tc *typeChecker) checkAssignAgainstDeclared(valNode rl.Node, valType, decl
 // has admitted us. Concretely: we want the most precise statically
 // known element type, gated by the user having opted in.
 //
-// Severity is Hint, matching checkAssignAgainstDeclared - same
-// structural-literal fidelity gap (Kan: promote-type-check). Other
-// forms of mutation (struct field assignment, slice assignment)
-// aren't checked here.
+// A provable element mismatch is an Error, matching
+// checkAssignAgainstDeclared - the declared element type is a contract,
+// and check downgrades to a Hint when the value is unknown. Other forms
+// of mutation (struct field assignment, slice assignment) aren't checked
+// here.
 func (tc *typeChecker) checkIndexedAssignTarget(target *rl.VarPath, valNode rl.Node, valType rl.TypingT) {
 	if valType == nil || isErrorType(valType) || isDynamicLike(valType) {
 		return
@@ -2421,7 +2417,7 @@ func (tc *typeChecker) checkIndexedAssignTarget(target *rl.VarPath, valNode rl.N
 	}
 	tc.info.Issues = append(tc.info.Issues, BindIssue{
 		Span:     res.offending.Span(),
-		Severity: IssueHint,
+		Severity: mismatchSeverity(res),
 		Code:     rl.ErrCollectionElementMismatch,
 		Message: fmt.Sprintf("Value of type '%s' is not assignable to element type '%s'",
 			res.got.Name(), res.want.Name()),
@@ -2926,9 +2922,10 @@ func (tc *typeChecker) checkCall(call *rl.Call, typing *rl.TypingFnT, implicitRe
 // mismatch check pinpoints the offending element, so the diagnostic
 // lands on the bad value rather than the whole argument.
 //
-// Severity is Hint pending the promote-type-check rollout (Phase D);
-// the structural-fidelity gap that previously forced Hint here is now
-// closed by check.
+// The runtime enforces argument types, so a provable mismatch is an
+// Error. check downgrades the verdict to a Hint when the real value is
+// unknown (a gradual `list`/`map`, or an interpolated string into a
+// str-enum) - see checkResult.gateable.
 func (tc *typeChecker) checkArgType(argNode rl.Node, param rl.TypingFnParam) {
 	if param.Type == nil {
 		return
@@ -2939,7 +2936,7 @@ func (tc *typeChecker) checkArgType(argNode rl.Node, param rl.TypingFnParam) {
 	}
 	tc.info.Issues = append(tc.info.Issues, BindIssue{
 		Span:     res.offending.Span(),
-		Severity: IssueHint,
+		Severity: mismatchSeverity(res),
 		Code:     rl.ErrTypeMismatch,
 		Message: fmt.Sprintf("Argument type '%s' is not assignable to expected type '%s'",
 			res.got.Name(), res.want.Name()),

--- a/rts/check/type_check_test.go
+++ b/rts/check/type_check_test.go
@@ -233,7 +233,7 @@ func TestTypeCheck_NoFalsePositivesOnSimpleAssignments(t *testing.T) {
 // below to assert "the type checker flagged this op."
 func hasOpIssue(info *check.TypeInfo) bool {
 	for _, i := range info.Issues {
-		if i.Code == rl.ErrInvalidTypeForOp && i.Severity == check.IssueHint {
+		if i.Code == rl.ErrInvalidTypeForOp && i.Severity == check.IssueError {
 			return true
 		}
 	}
@@ -295,13 +295,14 @@ func TestTypeCheck_StrTimesIntSynthesizesStr(t *testing.T) {
 	assert.Empty(t, info.Issues)
 }
 
-func TestTypeCheck_IntPlusStrFlagsHint(t *testing.T) {
+func TestTypeCheck_IntPlusStrFlagsError(t *testing.T) {
 	// This is the migration case from v0.9 - `+` no longer coerces.
-	// Surfaces as Hint (operator sites are held at Hint pending
-	// union-narrowing fidelity); the runtime emits ErrInvalidTypeForOp.
+	// Surfaces as Error (operator sites gate now that fallible-call
+	// error arms are stripped before the op); the runtime also rejects
+	// it with ErrInvalidTypeForOp.
 	_, info, _ := typeInfoFromSrc(t, "x = 1 + \"hi\"\n")
 	assert.True(t, hasOpIssue(info),
-		"expected Hint-severity ErrInvalidTypeForOp for int + str")
+		"expected Error-severity ErrInvalidTypeForOp for int + str")
 }
 
 func TestTypeCheck_LessThanReturnsBool(t *testing.T) {
@@ -373,8 +374,8 @@ func TestTypeCheck_UnaryNegOnIntReturnsInt(t *testing.T) {
 	assert.Equal(t, rl.T_INT, exprTypeOf(t, file, info).Name())
 }
 
-func TestTypeCheck_UnaryNegOnStrFlagsHint(t *testing.T) {
-	// `-"hi"` is a runtime error; the static side flags it as Hint.
+func TestTypeCheck_UnaryNegOnStrFlagsError(t *testing.T) {
+	// `-"hi"` is a runtime error; the static side gates it as Error.
 	_, info, _ := typeInfoFromSrc(t, "x = -\"hi\"\n")
 	assert.True(t, hasOpIssue(info))
 }
@@ -1034,11 +1035,16 @@ func TestTypeCheck_ReassignmentWidens(t *testing.T) {
 	// Reassigning a narrowed var to a value of the declared type
 	// widens it back. After `x = parse_int(...)` (returns int|error),
 	// the narrowing inside the if body is lost.
-	src := `fn f(x: int|error):
+	// The RHS is a union-typed param (g), not a fallible call: a fallible
+	// call's result has its error arm stripped at the call (Gap 2), so it
+	// wouldn't widen x back to a union. Reading the union straight from a
+	// param keeps this test focused on the reassignment-drops-narrowing
+	// mechanism it's actually exercising.
+	src := `fn f(x: int|error, g: int|error):
     if type_of(x) == "int":
         // x is int here
         a = x
-        x = parse_int("5")
+        x = g
         // x is back to int|error now
         b = x
 `
@@ -1053,8 +1059,7 @@ func TestTypeCheck_ReassignmentWidens(t *testing.T) {
 	assert.Equal(t, rl.T_INT, info.ExprTypes[aUse].Name(),
 		"x before reassignment should still be narrowed to int")
 
-	// b sees the post-reassignment x. parse_int returns int|error,
-	// so x should be back to int|error here.
+	// b sees the post-reassignment x. g is int|error, so x widens back.
 	bUse := bAssign.Values[0].(*rl.Identifier)
 	got := info.ExprTypes[bUse]
 	require.NotNil(t, got)

--- a/rts/check/type_check_test.go
+++ b/rts/check/type_check_test.go
@@ -163,21 +163,19 @@ func TestTypeCheck_BuiltinKnownNamedArgOK(t *testing.T) {
 	assert.Empty(t, info.Issues)
 }
 
-func TestTypeCheck_ArgTypeMismatchEmitsHint(t *testing.T) {
-	// `len` expects str/list/map. Passing an int surfaces a Hint -
-	// the call site is held at Hint until structural-literal fidelity
-	// lands; the runtime still catches the mismatch with a value-aware
-	// message.
+func TestTypeCheck_ArgTypeMismatchEmitsError(t *testing.T) {
+	// `len` expects str/list/map. Passing an int is a provable mismatch
+	// the runtime enforces, so it gates as an Error.
 	_, info, _ := typeInfoFromSrc(t, "x = len(5)\n")
 	require.NotEmpty(t, info.Issues)
 	found := false
 	for _, i := range info.Issues {
-		if i.Code == rl.ErrTypeMismatch && i.Severity == check.IssueHint {
+		if i.Code == rl.ErrTypeMismatch && i.Severity == check.IssueError {
 			found = true
 			break
 		}
 	}
-	assert.True(t, found, "expected a Hint-severity ErrTypeMismatch issue")
+	assert.True(t, found, "expected an Error-severity ErrTypeMismatch issue")
 }
 
 func TestTypeCheck_ArgTypeCorrectIsSilent(t *testing.T) {
@@ -189,18 +187,18 @@ func TestTypeCheck_ArgTypeCorrectIsSilent(t *testing.T) {
 	}
 }
 
-func TestTypeCheck_NamedArgTypeMismatchEmitsHint(t *testing.T) {
-	// `print(... sep: str = ...)` - sep expects str. Passing an int
-	// surfaces a Hint at the call site (see checkArgType comment).
+func TestTypeCheck_NamedArgTypeMismatchEmitsError(t *testing.T) {
+	// `print(... sep: str = ...)` - sep expects str. Passing an int is a
+	// provable mismatch and gates as an Error (see checkArgType comment).
 	_, info, _ := typeInfoFromSrc(t, "print(\"hi\", sep=5)\n")
 	found := false
 	for _, i := range info.Issues {
-		if i.Code == rl.ErrTypeMismatch && i.Severity == check.IssueHint {
+		if i.Code == rl.ErrTypeMismatch && i.Severity == check.IssueError {
 			found = true
 			break
 		}
 	}
-	assert.True(t, found, "expected type-mismatch hint on named arg")
+	assert.True(t, found, "expected type-mismatch error on named arg")
 }
 
 func TestTypeCheck_UFCSCallReceiverCountsAsFirstArg(t *testing.T) {
@@ -503,19 +501,19 @@ func TestTypeCheck_UserFnCallWithTooFewArgsFlagsArity(t *testing.T) {
 		"expected ErrWrongArgCount when user fn called with too few args")
 }
 
-func TestTypeCheck_UserFnCallWithWrongArgTypeFlagsHint(t *testing.T) {
-	// Type mismatch on a user fn arg surfaces as Hint, matching the
-	// deferred severity for call-site checks (see checkArgType comment).
+func TestTypeCheck_UserFnCallWithWrongArgTypeFlagsError(t *testing.T) {
+	// Type mismatch on a user fn arg gates as an Error - the runtime
+	// enforces user-fn argument types (see checkArgType comment).
 	src := "fn add(x: int, y: int) -> int: x + y\nz = add(\"a\", 2)\n"
 	_, info, _ := typeInfoFromSrc(t, src)
 	found := false
 	for _, i := range info.Issues {
-		if i.Code == rl.ErrTypeMismatch && i.Severity == check.IssueHint {
+		if i.Code == rl.ErrTypeMismatch && i.Severity == check.IssueError {
 			found = true
 			break
 		}
 	}
-	assert.True(t, found, "expected Hint-severity type-mismatch on user fn arg")
+	assert.True(t, found, "expected Error-severity type-mismatch on user fn arg")
 }
 
 func TestTypeCheck_UnannotatedUserFnFallsBackToDynamic(t *testing.T) {
@@ -699,18 +697,18 @@ func TestTypeCheck_TypedLocalAcceptsAssignableRHS(t *testing.T) {
 }
 
 func TestTypeCheck_TypedLocalRejectsIncompatibleRHS(t *testing.T) {
-	// str literal can't flow into `: int`. Held at Hint until
-	// structural-literal fidelity lands (Kan: promote-type-check).
+	// str literal can't flow into `: int`. The declared type is a
+	// contract, so this gates as an Error.
 	_, info, _ := typeInfoFromSrc(t, "x: int = \"hi\"\n")
 	found := false
 	for _, i := range info.Issues {
-		if i.Code == rl.ErrTypeMismatch && i.Severity == check.IssueHint {
+		if i.Code == rl.ErrTypeMismatch && i.Severity == check.IssueError {
 			found = true
 			break
 		}
 	}
 	assert.True(t, found,
-		"expected a Hint-severity type-mismatch when RHS isn't assignable to declared")
+		"expected an Error-severity type-mismatch when RHS isn't assignable to declared")
 }
 
 func TestTypeCheck_TypedLocalDeclaredFloatAcceptsInt(t *testing.T) {

--- a/rts/rl/errors.go
+++ b/rts/rl/errors.go
@@ -110,6 +110,7 @@ const (
 	ErrCannotCompare             Error = "30008"
 	ErrCannotConvert             Error = "30009"
 	ErrCollectionElementMismatch Error = "30010"
+	ErrUnhandledFallibleCall     Error = "30011"
 
 	// 4xxxx Validation Errors
 	ErrScientificNotationNotWholeNumber Error = "40001"

--- a/rts/rl/typing.go
+++ b/rts/rl/typing.go
@@ -786,6 +786,16 @@ func (t *TypingStrEnumT) Values() []string {
 	return t.values
 }
 
+// Contains reports whether value is one of the enum's members.
+func (t *TypingStrEnumT) Contains(value string) bool {
+	for _, v := range t.values {
+		if v == value {
+			return true
+		}
+	}
+	return false
+}
+
 func (t *TypingStrEnumT) IsCompatibleWith(val TypingCompatVal) bool {
 	if val.Val != nil {
 		strVal, ok := (val.Val).(string)

--- a/rts/rl/typing.go
+++ b/rts/rl/typing.go
@@ -62,14 +62,80 @@ func (r RadType) AsString() string {
 // vs parameter, return value vs declared return). It compares two *types*. The
 // rules implement gradual typing: `any` and `dynamic` are universally
 // compatible in both directions (you can store anything in them, and they can
-// flow anywhere); collections are invariant (allowing `int[]` into `(int|str)[]`
-// would let the callee write a string into a list the caller still believes is
-// int-typed); function parameters are contravariant and returns are covariant;
-// `int` widens implicitly to `float` to mirror the runtime rule.
+// flow anywhere); lists are covariant in their element (`int[]` flows into
+// `(int|str)[]`) for ergonomics, accepting the mutation-aliasing unsoundness;
+// maps and tuples stay invariant; function parameters are contravariant and
+// returns are covariant; `int` widens implicitly to `float` to mirror the
+// runtime rule.
 type TypingT interface {
 	Name() string
 	IsCompatibleWith(val TypingCompatVal) bool
 	IsAssignableFrom(other TypingT) bool
+}
+
+// DisplayName renders t as users should see it: identical to Name() except the
+// internal `dynamic` type surfaces as its behavioural twin `any`. `dynamic` is
+// the implicit-any the checker assigns when inference can't pin a type; users
+// never write it and have no docs for it, so it must never appear in a
+// user-facing surface (hover, messages). Name() stays the canonical spelling
+// for tests and the contributor-facing checker dump, which legitimately want to
+// see `dynamic`.
+func DisplayName(t TypingT) string {
+	return substituteDynamic(t).Name()
+}
+
+// substituteDynamic deep-copies t with every `dynamic` rewritten to `any`,
+// reusing each type's own Name() for rendering rather than duplicating format
+// logic. Unknown leaf types fall through unchanged; a future composite type not
+// handled here degrades to leaking `dynamic` in that nesting (same as no
+// rewrite at all), never to a crash.
+func substituteDynamic(t TypingT) TypingT {
+	switch tt := t.(type) {
+	case *TypingDynamicT:
+		return NewAnyType()
+	case *TypingListT:
+		return NewListType(substituteDynamic(tt.elem))
+	case *TypingTupleT:
+		return NewTupleType(substituteDynamicEach(tt.types)...)
+	case *TypingUnionT:
+		return NewUnionType(substituteDynamicEach(tt.types)...)
+	case *TypingOptionalT:
+		return NewOptionalType(substituteDynamic(tt.t))
+	case *TypingVarArgT:
+		return NewVarArgType(substituteDynamic(tt.t))
+	case *TypingMapT:
+		return NewMapType(substituteDynamic(tt.keyT), substituteDynamic(tt.valT))
+	case *TypingStructT:
+		named := make(map[MapNamedKey]TypingT, len(tt.named))
+		for k, v := range tt.named {
+			named[k] = substituteDynamic(v)
+		}
+		return NewStructType(named)
+	case *TypingFnT:
+		params := make([]TypingFnParam, len(tt.Params))
+		for i, p := range tt.Params {
+			params[i] = p
+			if p.Type != nil {
+				sub := substituteDynamic(*p.Type)
+				params[i].Type = &sub
+			}
+		}
+		var ret *TypingT
+		if tt.ReturnT != nil {
+			sub := substituteDynamic(*tt.ReturnT)
+			ret = &sub
+		}
+		return &TypingFnT{FnName: tt.FnName, Params: params, ReturnT: ret}
+	}
+	return t
+}
+
+func substituteDynamicEach(ts []TypingT) []TypingT {
+	out := make([]TypingT, len(ts))
+	for i, t := range ts {
+		out[i] = substituteDynamic(t)
+	}
+	return out
 }
 
 // Compile-time guards: every concrete typing must satisfy TypingT.
@@ -344,7 +410,7 @@ func (t *TypingNullT) IsCompatibleWith(val TypingCompatVal) bool {
 }
 
 // Collections
-type TypingAnyListT struct{} // var: list i.e. any[]
+type TypingAnyListT struct{} // the `list` keyword; `any[]`/`dynamic[]` collapse to this (see NewListType)
 
 func NewAnyListType() *TypingAnyListT {
 	return &TypingAnyListT{}
@@ -365,7 +431,36 @@ type TypingListT struct { // var: int[]
 	elem TypingT
 }
 
-func NewListType(elem TypingT) *TypingListT {
+// acceptsAnything reports whether every value satisfies t - i.e. t is `any`,
+// `dynamic`, or a union with such a member (since `T | any` accepts everything
+// the `any` arm does). A list with such an element is indistinguishable from
+// the generic `list`, so NewListType collapses it.
+func acceptsAnything(t TypingT) bool {
+	switch tt := t.(type) {
+	case *TypingAnyT, *TypingDynamicT:
+		return true
+	case *TypingUnionT:
+		for _, m := range tt.types {
+			if acceptsAnything(m) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// NewListType builds the static type for `T[]`. A list whose element accepts
+// everything (`any[]`, the inferred `dynamic[]`, or `(int|any)[]`) is collapsed
+// to the generic `list` (TypingAnyListT) so these spellings are one type. This
+// keeps an inferred `list` value assignable into an `any[]`-annotated slot:
+// TypingListT.IsAssignableFrom only accepts another TypingListT, so without the
+// collapse `any[].IsAssignableFrom(list)` falsely fails. It also guarantees
+// TypingListT never holds an all-accepting element, so its per-element checks
+// never run a trivially-true loop.
+func NewListType(elem TypingT) TypingT {
+	if acceptsAnything(elem) {
+		return NewAnyListType()
+	}
 	return &TypingListT{elem: elem}
 }
 

--- a/rts/rl/typing_assignable.go
+++ b/rts/rl/typing_assignable.go
@@ -1,9 +1,9 @@
 package rl
 
 // This file implements IsAssignableFrom for every TypingT. The variance rules
-// (invariant collections, contravariant params + covariant returns on
-// functions, int->float widening on scalars, universal consistency for
-// any/dynamic/error_type) are documented on the TypingT interface in
+// (covariant lists, invariant maps + tuples, contravariant params + covariant
+// returns on functions, int->float widening on scalars, universal consistency
+// for any/dynamic/error_type) are documented on the TypingT interface in
 // typing.go. Implementations live here to keep all the static-checker
 // compatibility logic together; the runtime IsCompatibleWith methods remain
 // alongside their types.
@@ -24,11 +24,11 @@ func isAnyLike(other TypingT) bool {
 }
 
 // typesEqual reports strict structural equality between two static types. Used
-// by the invariant variance checks on collections - allowing `int[]` to satisfy
-// `(int|str)[]` would let the callee push a string into a list the caller
-// still believes is int-typed, so collection element types must match exactly
-// rather than via the looser IsAssignableFrom. Treats nil ReturnT / param Type
-// as `any` to mirror the rendering convention in Name().
+// by the invariant types - maps, tuples, optionals - and by fn structural
+// matching, where element/component types must match exactly rather than via
+// the looser IsAssignableFrom. (Lists are covariant and use IsAssignableFrom on
+// their element instead.) Treats nil ReturnT / param Type as `any` to mirror
+// the rendering convention in Name().
 func typesEqual(a, b TypingT) bool {
 	if a == nil || b == nil {
 		return a == b
@@ -292,11 +292,12 @@ func (t *TypingErrorTypeT) IsAssignableFrom(TypingT) bool {
 	return true
 }
 
-// --- Collections (invariant) ---
+// --- Collections (lists covariant; maps + tuples invariant) ---
 
-// AnyList is the unparameterized list type. It accepts any concrete list or
-// tuple shape, since the caller has expressed no requirement on the element
-// type.
+// AnyList is the unparameterized list type - the `list` keyword, and what
+// `any[]`/`dynamic[]` collapse to (see NewListType). It accepts any concrete
+// list or tuple shape, since the caller has expressed no requirement on the
+// element type.
 func (t *TypingAnyListT) IsAssignableFrom(other TypingT) bool {
 	if isAnyLike(other) {
 		return true

--- a/rts/rl/typing_assignable_test.go
+++ b/rts/rl/typing_assignable_test.go
@@ -202,20 +202,45 @@ func TestAssign_StrEnumSubsetRelation(t *testing.T) {
 func TestAssign_ListsCovariant(t *testing.T) {
 	listInt := rl.NewListType(rl.NewIntType())
 	listFloat := rl.NewListType(rl.NewFloatType())
-	listAny := rl.NewListType(rl.NewAnyType())
 
 	// Identity holds.
 	assert.True(t, listInt.IsAssignableFrom(rl.NewListType(rl.NewIntType())))
 
 	// Covariance: List<int> flows into List<float> because int widens to
-	// float at the scalar level. Likewise List<int> flows into List<any>.
-	// Unsound under mutation+aliasing but accepted for ergonomics - see the
-	// commentary on TypingListT.IsAssignableFrom.
+	// float at the scalar level. Unsound under mutation+aliasing but accepted
+	// for ergonomics - see the commentary on TypingListT.IsAssignableFrom.
 	assert.True(t, listFloat.IsAssignableFrom(listInt))
-	assert.True(t, listAny.IsAssignableFrom(listInt))
 
 	// Narrowing direction stays refused.
 	assert.False(t, listInt.IsAssignableFrom(listFloat))
+}
+
+// any[] and dynamic[] are not distinct types - NewListType collapses an
+// all-accepting element to the generic `list` (TypingAnyListT). This is the
+// regression lock for the bug where `any[].IsAssignableFrom(list)` returned
+// false (a TypingListT only accepted another TypingListT, never the generic
+// list), so an inferred `list` value wrongly failed to satisfy an `any[]` slot.
+func TestAssign_AnyArrayCollapsesToList(t *testing.T) {
+	anyArray := rl.NewListType(rl.NewAnyType())
+	dynArray := rl.NewListType(rl.NewDynamicType())
+
+	// Both normalize to the generic `list`, not a parameterized T[].
+	assert.Equal(t, rl.T_LIST, anyArray.Name())
+	assert.Equal(t, rl.T_LIST, dynArray.Name())
+
+	// The bug: the generic `list` now flows into an `any[]` annotation.
+	genericList := rl.NewAnyListType()
+	assert.True(t, anyArray.IsAssignableFrom(genericList))
+	// And any concrete list still flows in.
+	assert.True(t, anyArray.IsAssignableFrom(rl.NewListType(rl.NewIntType())))
+
+	// A union element that accepts everything (it has an `any`/`dynamic` arm)
+	// makes the list indistinguishable from `list`, so it collapses too -
+	// otherwise `(int|any)[]` would inconsistently reject `list` while `any[]`
+	// accepts it.
+	unionArray := rl.NewListType(rl.NewUnionType(rl.NewIntType(), rl.NewAnyType()))
+	assert.Equal(t, rl.T_LIST, unionArray.Name())
+	assert.True(t, unionArray.IsAssignableFrom(genericList))
 }
 
 func TestAssign_ListsCovariantOverUnions(t *testing.T) {

--- a/rts/rl/typing_test.go
+++ b/rts/rl/typing_test.go
@@ -150,6 +150,28 @@ func TestStructNested(t *testing.T) {
 	assert.False(t, outer.IsCompatibleWith(missingRequired))
 }
 
+// DisplayName must never surface the internal `dynamic` to users - not at the
+// top level, and not nested inside composites (the hover leak the reviewers
+// flagged). It renders dynamic as its behavioural twin `any` while leaving real
+// types untouched.
+func TestDisplayNameHidesDynamicEverywhere(t *testing.T) {
+	// Bare dynamic, and real types unchanged.
+	assert.Equal(t, rl.T_ANY, rl.DisplayName(rl.NewDynamicType()))
+	assert.Equal(t, rl.T_INT, rl.DisplayName(rl.NewIntType()))
+	assert.Equal(t, "int[]", rl.DisplayName(rl.NewListType(rl.NewIntType())))
+
+	// Nested dynamic in an inferred fn signature (e.g. recursive/unknown call).
+	pt := rl.TypingT(rl.NewDynamicType())
+	ret := rl.TypingT(rl.NewDynamicType())
+	fn := &rl.TypingFnT{Params: []rl.TypingFnParam{{Type: &pt}}, ReturnT: &ret}
+	assert.Equal(t, "fn(any) -> any", rl.DisplayName(fn))
+
+	// Nested dynamic in a map value and an optional and a union.
+	assert.Equal(t, "{ str: any }", rl.DisplayName(rl.NewMapType(rl.NewStrType(), rl.NewDynamicType())))
+	assert.Equal(t, "any?", rl.DisplayName(rl.NewOptionalType(rl.NewDynamicType())))
+	assert.Equal(t, "int|any", rl.DisplayName(rl.NewUnionType(rl.NewIntType(), rl.NewDynamicType())))
+}
+
 func TestStructOptionalField(t *testing.T) {
 	s := rl.NewStructType(map[rl.MapNamedKey]rl.TypingT{
 		rl.NewMapNamedKey("req", false): rl.NewIntType(),


### PR DESCRIPTION
Improves the static checker's type-mismatch handling so it only blocks on what it can prove and reports everything else as guidance.

The four commits form one arc:

1. **Faithful typing for fallible calls and literals** - a fallible call's result is uncertain until checked, so it's no longer typed as its optimistic declared return. The inferred type reflects that uncertainty.
2. **Gate provable mismatches as errors** - only mismatches between two known, concrete types are provable enough to block (e.g. returning `str` where `bool` is declared).
3. **Keep uncertain mismatches non-blocking** - anything touched by an unprovable operand is demoted to a hint, so it informs without rejecting the program.
4. **Unify `any[]`, `dynamic[]`, and `list`** - collapses all-accepting list elements to the generic `list` at the `NewListType` chokepoint, fixing a bug where an inferred `list` failed to satisfy an `any[]` slot. Also hides the checker-internal `dynamic` from user-facing hover.

**Theme:** certainty decides severity - the checker blocks on provable mismatches, hints on uncertain ones.

All `rts/rl`, `rts/check`, and `radls/...` tests pass.
