### PR TITLE
fix(check): stop false positives, plus path & docs fixes

### DIFF
--- a/core/common/files.go
+++ b/core/common/files.go
@@ -8,12 +8,23 @@ import (
 	"strings"
 )
 
-func ToAbsolutePath(path string) string {
-	if strings.HasPrefix(path, "~") {
-		home, _ := os.UserHomeDir()          // todo technically should handle err
-		path = filepath.Join(home, path[1:]) // drop the "~"
+// ExpandTilde resolves a leading "~" (i.e. exactly "~" or a "~/" prefix) to the
+// user's home directory. Anything else is returned unchanged: "~user" (another
+// user's home) is not supported and is left as a literal path rather than
+// silently misexpanded, and a path like "~backup" is treated as a literal name.
+// If the home dir can't be resolved, the path is returned untouched so the
+// failure surfaces honestly at the os call site.
+func ExpandTilde(path string) string {
+	if path == "~" || strings.HasPrefix(path, "~/") {
+		if home, err := os.UserHomeDir(); err == nil {
+			path = filepath.Join(home, path[1:]) // drop the "~"
+		}
 	}
-	abs, _ := filepath.Abs(path) // todo handle err?
+	return path
+}
+
+func ToAbsolutePath(path string) string {
+	abs, _ := filepath.Abs(ExpandTilde(path)) // todo handle err?
 	return abs
 }
 

--- a/core/common/files_test.go
+++ b/core/common/files_test.go
@@ -1,0 +1,48 @@
+package com
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestExpandTilde(t *testing.T) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatalf("could not resolve home dir: %v", err)
+	}
+
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"bare tilde", "~", home},
+		{"tilde with subpath", "~/foo/bar.txt", filepath.Join(home, "foo/bar.txt")},
+		{"no tilde absolute", "/etc/hosts", "/etc/hosts"},
+		{"no tilde relative", "foo/bar.txt", "foo/bar.txt"},
+		{"tilde mid-string untouched", "/foo/~/bar", "/foo/~/bar"},
+		{"tilde literal name untouched", "~backup", "~backup"},
+		{"tilde user untouched", "~bob/config.txt", "~bob/config.txt"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ExpandTilde(tt.in); got != tt.want {
+				t.Errorf("ExpandTilde(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestToAbsolutePathExpandsTilde(t *testing.T) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatalf("could not resolve home dir: %v", err)
+	}
+
+	want := filepath.Join(home, "foo/bar.txt")
+	if got := ToAbsolutePath("~/foo/bar.txt"); got != want {
+		t.Errorf("ToAbsolutePath(\"~/foo/bar.txt\") = %q, want %q", got, want)
+	}
+}

--- a/core/embedded/check
+++ b/core/embedded/check
@@ -6,13 +6,14 @@ args:
     script str?       # Path of script to check.
     from_logs str?    # Check scripts from invocation logs (duration like "30d" or "all").
     verbose v bool    # Print verbose output (e.g., skipped scripts).
+    strict bool       # Surface advisory checks (e.g. unhandled fallible calls) as warnings.
 
     script mutually excludes from_logs
 
 if from_logs:
-    _rad_check_from_logs(from_logs, verbose)
+    _rad_check_from_logs(from_logs, verbose, strict)
 else if script:
-    result = _rad_run_check(script)
+    result = _rad_run_check(script, strict)
 
     diagnostics = result.diagnostics
 

--- a/core/func_helpers.go
+++ b/core/func_helpers.go
@@ -89,15 +89,9 @@ func (i *Interpreter) callFunction(callNode *rl.Call, ufcsArg *PosArg) RadValue 
 
 	val, exist := i.env.GetVar(funcName)
 	if !exist {
-		switch funcName {
-		case "get_default":
+		if hint, ok := rl.RemovedFuncHints[funcName]; ok {
 			i.emitErrorWithHint(rl.ErrUnknownFunction, funcExpr,
-				"Cannot invoke unknown function: get_default",
-				"get_default was removed. Use: map[\"key\"] ?? default. See: https://amterp.dev/rad/migrations/v0.8/")
-		case "get_stash_dir":
-			i.emitErrorWithHint(rl.ErrUnknownFunction, funcExpr,
-				"Cannot invoke unknown function: get_stash_dir",
-				"get_stash_dir was renamed to get_stash_path. See: https://amterp.dev/rad/migrations/v0.9/")
+				"Cannot invoke unknown function: "+funcName, hint)
 		}
 		i.emitErrorf(rl.ErrUnknownFunction, funcExpr, "Cannot invoke unknown function: %s", funcName)
 	}

--- a/core/funcs.go
+++ b/core/funcs.go
@@ -790,7 +790,7 @@ func init() {
 
 				radMap.SetPrimitiveStr(constFullPath, NormalizePath(absPath))
 
-				stat, err1 := os.Stat(path)
+				stat, err1 := os.Stat(absPath)
 				if err1 == nil {
 					radMap.SetPrimitiveStr(constBaseName, stat.Name())
 					radMap.SetPrimitiveStr(constPermissions, stat.Mode().Perm().String())
@@ -835,7 +835,7 @@ func init() {
 						relativeMode, []string{constTarget, constCwd, constAbsolute})
 				}
 
-				absTarget, err := filepath.Abs(path) // todo should be abstracted away for testing
+				absTarget, err := filepath.Abs(com.ExpandTilde(path)) // todo should be abstracted away for testing
 				if err != nil {
 					return f.ReturnErrf(rl.ErrGenericRuntime, "Error resolving absolute path for target: %v", err)
 				}
@@ -901,7 +901,7 @@ func init() {
 			// todo should offer args like find_paths
 			Name: FUNC_DELETE_PATH,
 			Execute: func(f FuncInvocation) RadValue {
-				path := f.GetStr("_path").Plain()
+				path := com.ExpandTilde(f.GetStr("_path").Plain())
 				deleted := false
 
 				if _, err := os.Stat(path); err == nil {
@@ -1119,7 +1119,7 @@ func init() {
 			//   - tail              # Last N bytes
 			Name: FUNC_READ_FILE,
 			Execute: func(f FuncInvocation) RadValue {
-				path := f.GetStr("_path").Plain()
+				path := com.ExpandTilde(f.GetStr("_path").Plain())
 				mode := f.GetStr("mode").Plain()
 
 				data, err := os.ReadFile(path)
@@ -1158,7 +1158,7 @@ func init() {
 		{
 			Name: FUNC_WRITE_FILE,
 			Execute: func(f FuncInvocation) RadValue {
-				path := f.GetStr("_path").Plain()
+				path := com.ExpandTilde(f.GetStr("_path").Plain())
 				content := f.GetStr("_content").Plain()
 				appendFlag := f.GetBool("append")
 

--- a/core/funcs_internal.go
+++ b/core/funcs_internal.go
@@ -70,28 +70,29 @@ func AddInternalFuncs() {
 		{
 			Name: INTERNAL_FUNC_RUN_CHECK,
 			Execute: func(f FuncInvocation) RadValue {
-				scriptArg := f.args[0]
-				scriptPath := scriptArg.value.RequireStr(f.i, scriptArg.node).Plain()
+				scriptPath := f.GetStr("_script").Plain()
 				if !com.IsRegularFile(scriptPath) {
-					f.i.emitErrorf(rl.ErrFileRead, scriptArg.node, "Cannot check '%s': not a regular file", scriptPath)
+					f.i.emitErrorf(rl.ErrFileRead, f.callNode, "Cannot check '%s': not a regular file", scriptPath)
 				}
 				result := com.LoadFile(scriptPath)
 				if result.Error != nil {
 					// todo don't think we can point at the node -- it's an internal function. Generally true for embedded commands, actually
-					f.i.emitErrorf(rl.ErrFileRead, scriptArg.node, "Failed to load script for checking: %s", result.Error.Error())
+					f.i.emitErrorf(rl.ErrFileRead, f.callNode, "Failed to load script for checking: %s", result.Error.Error())
 				}
 
 				contents := NormalizeLineEndings(result.Content)
 				checker, err := check.NewChecker()
 				if err != nil {
-					f.i.emitErrorf(rl.ErrGenericRuntime, scriptArg.node, "Failed to create checker: %s", err.Error())
+					f.i.emitErrorf(rl.ErrGenericRuntime, f.callNode, "Failed to create checker: %s", err.Error())
 				}
+
+				checker.SetStrict(f.GetBool("_strict"))
 
 				checker.UpdateSrc(contents)
 
 				checkR, err := checker.Check()
 				if err != nil {
-					f.i.emitErrorf(rl.ErrGenericRuntime, scriptArg.node, "Failed to run checker: %s", err.Error())
+					f.i.emitErrorf(rl.ErrGenericRuntime, f.callNode, "Failed to run checker: %s", err.Error())
 				}
 
 				radMap := NewRadMap()

--- a/core/funcs_internal_check_from_logs.go
+++ b/core/funcs_internal_check_from_logs.go
@@ -68,6 +68,7 @@ var FuncInternalCheckFromLogs = BuiltInFunc{
 
 		// Get verbose flag
 		verbose := f.GetBool("_verbose")
+		strict := f.GetBool("_strict")
 
 		// read and parse invocation logs
 		scripts := parseInvocationLogs(f.i, f.callNode, durationMillis)
@@ -89,6 +90,9 @@ var FuncInternalCheckFromLogs = BuiltInFunc{
 			chk = nil
 			RP.RadStderrf("Warning! Failed to init checker once, will init per file: %v\n", err)
 		}
+		if chk != nil {
+			chk.SetStrict(strict)
+		}
 
 		// First pass: collect results and determine max path width for alignment
 		results := make([]scriptResult, 0, len(scripts))
@@ -101,7 +105,7 @@ var FuncInternalCheckFromLogs = BuiltInFunc{
 				continue
 			}
 			checkStart := time.Now()
-			counts, ok := checkScriptWith(script.Path, chk)
+			counts, ok := checkScriptWith(script.Path, chk, strict)
 			RP.RadDebugf("  checked in %s (ok=%t, errors=%d)", time.Since(checkStart), ok, counts.Errors)
 			r := scriptResult{Path: script.Path, Counts: counts, Ok: ok}
 			results = append(results, r)
@@ -374,7 +378,9 @@ func sortScriptsByLastOccurrence(scripts []scriptInfo) {
 
 // checkScriptWith runs rad checks and returns per-severity counts.
 // The bool is false when the file can't be loaded or parsed at all.
-func checkScriptWith(scriptPath string, reusable check.RadChecker) (diagCounts, bool) {
+// strict is applied to the fallback checker created when reusable is nil; the
+// caller has already set it on a non-nil reusable checker.
+func checkScriptWith(scriptPath string, reusable check.RadChecker, strict bool) (diagCounts, bool) {
 	result := com.LoadFile(scriptPath)
 	if result.Error != nil {
 		return diagCounts{}, false
@@ -387,6 +393,7 @@ func checkScriptWith(scriptPath string, reusable check.RadChecker) (diagCounts, 
 		if err != nil {
 			return diagCounts{}, false
 		}
+		chk.SetStrict(strict)
 	}
 
 	chk.UpdateSrc(NormalizeLineEndings(result.Content))

--- a/core/testing/check_test.go
+++ b/core/testing/check_test.go
@@ -137,3 +137,30 @@ Reported 2 diagnostics.
 `
 	assertOnlyOutput(t, stdOutBuffer, expected)
 }
+
+func Test_Check_UnhandledFallible_HiddenByDefault(t *testing.T) {
+	// RAD30011 (unhandled fallible call) is suppressed by default - it's too
+	// noisy to be on for every fallible builtin.
+	expected := `No diagnostics to report.
+`
+	setupAndRunArgs(t, "check", "./rad_scripts/unhandled_fallible.rad", "--color=never")
+	assertOnlyOutput(t, stdOutBuffer, expected)
+	assertNoErrors(t)
+}
+
+func Test_Check_UnhandledFallible_StrictSurfacesWarning(t *testing.T) {
+	// Under --strict the advisory surfaces, as a warning (not an error), so it
+	// doesn't fail the exit code.
+	expected := `L1:5: WARN
+
+     1 | n = parse_int("5")
+       |     ^ This call can fail; the error isn't handled and would halt the script
+       |     (code: RAD30011)
+       = help: Handle it with ` + "`catch`" + ` or ` + "`??`" + `, e.g. ` + "`x = <call> catch <fallback>`" + `
+
+Reported 1 diagnostic.
+`
+	setupAndRunArgs(t, "check", "./rad_scripts/unhandled_fallible.rad", "--strict", "--color=never")
+	assertOnlyOutput(t, stdOutBuffer, expected)
+	assertExitCode(t, 0)
+}

--- a/core/testing/docs_snippet_tolerances.go
+++ b/core/testing/docs_snippet_tolerances.go
@@ -98,12 +98,12 @@ var docSnippetTolerances = map[string]Tolerance{
 		Reason:        "demo: scope leak - `config` defined inside setup() isn't visible after.",
 	},
 	"core/error_docs/20030.md#63c4f300": {
-		ExpectedCodes: []string{"RAD20030", "RAD30002"},
-		Reason:        "demo: break outside a loop. RAD30002 is incidental - `i > 5` in the Correct half fires a Hint because iterating `range(10)` binds `i` as `float|int` and `>` doesn't yet narrow that union against the int literal.",
+		ExpectedCodes: []string{"RAD20030"},
+		Reason:        "demo: break outside a loop. (The old incidental RAD30002 on `i > 5` is gone now that comparisons decompose a numeric `float|int` union.)",
 	},
 	"core/error_docs/20031.md#34cd8497": {
-		ExpectedCodes: []string{"RAD20031", "RAD30002"},
-		Reason:        "demo: continue outside a loop. RAD30002 is incidental for the same reason as 20030 (range element binds as float|int).",
+		ExpectedCodes: []string{"RAD20031"},
+		Reason:        "demo: continue outside a loop. (Old incidental RAD30002 gone now that numeric-union comparisons type-check.)",
 	},
 	"core/error_docs/30002.md#39029f35": {
 		ExpectedCodes: []string{"RAD30002"},
@@ -324,12 +324,6 @@ var docSnippetTolerances = map[string]Tolerance{
 	"docs-web/docs/migrations/v0.9.md#99b3964d": {Skip: true, Reason: "migration guide: before/after example"},
 	"docs-web/docs/migrations/v0.9.md#b0cf666d": {Skip: true, Reason: "migration guide: before/after example"},
 
-	// ---- docs-web/docs/guide/args.md -------------------------------
-	"docs-web/docs/guide/args.md#9b627343": {
-		ExpectedCodes: []string{"RAD30001"},
-		Reason:        "checker hint: `[upper(w) for w in words]` synthesises as `dynamic|str[]` (list-comprehension result loses its precise list typing), so the subsequent `join(words, joiner)` call flags a hint. The script is correct at runtime.",
-	},
-
 	// ---- docs-web/docs/guide/basics.md ------------------------------
 	"docs-web/docs/guide/basics.md#210039b1": {
 		Skip:   true,
@@ -528,44 +522,24 @@ var docSnippetTolerances = map[string]Tolerance{
 	},
 
 	// ---- docs-web/docs/guide/type-annotations.md --------------------
-	// Type-annotation examples often demonstrate function signatures
-	// against typed returns. The remaining pins here hit an *inference*
-	// fidelity gap: the returned value is a variable built up in a loop
-	// (`counts = {}; counts[k] = 1; return counts`), so its synthesised
-	// type stays wider than the declared annotated shape and the static
-	// check fires a Hint even though the code is correct at runtime.
-	// (The literal-at-site cases - returning a map/list literal directly -
-	// are now handled structurally by check and no longer fire.) Pinned
-	// to RAD30001 (Hint) so language changes that surface a different
-	// code show up.
+	// Type-annotation examples demonstrate function signatures against
+	// typed returns. The loop-built-collection cases (`counts = {};
+	// counts[k] = 1; return counts`) no longer fire: a bare `list`/`map`
+	// now flows into a typed `T[]`/`{K: V}` as the gradual escape hatch.
+	// The remaining pins are intentional teaching demos (bad arg type,
+	// missing `T?`) or a still-imprecise vararg-into-typed-param case.
 
 	"docs-web/docs/guide/type-annotations.md#8bcb60a4": {
-		ExpectedCodes: []string{"RAD30001", "RAD30002"},
-		Reason:        "checker hint: vararg `*data_points: int|float` doesn't refine into `sum()`'s `float[]` or `join()`'s `str|list|map` parameters. RAD30002 cascades on the division because total/len both produce union types.",
+		ExpectedCodes: []string{"RAD30001"},
+		Reason:        "checker hint: vararg `*data_points: int|float` doesn't refine into `sum()`'s `float[]` parameter. (The old RAD30002 on the division is gone now that numeric-union operands decompose.)",
 	},
 	"docs-web/docs/guide/type-annotations.md#b264b53b": {
 		ExpectedCodes: []string{"RAD30001"},
 		Reason:        "intentional demo: returning null from fn typed as str (without ?). Doc teaches that T? is required for nullable returns.",
 	},
-	"docs-web/docs/guide/type-annotations.md#b4fcceab": {
-		ExpectedCodes: []string{"RAD30001"},
-		Reason:        "literal-fidelity hint: list-literal append into a typed list parameter.",
-	},
 	"docs-web/docs/guide/type-annotations.md#b9ca5c02": {
 		ExpectedCodes: []string{"RAD30001"},
 		Reason:        "intentional demo: calling greet(42) where greet expects str - the doc teaches arg-type checking.",
-	},
-	"docs-web/docs/guide/type-annotations.md#ca9eb821": {
-		ExpectedCodes: []string{"RAD30002"},
-		Reason:        "literal-fidelity hint on words.join(' ') return type vs declared str.",
-	},
-	"docs-web/docs/guide/type-annotations.md#defd0b86": {
-		ExpectedCodes: []string{"RAD30001"},
-		Reason:        "literal-fidelity hint on map-of-list return shape.",
-	},
-	"docs-web/docs/guide/type-annotations.md#efadde9e": {
-		ExpectedCodes: []string{"RAD30001"},
-		Reason:        "literal-fidelity hint on map-of-int return shape.",
 	},
 
 	// ---- docs-web/docs/releases.md ----------------------------------

--- a/core/testing/func_path_tilde_unix_test.go
+++ b/core/testing/func_path_tilde_unix_test.go
@@ -1,0 +1,72 @@
+//go:build unix
+
+package testing
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// Issue 125: path builtins should expand a leading "~" consistently, matching
+// shell behavior. These tests point $HOME at a temp dir (os.UserHomeDir reads
+// $HOME on unix) so "~" resolves there without touching the real home.
+
+func Test_PathTilde_WriteReadDeleteRoundTrip(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+
+	script := `
+w = write_file("~/issue125.txt", "hi there")
+print(w.path)
+print(read_file("~/issue125.txt").content)
+print(delete_path("~/issue125.txt"))
+`
+	setupAndRunCode(t, script, "--color=never")
+	expected := fmt.Sprintf("%s/issue125.txt\nhi there\ntrue\n", filepath.ToSlash(tmpHome))
+	assertOnlyOutput(t, stdOutBuffer, expected)
+	assertNoErrors(t)
+
+	if _, err := os.Stat(filepath.Join(tmpHome, "issue125.txt")); !os.IsNotExist(err) {
+		t.Errorf("expected file to be deleted, stat err = %v", err)
+	}
+}
+
+// The headline inconsistency from the issue: get_path("~/...").exists was false
+// even when full_path pointed at a real file.
+func Test_PathTilde_GetPathExists(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+
+	target := filepath.Join(tmpHome, "exists_check.txt")
+	if err := os.WriteFile(target, []byte("x"), 0644); err != nil {
+		t.Fatalf("failed to seed file: %v", err)
+	}
+
+	script := `
+p = get_path("~/exists_check.txt")
+print(p.exists)
+print(p.full_path)
+`
+	setupAndRunCode(t, script, "--color=never")
+	expected := fmt.Sprintf("true\n%s/exists_check.txt\n", filepath.ToSlash(tmpHome))
+	assertOnlyOutput(t, stdOutBuffer, expected)
+	assertNoErrors(t)
+}
+
+func Test_PathTilde_FindPaths(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+
+	if err := os.WriteFile(filepath.Join(tmpHome, "a.txt"), []byte("a"), 0644); err != nil {
+		t.Fatalf("failed to seed file: %v", err)
+	}
+
+	script := `
+print(find_paths("~"))
+`
+	setupAndRunCode(t, script, "--color=never")
+	assertOnlyOutput(t, stdOutBuffer, "[ \"a.txt\" ]\n")
+	assertNoErrors(t)
+}

--- a/core/testing/funcdocs_test.go
+++ b/core/testing/funcdocs_test.go
@@ -41,8 +41,33 @@ func TestFuncDocsValid(t *testing.T) {
 			if doc.Category == "" {
 				t.Errorf("%s: empty category", name)
 			}
+			if marker := danglingNotesMarker(doc.Notes); marker != "" {
+				t.Errorf("%s: Notes ends with a dangling bold label %q with no "+
+					"content after it - drop the marker or fill it in", name, marker)
+			}
 		})
 	}
+}
+
+// danglingNotesMarker returns the last line of a Notes section when
+// that line is a lone bold label (e.g. "**Examples:**") with nothing
+// following it, otherwise "". The docs/funcs source-of-truth
+// migration left such empty markers behind, which the functions.md
+// generator then rendered as empty headers (issue 128). This guard
+// keeps the smell from recurring for any label, not just Examples.
+func danglingNotesMarker(notes string) string {
+	lines := strings.Split(strings.TrimRight(notes, "\n"), "\n")
+	for i := len(lines) - 1; i >= 0; i-- {
+		last := strings.TrimSpace(lines[i])
+		if last == "" {
+			continue
+		}
+		if strings.HasPrefix(last, "**") && strings.HasSuffix(last, ":**") {
+			return last
+		}
+		return ""
+	}
+	return ""
 }
 
 // TestParseFuncDocNormalizesCRLF guards the cross-platform bug where

--- a/core/testing/rad_scripts/unhandled_fallible.rad
+++ b/core/testing/rad_scripts/unhandled_fallible.rad
@@ -1,0 +1,2 @@
+n = parse_int("5")
+print(n + 1)

--- a/core/testing/snapshots/misc/migration.snap
+++ b/core/testing/snapshots/misc/migration.snap
@@ -75,7 +75,7 @@ error[RAD20028]: Undefined identifier 'get_default'
 3 | get_default(m, "b", 0)
   | ^^^^^^^^^^^
   |
-   = help: did you mean 'get_args', 'get_env', or 'get_path'?
+   = help: get_default was removed. Use: map["key"] ?? default. See: https://amterp.dev/rad/migrations/v0.8/
    = info: rad explain RAD20028
 
 
@@ -94,7 +94,7 @@ error[RAD20028]: Undefined identifier 'get_stash_dir'
 2 | get_stash_dir()
   | ^^^^^^^^^^^^^
   |
-   = help: did you mean 'get_stash_path', 'get_path', or 'load_stash_file'?
+   = help: get_stash_dir was renamed to get_stash_path. See: https://amterp.dev/rad/migrations/v0.9/
    = info: rad explain RAD20028
 
 
@@ -114,7 +114,7 @@ error[RAD20028]: Undefined identifier 'get_default'
 3 | m.get_default("b", 0)
   |   ^^^^^^^^^^^
   |
-   = help: did you mean 'get_args', 'get_env', or 'get_path'?
+   = help: get_default was removed. Use: map["key"] ?? default. See: https://amterp.dev/rad/migrations/v0.8/
    = info: rad explain RAD20028
 
 

--- a/docs-web/docs/reference/functions.md
+++ b/docs-web/docs/reference/functions.md
@@ -792,8 +792,6 @@ paths = find_paths("src/", relative="absolute")
 
 A leading `~` in `_path` is expanded to your home directory.
 
-**Examples:**
-
 ### input
 
 Gets a line of text input from the user with optional prompt, default, hint, and secret mode.
@@ -828,8 +826,6 @@ password = input("Password: ", secret=true)           // -> Hides typed characte
 If `secret` is true, input is hidden (useful for passwords). The `hint` parameter has no effect when `secret` is
 enabled.
 
-**Examples:**
-
 ### multipick
 
 Presents an interactive menu for selecting multiple options from a list.
@@ -857,8 +853,6 @@ Unlike `pick`, which returns a single selection, `multipick` returns a list of a
 | `max`      | `int?`    | Maximum number of selections allowed (optional, unlimited if not set)         |
 
 The `prompt` parameter has smart defaults that adjust based on the min/max constraints.
-
-**Example:**
 
 ### pick
 
@@ -1012,8 +1006,6 @@ A leading `~` in `_path` is expanded to your home directory.
 - `size_bytes: int` - File size in bytes
 - `content: str|list[int]` - File contents (type depends on mode)
 
-**Examples:**
-
 ### read_stdin
 
 Reads all data from stdin.
@@ -1069,8 +1061,6 @@ A leading `~` in `_path` is expanded to your home directory.
 - `bytes_written: int` - Number of bytes written
 - `path: str` - Full path to the written file
 
-**Examples:**
-
 ## Lists
 
 ### filter
@@ -1087,8 +1077,6 @@ filter({"a": 1, "b": 2}, fn(k, v) v > 1)    // -> {"b": 2}
 ```
 
 For lists, function receives `fn(value)`. For maps, function receives `fn(key, value)`.
-
-**Examples:**
 
 ### flat_map
 
@@ -1125,8 +1113,6 @@ flat_map(_coll: map|list, _fn: any?) -> list
 **With function:** The function must return a list. Results are flattened.
 
 For lists, function receives `fn(value)`. For maps, function receives `fn(key, value)` and is required.
-
-**Examples:**
 
 ### join
 
@@ -1188,8 +1174,6 @@ map({"a": 1, "b": 2}, fn(k, v) v * 10)   // -> {"a": 10, "b": 20}
 ```
 
 For lists, function receives `fn(value)`. For maps, function receives `fn(key, value)`.
-
-**Examples:**
 
 ### sort
 
@@ -1272,8 +1256,6 @@ zip([1, 2, 3], ["a", "b"], strict=true)   // -> Error: Lists must have the same 
 - By default, truncates to the shortest list length
 - Cannot use `strict=true` with `fill` parameter (mutually exclusive)
 - Returns error if `strict=true` and lists have different lengths
-
-**Examples:**
 
 ## Math
 
@@ -1719,8 +1701,6 @@ load(cache, "data", fn() ignored(), override="forced")
 If key doesn't exist, `_loader` is called and result is cached. Cannot use `reload=true` with `override` (mutually
 exclusive).
 
-**Examples:**
-
 ### load_stash_file
 
 Loads a file from the script's stash directory, creating it with default content if it doesn't exist.
@@ -1852,8 +1832,6 @@ rad:
 
 Useful for automatically coloring table data or distinguishing values in lists.
 
-**Examples:**
-
 ### count
 
 Counts the number of non-overlapping instances of substring in string.
@@ -1929,8 +1907,6 @@ index_of(_subject: str|list, _target: any, *, n: int = 0, start: int = 0) -> int
 | `n`        | `int = 0`   | Which occurrence to find (0=first, 1=second, -1=last) |
 | `start`    | `int = 0`   | Position to start searching from                      |
 
-**Examples:**
-
 ### lower
 
 Converts a string to lowercase. Preserves color attributes.
@@ -1976,8 +1952,6 @@ replace("abc123def", "\\d+", "XXX")           // -> "abcXXXdef"
 ```
 
 The `_find` parameter is a regex pattern. The `_replace` parameter can use regex capture groups like `$1`.
-
-**Examples:**
 
 ### reverse
 
@@ -2254,8 +2228,6 @@ if info.exists:
 - `modified_millis?: int` - Modification time as epoch milliseconds
 - `accessed_millis?: int` - Access time as epoch milliseconds (Unix/macOS only)
 
-**Examples:**
-
 ### has_stdin
 
 Checks if stdin is piped to the script.
@@ -2316,8 +2288,6 @@ If `title` is provided, it's printed before sleeping.
 | `ms`         | Milliseconds |
 | `us` or `µs` | Microseconds |
 | `ns`         | Nanoseconds  |
-
-**Examples:**
 
 ### type_of
 
@@ -2386,8 +2356,6 @@ Map values:
 | `.epoch.seconds` | Seconds since 1970-01-01 00:00:00 UTC | int    | 1576246516          |
 | `.epoch.millis`  | Millis since 1970-01-01 00:00:00 UTC  | int    | 1576246516123       |
 | `.epoch.nanos`   | Nanos since 1970-01-01 00:00:00 UTC   | int    | 1576246516123456789 |
-
-**Examples:**
 
 ### parse_date
 
@@ -2460,8 +2428,6 @@ For strings without timezone information, the time is interpreted in the `tz` ti
 default). For strings with timezone info (e.g., `Z`, `+05:00`), the time is parsed in that timezone
 and then converted to the output `tz`.
 
-**Examples:**
-
 ### parse_epoch
 
 Parses a Unix epoch timestamp into various time formats.
@@ -2507,5 +2473,3 @@ if err:
 Converts an epoch timestamp to the same format as [`now()`](#now). Auto-detects units from digit count, or specify
 explicitly. When using a float, the fractional part provides sub-unit precision (e.g., `1712345678.5` seconds includes
 500 milliseconds).
-
-**Examples:**

--- a/docs-web/docs/reference/functions.md
+++ b/docs-web/docs/reference/functions.md
@@ -840,7 +840,7 @@ selected = multipick(fruits)
 // selected equals e.g. [ "apple", "cherry" ]
 ```
 
-Shows an interactive multi-select menu where users can select zero or more options. =
+Shows an interactive multi-select menu where users can select zero or more options.
 Unlike `pick`, which returns a single selection, `multipick` returns a list of all selected items.
 
 **Parameters:**

--- a/docs-web/docs/reference/functions.md
+++ b/docs-web/docs/reference/functions.md
@@ -755,6 +755,8 @@ delete_path("directory/")       // -> true (if directory existed and was deleted
 
 Returns `true` if the path was successfully deleted, `false` if it didn't exist or couldn't be deleted.
 
+A leading `~` in `_path` is expanded to your home directory.
+
 ### find_paths
 
 Returns a list of all paths under a directory.
@@ -787,6 +789,8 @@ paths = find_paths("src/", relative="absolute")
 - `"target"` - Relative to input path (default)
 - `"cwd"` - Relative to current directory
 - `"absolute"` - Full absolute paths
+
+A leading `~` in `_path` is expanded to your home directory.
 
 **Examples:**
 
@@ -1001,6 +1005,8 @@ if not result.success:
 
 In text mode, decodes as UTF-8 and returns a string. In bytes mode, returns a list of integers.
 
+A leading `~` in `_path` is expanded to your home directory.
+
 **Return map contains:**
 
 - `size_bytes: int` - File size in bytes
@@ -1055,6 +1061,8 @@ if err:
 | `append`   | `bool = false` | Append to existing content instead of overwriting |
 
 By default overwrites the file. Use `append=true` to append to existing content.
+
+A leading `~` in `_path` is expanded to your home directory.
 
 **Return map contains:**
 
@@ -2235,7 +2243,7 @@ if info.exists:
 **Always returns:**
 
 - `exists: bool` - Whether the path exists
-- `full_path: str` - Absolute path
+- `full_path: str` - Absolute path (a leading `~` in `_path` is expanded to your home directory)
 
 **When path exists, also returns:**
 

--- a/docs/funcs/colorize.md
+++ b/docs/funcs/colorize.md
@@ -37,5 +37,3 @@ strings
 | `skip_if_single` | `bool = false` | Don't colorize if only one value in set        |
 
 Useful for automatically coloring table data or distinguishing values in lists.
-
-**Examples:**

--- a/docs/funcs/delete_path.md
+++ b/docs/funcs/delete_path.md
@@ -21,3 +21,5 @@ io
 ## Notes
 
 Returns `true` if the path was successfully deleted, `false` if it didn't exist or couldn't be deleted.
+
+A leading `~` in `_path` is expanded to your home directory.

--- a/docs/funcs/filter.md
+++ b/docs/funcs/filter.md
@@ -20,5 +20,3 @@ lists
 ## Notes
 
 For lists, function receives `fn(value)`. For maps, function receives `fn(key, value)`.
-
-**Examples:**

--- a/docs/funcs/find_paths.md
+++ b/docs/funcs/find_paths.md
@@ -39,4 +39,6 @@ io
 - `"cwd"` - Relative to current directory
 - `"absolute"` - Full absolute paths
 
+A leading `~` in `_path` is expanded to your home directory.
+
 **Examples:**

--- a/docs/funcs/find_paths.md
+++ b/docs/funcs/find_paths.md
@@ -40,5 +40,3 @@ io
 - `"absolute"` - Full absolute paths
 
 A leading `~` in `_path` is expanded to your home directory.
-
-**Examples:**

--- a/docs/funcs/flat_map.md
+++ b/docs/funcs/flat_map.md
@@ -41,5 +41,3 @@ lists
 **With function:** The function must return a list. Results are flattened.
 
 For lists, function receives `fn(value)`. For maps, function receives `fn(key, value)` and is required.
-
-**Examples:**

--- a/docs/funcs/get_path.md
+++ b/docs/funcs/get_path.md
@@ -42,5 +42,3 @@ system
 - `size_bytes?: int` - File size (only for files)
 - `modified_millis?: int` - Modification time as epoch milliseconds
 - `accessed_millis?: int` - Access time as epoch milliseconds (Unix/macOS only)
-
-**Examples:**

--- a/docs/funcs/get_path.md
+++ b/docs/funcs/get_path.md
@@ -32,7 +32,7 @@ system
 **Always returns:**
 
 - `exists: bool` - Whether the path exists
-- `full_path: str` - Absolute path
+- `full_path: str` - Absolute path (a leading `~` in `_path` is expanded to your home directory)
 
 **When path exists, also returns:**
 

--- a/docs/funcs/index_of.md
+++ b/docs/funcs/index_of.md
@@ -37,5 +37,3 @@ strings
 | `_target`  | `any`       | The value to search for                               |
 | `n`        | `int = 0`   | Which occurrence to find (0=first, 1=second, -1=last) |
 | `start`    | `int = 0`   | Position to start searching from                      |
-
-**Examples:**

--- a/docs/funcs/input.md
+++ b/docs/funcs/input.md
@@ -39,5 +39,3 @@ io
 
 If `secret` is true, input is hidden (useful for passwords). The `hint` parameter has no effect when `secret` is
 enabled.
-
-**Examples:**

--- a/docs/funcs/load.md
+++ b/docs/funcs/load.md
@@ -38,5 +38,3 @@ stash
 
 If key doesn't exist, `_loader` is called and result is cached. Cannot use `reload=true` with `override` (mutually
 exclusive).
-
-**Examples:**

--- a/docs/funcs/map.md
+++ b/docs/funcs/map.md
@@ -20,5 +20,3 @@ lists
 ## Notes
 
 For lists, function receives `fn(value)`. For maps, function receives `fn(key, value)`.
-
-**Examples:**

--- a/docs/funcs/multipick.md
+++ b/docs/funcs/multipick.md
@@ -20,7 +20,7 @@ io
 
 ## Notes
 
-Shows an interactive multi-select menu where users can select zero or more options. =
+Shows an interactive multi-select menu where users can select zero or more options.
 Unlike `pick`, which returns a single selection, `multipick` returns a list of all selected items.
 
 **Parameters:**

--- a/docs/funcs/multipick.md
+++ b/docs/funcs/multipick.md
@@ -33,5 +33,3 @@ Unlike `pick`, which returns a single selection, `multipick` returns a list of a
 | `max`      | `int?`    | Maximum number of selections allowed (optional, unlimited if not set)         |
 
 The `prompt` parameter has smart defaults that adjust based on the min/max constraints.
-
-**Example:**

--- a/docs/funcs/now.md
+++ b/docs/funcs/now.md
@@ -50,5 +50,3 @@ Map values:
 | `.epoch.seconds` | Seconds since 1970-01-01 00:00:00 UTC | int    | 1576246516          |
 | `.epoch.millis`  | Millis since 1970-01-01 00:00:00 UTC  | int    | 1576246516123       |
 | `.epoch.nanos`   | Nanos since 1970-01-01 00:00:00 UTC   | int    | 1576246516123456789 |
-
-**Examples:**

--- a/docs/funcs/parse_date.md
+++ b/docs/funcs/parse_date.md
@@ -76,5 +76,3 @@ wrong results or parse errors.
 For strings without timezone information, the time is interpreted in the `tz` timezone (local by
 default). For strings with timezone info (e.g., `Z`, `+05:00`), the time is parsed in that timezone
 and then converted to the output `tz`.
-
-**Examples:**

--- a/docs/funcs/parse_epoch.md
+++ b/docs/funcs/parse_epoch.md
@@ -51,5 +51,3 @@ time
 Converts an epoch timestamp to the same format as [`now()`](#now). Auto-detects units from digit count, or specify
 explicitly. When using a float, the fractional part provides sub-unit precision (e.g., `1712345678.5` seconds includes
 500 milliseconds).
-
-**Examples:**

--- a/docs/funcs/read_file.md
+++ b/docs/funcs/read_file.md
@@ -46,5 +46,3 @@ A leading `~` in `_path` is expanded to your home directory.
 
 - `size_bytes: int` - File size in bytes
 - `content: str|list[int]` - File contents (type depends on mode)
-
-**Examples:**

--- a/docs/funcs/read_file.md
+++ b/docs/funcs/read_file.md
@@ -40,6 +40,8 @@ io
 
 In text mode, decodes as UTF-8 and returns a string. In bytes mode, returns a list of integers.
 
+A leading `~` in `_path` is expanded to your home directory.
+
 **Return map contains:**
 
 - `size_bytes: int` - File size in bytes

--- a/docs/funcs/replace.md
+++ b/docs/funcs/replace.md
@@ -21,5 +21,3 @@ strings
 ## Notes
 
 The `_find` parameter is a regex pattern. The `_replace` parameter can use regex capture groups like `$1`.
-
-**Examples:**

--- a/docs/funcs/sleep.md
+++ b/docs/funcs/sleep.md
@@ -37,5 +37,3 @@ If `title` is provided, it's printed before sleeping.
 | `ms`         | Milliseconds |
 | `us` or `µs` | Microseconds |
 | `ns`         | Nanoseconds  |
-
-**Examples:**

--- a/docs/funcs/write_file.md
+++ b/docs/funcs/write_file.md
@@ -38,6 +38,8 @@ io
 
 By default overwrites the file. Use `append=true` to append to existing content.
 
+A leading `~` in `_path` is expanded to your home directory.
+
 **Return map contains:**
 
 - `bytes_written: int` - Number of bytes written

--- a/docs/funcs/write_file.md
+++ b/docs/funcs/write_file.md
@@ -44,5 +44,3 @@ A leading `~` in `_path` is expanded to your home directory.
 
 - `bytes_written: int` - Number of bytes written
 - `path: str` - Full path to the written file
-
-**Examples:**

--- a/docs/funcs/zip.md
+++ b/docs/funcs/zip.md
@@ -37,5 +37,3 @@ lists
 - By default, truncates to the shortest list length
 - Cannot use `strict=true` with `fill` parameter (mutually exclusive)
 - Returns error if `strict=true` and lists have different lengths
-
-**Examples:**

--- a/radls/analysis/diagnostics_test.go
+++ b/radls/analysis/diagnostics_test.go
@@ -81,6 +81,7 @@ type stubChecker struct {
 
 func (s *stubChecker) UpdateSrc(string)                            {}
 func (s *stubChecker) Update(*rts.RadTree, string, *rl.SourceFile) {}
+func (s *stubChecker) SetStrict(bool)                              {}
 func (s *stubChecker) Check() (check.Result, error)                { return s.result, nil }
 
 // Compile-time interface check. lsp import keeps the file honest if

--- a/rts/check/binder.go
+++ b/rts/check/binder.go
@@ -157,12 +157,21 @@ func (b *binder) resolveIdentifier(ident *rl.Identifier) *Symbol {
 // runtime's FindSimilarVars so the static and runtime suggestion
 // sets line up.
 func (b *binder) emitUndefinedIdentifier(ident *rl.Identifier) {
-	var builtinNames map[string]bool
-	if b.builtins != nil {
-		builtinNames = b.builtins.Names()
+	// A removed/renamed builtin gets its migration hint rather than a generic
+	// "did you mean" - the runtime shows the same text (rl.RemovedFuncHints),
+	// so a script failing at runtime and one flagged by `rad check` guide the
+	// user identically.
+	suggestion := ""
+	if hint, ok := rl.RemovedFuncHints[ident.Name]; ok {
+		suggestion = hint
+	} else {
+		var builtinNames map[string]bool
+		if b.builtins != nil {
+			builtinNames = b.builtins.Names()
+		}
+		similar := findSimilarNames(b.current, builtinNames, ident.Name, 3)
+		suggestion = formatDidYouMean(similar)
 	}
-	similar := findSimilarNames(b.current, builtinNames, ident.Name, 3)
-	suggestion := formatDidYouMean(similar)
 	b.resolved.Issues = append(b.resolved.Issues, BindIssue{
 		Span:       ident.Span(),
 		Severity:   IssueError,
@@ -573,8 +582,8 @@ func (b *binder) bindFnLike(typing *rl.TypingFnT, body []rl.Node, kind ScopeKind
 				continue
 			}
 			sym := b.declare(p.Name, SymParam, declSpan, nil)
-			// Param type annotation acts like a typed local'\''s
-			// declared type: it'\''s an immutable contract subsequent
+			// Param type annotation acts like a typed local's
+			// declared type: it's an immutable contract subsequent
 			// reads / assigns must respect. Unannotated params stay
 			// at Declared == nil (effectively Dynamic).
 			if p.Type != nil {

--- a/rts/check/check.go
+++ b/rts/check/check.go
@@ -9,6 +9,7 @@ import (
 type RadChecker interface {
 	UpdateSrc(src string)
 	Update(tree *rts.RadTree, src string, ast *rl.SourceFile)
+	SetStrict(strict bool)
 	Check() (Result, error)
 }
 
@@ -17,6 +18,9 @@ type RadCheckerImpl struct {
 	tree   *rts.RadTree
 	src    string
 	ast    *rl.SourceFile
+	// strict opts into advisory diagnostics that are suppressed by default
+	// (see strictOnlyCodes). Off unless the caller flips it on.
+	strict bool
 }
 
 func NewChecker() (RadChecker, error) {
@@ -62,6 +66,10 @@ func (c *RadCheckerImpl) Update(tree *rts.RadTree, src string, ast *rl.SourceFil
 	c.tree = tree
 	c.src = src
 	c.ast = ast
+}
+
+func (c *RadCheckerImpl) SetStrict(strict bool) {
+	c.strict = strict
 }
 
 func (c *RadCheckerImpl) Check() (Result, error) {
@@ -113,8 +121,27 @@ func (c *RadCheckerImpl) addTypeIssues(info *TypeInfo, d *[]Diagnostic) {
 		return
 	}
 	for _, issue := range info.Issues {
+		if strictOnlyCodes[issue.Code] {
+			// Suppressed by default; surfaced only under --strict, and then
+			// as a warning rather than its emit-time severity.
+			if !c.strict {
+				continue
+			}
+			issue.Severity = IssueWarning
+		}
 		*d = append(*d, diagnosticFromBindIssue(issue, c.src))
 	}
+}
+
+// strictOnlyCodes are advisory diagnostics that `rad check` hides by default
+// and surfaces only under --strict. RAD30011 (unhandled fallible call) is the
+// first: the concept is valuable (the parse_int-on-bad-input footgun is real),
+// but it fires on every fallible builtin - now(), round(), clamp(), zip(),
+// confirm(), ... - so on by default it drowns the signal (it was ~73% of all
+// hints in a real-script sweep). Strict mode is the opt-in for users who want
+// the nudge. Keep this table small; it's the single place a code opts in.
+var strictOnlyCodes = map[rl.Error]bool{
+	rl.ErrUnhandledFallibleCall: true,
 }
 
 // addBindIssues surfaces structural findings the binder collected

--- a/rts/check/check_lit.go
+++ b/rts/check/check_lit.go
@@ -79,7 +79,7 @@ func (tc *typeChecker) check(node rl.Node, expected rl.TypingT) checkResult {
 	// below exists solely to recover those false negatives, so anything
 	// IsAssignableFrom already admits (including `int?` into `int?` and
 	// `int|error` into `int|error`) must short-circuit here first.
-	if expected.IsAssignableFrom(got) {
+	if rl.IsAssignable(expected, got) {
 		return accept(node, got, expected)
 	}
 

--- a/rts/check/narrow.go
+++ b/rts/check/narrow.go
@@ -709,7 +709,7 @@ func narrowByTypeOf(base rl.TypingT, target string) (truthy, falsy rl.TypingT) {
 			// Drop Never contributions; preserve actual types.
 			// nil from a recursive call means "this arm has no
 			// static handle for either side." Pass the arm through
-			// unchanged so the union join doesn'\''t lose it.
+			// unchanged so the union join doesn't lose it.
 			if tA == nil {
 				truthyArms = append(truthyArms, arm)
 			} else if !isNeverType(tA) {
@@ -735,7 +735,7 @@ func narrowByTypeOf(base rl.TypingT, target string) (truthy, falsy rl.TypingT) {
 			// left is null.
 			return inner, rl.NewNullType()
 		}
-		// Inner doesn'\''t match target and null doesn'\''t match any
+		// Inner doesn't match target and null doesn't match any
 		// non-null target. Truthy is empty; falsy is the original.
 		return rl.NewNeverType(), base
 	}

--- a/rts/check/narrow_interp_test.go
+++ b/rts/check/narrow_interp_test.go
@@ -187,8 +187,8 @@ func TestNarrowByTypeOf_OptionalNullTarget(t *testing.T) {
 
 func TestNarrowByTypeOf_UnionWithOptionalPreservesNullArm(t *testing.T) {
 	// int?|str narrowed by type_of=="int".
-	// Truthy: int (the optional'\''s inner matched).
-	// Falsy: int? (the optional'\''s null half stays) and str (untouched).
+	// Truthy: int (the optional's inner matched).
+	// Falsy: int? (the optional's null half stays) and str (untouched).
 	// This is the Phase 4h regression test for "union+optional drops null."
 	base := rl.NewUnionType(
 		rl.NewOptionalType(rl.NewIntType()),
@@ -200,14 +200,14 @@ func TestNarrowByTypeOf_UnionWithOptionalPreservesNullArm(t *testing.T) {
 	require.NotNil(t, falsy)
 	// Falsy should contain int? (null arm preserved) and str. Exact
 	// representation depends on the join; what matters is the null
-	// component isn'\''t silently dropped.
+	// component isn't silently dropped.
 	name := falsy.Name()
 	assert.Contains(t, name, "?",
 		"falsy must retain the nullable arm; got %q", name)
 }
 
 func TestNarrowByTypeOf_AnyShortCircuits(t *testing.T) {
-	// any can'\''t be partitioned without losing information.
+	// any can't be partitioned without losing information.
 	truthy, falsy := narrowByTypeOf(rl.NewAnyType(), "int")
 	assert.Nil(t, truthy)
 	assert.Nil(t, falsy)
@@ -268,7 +268,7 @@ func TestInterpretCondition_TypeOfSwappedOperands(t *testing.T) {
 }
 
 func TestInterpretCondition_TypeOfInvalidTargetMakesTruthyUnreachable(t *testing.T) {
-	// type_of(x) == "frobnicate" - "frobnicate" isn'\''t a valid type_of
+	// type_of(x) == "frobnicate" - "frobnicate" isn't a valid type_of
 	// return, so the equality is statically false. Truthy is Never.
 	tc, ident, sym := makeChecker(rl.NewIntType())
 	cond := rl.NewOpBinary(rl.Span{}, rl.OpEq,
@@ -344,7 +344,7 @@ func TestInterpretCondition_StrEnumNeqLiteralInverts(t *testing.T) {
 }
 
 func TestInterpretCondition_StrEnumPlainStrNoNarrowing(t *testing.T) {
-	// Plain str shouldn'\''t narrow to a singleton enum - that surprises
+	// Plain str shouldn't narrow to a singleton enum - that surprises
 	// users who declared the var as str.
 	tc, ident, sym := makeChecker(rl.NewStrType())
 	cond := rl.NewOpBinary(rl.Span{}, rl.OpEq, ident, rl.NewLitStringSimple(rl.Span{}, "x"))

--- a/rts/check/snapshot_test.go
+++ b/rts/check/snapshot_test.go
@@ -92,6 +92,14 @@ func TestCheckSnapshots(t *testing.T) {
 				// proceeds without an AST; snapshots should too.
 				file := safeConvertCST(tree.Root(), tc.Input)
 				checker := check.NewCheckerWithTree(tree, parser, tc.Input, file)
+				// A case opts into strict mode (advisory codes like RAD30011
+				// surfaced as warnings) via `### ARGS ###` containing
+				// --strict, mirroring the real `rad check --strict` flag.
+				for _, arg := range tc.Args {
+					if strings.TrimSpace(arg) == "--strict" {
+						checker.SetStrict(true)
+					}
+				}
 				result, err := checker.Check()
 				require.NoError(t, err, "Check should not error")
 				// Resolved / Types may be nil when the converter

--- a/rts/check/snapshots/builtin_refine.snap
+++ b/rts/check/snapshots/builtin_refine.snap
@@ -1,0 +1,99 @@
+### TITLE ###
+UfcsSortPreservesElementType
+### DESCRIPTION ###
+The single-list UFCS form `items.sort()` threads the receiver in as the
+implicit first argument, so refinement preserves the element type (str[])
+just like the call form `sort(items)`. Iterating then yields str.
+### INPUT ###
+items = ["b", "a"]
+items = items.sort()
+for v in items:
+    split(v, ",")
+### STDOUT ###
+# Identifier types
+  items @ 1:1 -> <no-type>
+  items @ 2:1 -> <no-type>
+  items @ 2:9 -> str[]
+  sort @ 2:15 -> dynamic
+  items @ 3:10 -> str[]
+  split @ 4:5 -> dynamic
+  v @ 4:11 -> str
+
+# Symbol types
+  items (local): str[]
+  v (loop): str
+
+# Diagnostics
+  (none)
+### TITLE ###
+ParallelSortNotRefinedToFirstArg
+### DESCRIPTION ###
+Parallel sort (`sort(xs, ys)`) returns a list-of-lists, not its first
+argument, so refinement must NOT collapse the return to xs's type. The
+result stays the signature's wide type rather than being mis-typed int[].
+### INPUT ###
+xs = [3, 1, 2]
+ys = ["c", "a", "b"]
+a, b = sort(xs, ys)
+### STDOUT ###
+# Identifier types
+  xs @ 1:1 -> <no-type>
+  ys @ 2:1 -> <no-type>
+  a @ 3:1 -> <no-type>
+  b @ 3:4 -> <no-type>
+  sort @ 3:8 -> dynamic
+  xs @ 3:13 -> int[]
+  ys @ 3:17 -> str[]
+
+# Symbol types
+  a (local): dynamic|str
+  b (local): dynamic|null
+  xs (local): int[]
+  ys (local): str[]
+
+# Diagnostics
+  (none)
+### TITLE ###
+UfcsClampFloatReceiverStaysFloat
+### DESCRIPTION ###
+`v.clamp(0, 10)` on a float receiver must include the receiver when deciding
+all-int collapse: the float receiver means the result is int|float, not the
+wrongly-collapsed int it would be if only the written args (0, 10) were seen.
+### INPUT ###
+v = 1.5
+r = v.clamp(0, 10)
+### STDOUT ###
+# Identifier types
+  v @ 1:1 -> <no-type>
+  r @ 2:1 -> <no-type>
+  v @ 2:5 -> float
+  clamp @ 2:7 -> dynamic
+
+# Symbol types
+  r (local): int|float
+  v (local): float
+
+# Diagnostics
+  (none)
+### TITLE ###
+UfcsClampIntReceiverCollapsesToInt
+### DESCRIPTION ###
+With an all-int receiver and args, `n.clamp(0, 10)` collapses to int - the
+receiver participates in the all-int check, so the precise int return is
+recovered for the UFCS form too.
+### INPUT ###
+n = 5
+r = n.clamp(0, 10)
+### STDOUT ###
+# Identifier types
+  n @ 1:1 -> <no-type>
+  r @ 2:1 -> <no-type>
+  n @ 2:5 -> int
+  clamp @ 2:7 -> dynamic
+
+# Symbol types
+  n (local): int
+  r (local): int
+
+# Diagnostics
+  (none)

--- a/rts/check/snapshots/fallible.snap
+++ b/rts/check/snapshots/fallible.snap
@@ -1,9 +1,11 @@
 ### TITLE ###
-UnguardedFallibleStripsAndHints
+UnguardedFallibleHiddenByDefault
 ### DESCRIPTION ###
 An unhandled fallible call (parse_int) strips its error arm to the
-success type (int), so `a + 1` type-checks. The call carries a hint
-nudging the user to handle the error. Gap 2 panic-promotion model.
+success type (int), so `a + 1` type-checks. By default the
+unhandled-fallible advisory (RAD30011) is suppressed entirely - too
+noisy to be on by default - so no diagnostic fires. Gap 2
+panic-promotion model.
 ### INPUT ###
 a = parse_int("2")
 print(a + 1)
@@ -18,7 +20,30 @@ print(a + 1)
   a (local): int
 
 # Diagnostics
-  [hint] RAD30011 @ 1:5 - This call can fail; the error isn't handled and would halt the script
+  (none)
+### TITLE ###
+UnguardedFallibleWarnsUnderStrict
+### DESCRIPTION ###
+The same unguarded call under --strict: the unhandled-fallible
+advisory surfaces, now as a warning rather than a hint. Strict mode
+is the opt-in for this nudge.
+### INPUT ###
+a = parse_int("2")
+print(a + 1)
+### ARGS ###
+--strict
+### STDOUT ###
+# Identifier types
+  a @ 1:1 -> <no-type>
+  parse_int @ 1:5 -> dynamic
+  print @ 2:1 -> dynamic
+  a @ 2:7 -> int
+
+# Symbol types
+  a (local): int
+
+# Diagnostics
+  [warn] RAD30011 @ 1:5 - This call can fail; the error isn't handled and would halt the script
     help: Handle it with `catch` or `??`, e.g. `x = <call> catch <fallback>`
 ### TITLE ###
 CatchExpressionSuppressesHint
@@ -129,17 +154,20 @@ print(e)
 # Diagnostics
   (none)
 ### TITLE ###
-UserFnUnionStripsAndHints
+UserFnUnionWarnsUnderStrict
 ### DESCRIPTION ###
 A user fn declaring -> int|error panic-promotes like any call, so
-an unguarded call strips to int and gets the hint; the parse_int
-inside the fn body is guarded by its own catch.
+under --strict an unguarded call strips to int and gets the
+unhandled-fallible warning; the parse_int inside the fn body is
+guarded by its own catch.
 ### INPUT ###
 fn maybe(s: str) -> int|error:
     return parse_int(s) catch error("nope")
 
 x = maybe("2")
 print(x + 1)
+### ARGS ###
+--strict
 ### STDOUT ###
 # Identifier types
   parse_int @ 2:12 -> dynamic
@@ -156,5 +184,5 @@ print(x + 1)
   x (local): int
 
 # Diagnostics
-  [hint] RAD30011 @ 4:5 - This call can fail; the error isn't handled and would halt the script
+  [warn] RAD30011 @ 4:5 - This call can fail; the error isn't handled and would halt the script
     help: Handle it with `catch` or `??`, e.g. `x = <call> catch <fallback>`

--- a/rts/check/snapshots/gradual_assign.snap
+++ b/rts/check/snapshots/gradual_assign.snap
@@ -1,0 +1,131 @@
+### TITLE ###
+EmptyListIntoTypedReturn
+### DESCRIPTION ###
+An empty `[]` synthesises as bare `list`; it must satisfy a `str[]`
+return annotation. The list built up with `+` stays bare `list`,
+which is the gradual escape hatch and flows into `str[]`.
+### INPUT ###
+fn collect() -> str[]:
+    out = []
+    out = out + ["a"]
+    return out
+### STDOUT ###
+# Identifier types
+  out @ 2:5 -> <no-type>
+  out @ 3:5 -> <no-type>
+  out @ 3:11 -> list
+  out @ 4:12 -> list
+
+# Symbol types
+  collect (fn): fn() -> str[]
+  out (local): list
+
+# Diagnostics
+  (none)
+### TITLE ###
+EmptyListIntoTypedLocal
+### DESCRIPTION ###
+`xs: str[] = []` - the empty-list literal flows into the declared
+typed-list local without a seed value.
+### INPUT ###
+xs: str[] = []
+### STDOUT ###
+# Identifier types
+  xs @ 1:1 -> <no-type>
+
+# Symbol types
+  xs (local): str[]
+
+# Diagnostics
+  (none)
+### TITLE ###
+TernaryStrOrNullIntoOptional
+### DESCRIPTION ###
+A ternary producing `str|null` is assignable to a `str?` return:
+a union source is assignable when every arm fits (`str` and `null`
+both fit `str?`).
+### INPUT ###
+fn pick_or_none(s: str) -> str?:
+    return s == "x" ? s : null
+### STDOUT ###
+# Identifier types
+  s @ 2:12 -> str
+  s @ 2:23 -> str
+
+# Symbol types
+  pick_or_none (fn): fn(str) -> str?
+  s (param): str
+
+# Diagnostics
+  (none)
+### TITLE ###
+DynamicUnionIntoConcreteReturn
+### DESCRIPTION ###
+`d["items"] ?? []` on an untyped (dynamic) param is `dynamic|list`;
+it flows into a `list` return because each arm does (dynamic is
+any-like, bare list is gradual).
+### INPUT ###
+fn first_items(d) -> list:
+    return d["items"] ?? []
+### STDOUT ###
+# Identifier types
+  d @ 2:12 -> dynamic
+
+# Symbol types
+  d (param): <no-type>
+  first_items (fn): fn(any) -> list
+
+# Diagnostics
+  (none)
+### TITLE ###
+AnyUnionIntoStrArg
+### DESCRIPTION ###
+sort() of a `str[]` preserves the element type, so iterating yields
+`str` (not `any|str`), and the `any`-like arm of any residual union
+is assignable to a `str` parameter.
+### INPUT ###
+items = ["a,b", "c,d"]
+items = sort(items)
+for v in items:
+    split(v, ",")
+### STDOUT ###
+# Identifier types
+  items @ 1:1 -> <no-type>
+  items @ 2:1 -> <no-type>
+  sort @ 2:9 -> dynamic
+  items @ 2:14 -> str[]
+  items @ 3:10 -> str[]
+  split @ 4:5 -> dynamic
+  v @ 4:11 -> str
+
+# Symbol types
+  items (local): str[]
+  v (loop): str
+
+# Diagnostics
+  (none)
+### TITLE ###
+TypedListOrBareListCompoundAdd
+### DESCRIPTION ###
+`true ? defaults : []` is `str[]|list`; the bare-list arm makes the
+whole thing gradual, so `acc += "x,y".split(",")` (a `str[]`) is a
+clean list append rather than a poisoned union op.
+### INPUT ###
+defaults = ["a", "b"]
+acc = true ? defaults : []
+acc += "x,y".split(",")
+### STDOUT ###
+# Identifier types
+  defaults @ 1:1 -> <no-type>
+  acc @ 2:1 -> <no-type>
+  defaults @ 2:14 -> str[]
+  acc @ 3:1 -> <no-type>
+  acc @ 3:1 -> str[]|list
+  split @ 3:14 -> dynamic
+
+# Symbol types
+  acc (local): list
+  defaults (local): str[]
+
+# Diagnostics
+  (none)

--- a/rts/check/snapshots/lit_check/gateable_boundary.snap
+++ b/rts/check/snapshots/lit_check/gateable_boundary.snap
@@ -1,10 +1,13 @@
 ### TITLE ###
-OpenListIntoTypedParamStaysHint
+OpenListIntoTypedParamAccepted
 ### DESCRIPTION ###
-A value typed as the open gradual `list` flowing into a structured
-`int[]` parameter cannot be proven wrong - the runtime contents
-might all be ints - so the mismatch is a non-gating Hint, never an
-Error. Guards the gateableMismatch gradual-container rule.
+A value typed as the open gradual `list` (no element constraint -
+what `[]` synthesizes to and what `any[]`/`dynamic[]` collapse to)
+flows into a structured `int[]` parameter without complaint, the
+same way `any`/`dynamic` do. Bare `list` is the gradual escape
+hatch; gating it would brick the idiomatic `xs: str[] = []` and
+`return <list>` patterns. Guards the bare-list gradual rule in
+TypingListT.IsAssignableFrom.
 ### INPUT ###
 fn outer(x: list):
     want_ints(x)
@@ -25,7 +28,7 @@ fn want_ints(xs: int[]):
   xs (param): int[]
 
 # Diagnostics
-  [hint] RAD30001 @ 2:15 - Argument type 'list' is not assignable to expected type 'int[]'
+  (none)
 ### TITLE ###
 StrVariableIntoStrEnumStaysHint
 ### DESCRIPTION ###

--- a/rts/check/snapshots/narrow/args_block.snap
+++ b/rts/check/snapshots/narrow/args_block.snap
@@ -123,3 +123,53 @@ maybe_str(name)
 
 # Diagnostics
   [hint] RAD30001 @ 10:10 - Argument type 'str?' is not assignable to expected type 'str'
+### TITLE ###
+ArgReassignedToNewTypeFlows
+### DESCRIPTION ###
+An args-block variable's type is mandatory, not an opt-in contract,
+so reassigning it to a new type is allowed (flow-typing): `items`
+starts as str[] and becomes str after `.join(",")`, with no mismatch
+error. Reads before the reassignment still see str[].
+### INPUT ###
+args:
+    items str[]
+
+print(items.join(","))
+items = items.join(",")
+print(items.upper())
+### STDOUT ###
+# Identifier types
+  print @ 4:1 -> dynamic
+  items @ 4:7 -> str[]
+  join @ 4:13 -> dynamic
+  items @ 5:1 -> <no-type>
+  items @ 5:9 -> str[]
+  join @ 5:15 -> dynamic
+  print @ 6:1 -> dynamic
+  items @ 6:7 -> str
+  upper @ 6:13 -> dynamic
+
+# Symbol types
+  items (arg): str
+
+# Diagnostics
+  (none)
+### TITLE ###
+TypedLocalReassignedToNewTypePinned
+### DESCRIPTION ###
+The contrast: an explicitly annotated local IS a contract the user
+opted into, so reassigning it to a different type is still a gating
+Error. Only args-block (mandatory) types flow-type.
+### INPUT ###
+x: int = 5
+x = "hi"
+### STDOUT ###
+# Identifier types
+  x @ 1:1 -> <no-type>
+  x @ 2:1 -> <no-type>
+
+# Symbol types
+  x (local): int
+
+# Diagnostics
+  [error] RAD30001 @ 2:5 - Value of type 'str' is not assignable to declared type 'int'

--- a/rts/check/snapshots/numeric_union_ops.snap
+++ b/rts/check/snapshots/numeric_union_ops.snap
@@ -1,0 +1,66 @@
+### TITLE ###
+NumericUnionArithmetic
+### DESCRIPTION ###
+An `int|float` operand against an int literal is valid for arithmetic
+- both arms are numeric - and yields `int|float`. Operators decompose
+a numeric union over its arms rather than rejecting it.
+### INPUT ###
+fn f(x: int|float):
+    y = x - 1
+    z = x * 2
+### STDOUT ###
+# Identifier types
+  y @ 2:5 -> <no-type>
+  x @ 2:9 -> int|float
+  z @ 3:5 -> <no-type>
+  x @ 3:9 -> int|float
+
+# Symbol types
+  f (fn): fn(int|float) -> void
+  x (param): int|float
+  y (local): int|float
+  z (local): int|float
+
+# Diagnostics
+  (none)
+### TITLE ###
+NumericUnionComparison
+### DESCRIPTION ###
+The same decomposition applies to comparisons: `int|float > int` is
+valid and yields bool.
+### INPUT ###
+fn f(x: int|float):
+    b = x > 0
+### STDOUT ###
+# Identifier types
+  b @ 2:5 -> <no-type>
+  x @ 2:9 -> int|float
+
+# Symbol types
+  b (local): bool
+  f (fn): fn(int|float) -> void
+  x (param): int|float
+
+# Diagnostics
+  (none)
+### TITLE ###
+NonNumericUnionStillFlags
+### DESCRIPTION ###
+A union with a non-numeric arm (`int|str`) can't do arithmetic - the
+str arm has no `- int` overload - so it still flags, and as a Hint
+(one arm might fit at runtime), not a gating Error.
+### INPUT ###
+fn f(x: int|str):
+    y = x - 1
+### STDOUT ###
+# Identifier types
+  y @ 2:5 -> <no-type>
+  x @ 2:9 -> int|str
+
+# Symbol types
+  f (fn): fn(int|str) -> void
+  x (param): int|str
+  y (local): <error>
+
+# Diagnostics
+  [hint] RAD30002 @ 2:9 - Invalid operand types: cannot do 'int|str - int'

--- a/rts/check/snapshots/tuple_unpack.snap
+++ b/rts/check/snapshots/tuple_unpack.snap
@@ -1,0 +1,142 @@
+### TITLE ###
+UnpackSingleTuple
+### DESCRIPTION ###
+`x, y = pair()` distributes the returned tuple's element types across
+the targets: x is float, y is int - not the whole `[float, int]`
+bound to x with y left untyped.
+### INPUT ###
+fn pair() -> [float, int]:
+    return 1.5, 2
+
+x, y = pair()
+### STDOUT ###
+# Identifier types
+  x @ 4:1 -> <no-type>
+  y @ 4:4 -> <no-type>
+  pair @ 4:8 -> fn() -> [float, int]
+
+# Symbol types
+  pair (fn): fn() -> [float, int]
+  x (local): float
+  y (local): int
+
+# Diagnostics
+  (none)
+### TITLE ###
+UnpackUnionOfTuples
+### DESCRIPTION ###
+When the return is a union of tuples (`[float,int]|[int,int]`), each
+target gets the union of that position across arms: x is `float|int`,
+y is int. Confirms the distribution unions per-position across arms.
+### INPUT ###
+fn make_pair(flag):
+    if flag:
+        return 1.5, 2
+    return 3, 4
+
+x, y = make_pair(true)
+ep = parse_epoch(x)
+### STDOUT ###
+# Identifier types
+  flag @ 2:8 -> dynamic
+  x @ 6:1 -> <no-type>
+  y @ 6:4 -> <no-type>
+  make_pair @ 6:8 -> fn(any) -> [float, int]|[int, int]
+  ep @ 7:1 -> <no-type>
+  parse_epoch @ 7:6 -> dynamic
+  x @ 7:18 -> float|int
+
+# Symbol types
+  ep (local): { "date": str, "day": int, "epoch": { "millis": int, "nanos": int, "seconds": int }, "hour": int, "minute": int, "month": int, "second": int, "time": str, "year": int }
+  flag (param): <no-type>
+  make_pair (fn): fn(any) -> [float, int]|[int, int]
+  x (local): float|int
+  y (local): int
+
+# Diagnostics
+  (none)
+### TITLE ###
+UnpackIntoDeclaredTargetsClean
+### DESCRIPTION ###
+Unpacking into pre-declared targets checks the *distributed* element type
+against each target's declared type, not the whole tuple. `a: int` gets int
+and `b: str` gets str, both assignable, so no diagnostic - the shared RHS
+node is not re-synthesized per target.
+### INPUT ###
+fn get_pair() -> [int, str]:
+    return 1, "hello"
+
+a: int = 0
+b: str = ""
+a, b = get_pair()
+### STDOUT ###
+# Identifier types
+  a @ 4:1 -> <no-type>
+  b @ 5:1 -> <no-type>
+  a @ 6:1 -> <no-type>
+  b @ 6:4 -> <no-type>
+  get_pair @ 6:8 -> fn() -> [int, str]
+
+# Symbol types
+  a (local): int
+  b (local): str
+  get_pair (fn): fn() -> [int, str]
+
+# Diagnostics
+  (none)
+### TITLE ###
+UnpackIntoDeclaredTargetMismatch
+### DESCRIPTION ###
+The distributed element is still checked: unpacking `[int, str]` into a
+`str`-declared first target is a provable mismatch (int into str), so it
+gates as an Error pointed at the target.
+### INPUT ###
+fn get_pair() -> [int, str]:
+    return 1, "hello"
+
+a: str = ""
+b: str = ""
+a, b = get_pair()
+### STDOUT ###
+# Identifier types
+  a @ 4:1 -> <no-type>
+  b @ 5:1 -> <no-type>
+  a @ 6:1 -> <no-type>
+  b @ 6:4 -> <no-type>
+  get_pair @ 6:8 -> fn() -> [int, str]
+
+# Symbol types
+  a (local): str
+  b (local): str
+  get_pair (fn): fn() -> [int, str]
+
+# Diagnostics
+  [error] RAD30001 @ 6:1 - Value of type 'int' is not assignable to declared type 'str'
+### TITLE ###
+UnpackOptionalTupleDistributesNullable
+### DESCRIPTION ###
+An optional tuple return (`[int, str]?`) unpacks by its inner shape with each
+position made nullable: x is `int|null`, y is `str|null`. (At runtime a null
+value would error on unpack; statically each target carries the nullable arm.)
+### INPUT ###
+fn maybe_pair(b: bool) -> [int, str]?:
+    if b:
+        return 1, "hello"
+    return null
+
+x, y = maybe_pair(true)
+### STDOUT ###
+# Identifier types
+  b @ 2:8 -> bool
+  x @ 6:1 -> <no-type>
+  y @ 6:4 -> <no-type>
+  maybe_pair @ 6:8 -> fn(bool) -> [int, str]?
+
+# Symbol types
+  b (param): bool
+  maybe_pair (fn): fn(bool) -> [int, str]?
+  x (local): int|null
+  y (local): str|null
+
+# Diagnostics
+  (none)

--- a/rts/check/type_check.go
+++ b/rts/check/type_check.go
@@ -190,7 +190,7 @@ func (tc *typeChecker) recordReturn(t rl.TypingT, spanNode rl.Node, valNodes []r
 		}
 		return
 	}
-	if expected.IsAssignableFrom(t) {
+	if rl.IsAssignable(expected, t) {
 		return
 	}
 	severity := IssueHint
@@ -892,9 +892,9 @@ func (tc *typeChecker) walkIf(n *rl.If) {
 // outer locals. Conservative but sound.
 func (tc *typeChecker) walkFnDef(n *rl.FnDef) {
 	saved := tc.frame
-	// Param defaults synth in the surrounding frame (not the body'\''s
-	// fresh frame), matching Phase 2'\''s behavior - they'\''re evaluated
-	// at the call site, which is in the caller'\''s scope.
+	// Param defaults synth in the surrounding frame (not the body's
+	// fresh frame), matching Phase 2's behavior - they're evaluated
+	// at the call site, which is in the caller's scope.
 	if n.Typing != nil {
 		for _, p := range n.Typing.Params {
 			if p.DefaultAST != nil && p.DefaultAST.Node != nil {
@@ -904,7 +904,7 @@ func (tc *typeChecker) walkFnDef(n *rl.FnDef) {
 	}
 	tc.frame = NewFrame()
 	// Push a return-collector frame so any `return E` inside the
-	// body lands in this fn'\''s slot, not whatever lambda we may
+	// body lands in this fn's slot, not whatever lambda we may
 	// be nested under at the call site. We feed the declared
 	// return (if any) so body returns get checked against it at
 	// their own span, same as lambdas.
@@ -1078,19 +1078,19 @@ func (tc *typeChecker) walkWhileLoop(n *rl.WhileLoop) {
 	// frame: `while cond: x = "hello"` leaves x as the union of
 	// its pre-body type (body never ran) and "hello" (body ran).
 	//
-	// We don'\''t special-case a "body always diverges" early exit
+	// We don't special-case a "body always diverges" early exit
 	// here. Distinguishing diverges-via-return (post-loop is dead)
 	// from diverges-via-break (post-loop gets bodyExit at break
 	// time) would need finer-grained reachability tracking than
 	// branchExits provides. Joining both unconditionally is
 	// safe - in the diverges-via-return case the post-loop is
-	// unreachable anyway, and any spurious union arms there don'\''t
+	// unreachable anyway, and any spurious union arms there don't
 	// affect a real program path.
 	//
 	// WhenFalse is applied only on the fall-through path, since
-	// that'\''s the only one where the loop exited "naturally" via
+	// that's the only one where the loop exited "naturally" via
 	// a falsy condition. The body-ran path may have exited via
-	// break, where the condition'\''s truthy state still held.
+	// break, where the condition's truthy state still held.
 	fallThrough := widened.WithMany(ref.WhenFalse)
 	tc.frame = tc.joinFrames(initial, []*Frame{bodyExit, fallThrough})
 }
@@ -1203,14 +1203,14 @@ func (tc *typeChecker) dropNarrowings(frame *Frame, syms map[*Symbol]bool) *Fram
 		if sym.Declared != nil {
 			overrides[sym] = sym.Declared
 		}
-		// No known base type. We don'\''t add an override here, so a
+		// No known base type. We don't add an override here, so a
 		// prior narrowing from an ancestor frame keeps applying via
-		// Frame.Lookup'\''s parent walk. That'\''s probably wrong for
+		// Frame.Lookup's parent walk. That's probably wrong for
 		// the Sorbet rule - the whole point is to widen vars the
 		// body may reassign - but the fix is to track base types
 		// for every symbol, not to special-case this branch. Until
 		// then, this is the conservative under-widening: we may keep
-		// a narrowing we should have dropped, but we don'\''t introduce
+		// a narrowing we should have dropped, but we don't introduce
 		// spurious narrowings.
 	}
 	return frame.WithMany(overrides)
@@ -1711,7 +1711,7 @@ func stmtDiverges(n rl.Node, ctx divergeCtx, tc *typeChecker) bool {
 		return whileDiverges(s, tc)
 	case *rl.ForLoop:
 		// For loops may iterate zero times; the body might never
-		// run. Even if the body diverges, the whole loop doesn'\''t.
+		// run. Even if the body diverges, the whole loop doesn't.
 		return false
 	case *rl.Assign:
 		// Bare assignment never diverges. An assignment with a
@@ -2102,7 +2102,7 @@ func mergeStructuralByKind(types []rl.TypingT) []rl.TypingT {
 func applySubsumption(types []rl.TypingT) []rl.TypingT {
 	var kept []rl.TypingT
 	for _, candidate := range types {
-		// Gradual candidates can'\''t be subsumed - we always want to
+		// Gradual candidates can't be subsumed - we always want to
 		// preserve an explicit `any` in the join. The asymmetry
 		// matters because gradual consistency makes IsAssignableFrom
 		// return true in both directions for any-vs-T, which would
@@ -2202,78 +2202,46 @@ func (tc *typeChecker) walkCmd(c *rl.CmdBlock) {
 // Declared, so the annotation acts as a stable contract for every
 // later read of the binding.
 func (tc *typeChecker) walkAssign(a *rl.Assign) {
-	for i, val := range a.Values {
-		// Recursive-lambda support: when a lambda RHS is assigned
-		// to an identifier whose symbol has no declared type, the
-		// recursive reference inside the lambda body would otherwise
-		// see Dynamic (SymbolTypes hasn't been populated yet). Plant
-		// a tentative TypingFnT with a Never return placeholder so
-		// the recursive callsite synths to Never (which propagates
-		// trivially and drops in unionTypesForJoin, leaving non-
-		// recursive paths to determine the inferred return). This
-		// mirrors the hoisted-fn SCC pre-pass strategy for the
-		// local-binding case. After synth completes, the lambda's
-		// real TypingFnT overwrites the placeholder via the normal
-		// SymbolTypes update below.
-		if i < len(a.Targets) {
-			if lam, ok := val.(*rl.Lambda); ok {
-				if ident, ok := a.Targets[i].(*rl.Identifier); ok {
-					if sym, ok := tc.resolved.Uses[ident]; ok && sym.Declared == nil {
-						tc.prePlantLambdaSignature(sym, lam)
+	// `x, y = pair()`: a single RHS produces multiple values. Distribute the
+	// RHS's element types across the targets rather than binding the whole
+	// tuple/union-of-tuples to the first target and leaving the rest untyped.
+	// Mirrors the runtime's destructuring in assignRightsToLefts.
+	if a.IsUnpacking && len(a.Values) == 1 && len(a.Targets) > 1 {
+		valNode := a.Values[0]
+		valType := tc.synth(valNode)
+		perTarget := distributeUnpack(valType, len(a.Targets))
+		for i, target := range a.Targets {
+			tc.bindAssignTarget(target, valNode, perTarget[i], true)
+		}
+	} else {
+		for i, val := range a.Values {
+			// Recursive-lambda support: when a lambda RHS is assigned
+			// to an identifier whose symbol has no declared type, the
+			// recursive reference inside the lambda body would otherwise
+			// see Dynamic (SymbolTypes hasn't been populated yet). Plant
+			// a tentative TypingFnT with a Never return placeholder so
+			// the recursive callsite synths to Never (which propagates
+			// trivially and drops in unionTypesForJoin, leaving non-
+			// recursive paths to determine the inferred return). This
+			// mirrors the hoisted-fn SCC pre-pass strategy for the
+			// local-binding case. After synth completes, the lambda's
+			// real TypingFnT overwrites the placeholder via the normal
+			// SymbolTypes update below.
+			if i < len(a.Targets) {
+				if lam, ok := val.(*rl.Lambda); ok {
+					if ident, ok := a.Targets[i].(*rl.Identifier); ok {
+						if sym, ok := tc.resolved.Uses[ident]; ok && sym.Declared == nil {
+							tc.prePlantLambdaSignature(sym, lam)
+						}
 					}
 				}
 			}
-		}
-		valType := tc.synth(val)
-		if i >= len(a.Targets) {
-			continue
-		}
-		// Indexed assignment (`xs[i] = v`, `m[k] = v`): the target is
-		// a VarPath whose last segment is a bracket-index. The
-		// Identifier branch below doesn't fire, so we handle it here
-		// and continue. We deliberately don't update SymbolTypes or
-		// frame for these: indexed assign mutates the container's
-		// contents, not the binding, so the symbol's type is unchanged.
-		if vp, ok := a.Targets[i].(*rl.VarPath); ok {
-			// Walk children for hover/use tracking. asTarget=true so
-			// the final segment (the write slot) doesn't fire the
-			// unknown-key check - writing an undeclared key is a
-			// legal runtime add - while intermediate reads still do.
-			_ = tc.synthVarPath(vp, true)
-			tc.checkIndexedAssignTarget(vp, val, valType)
-			continue
-		}
-		ident, ok := a.Targets[i].(*rl.Identifier)
-		if !ok {
-			continue
-		}
-		sym, ok := tc.resolved.Uses[ident]
-		if !ok {
-			continue
-		}
-		if sym.Declared != nil {
-			tc.checkAssignAgainstDeclared(val, valType, sym.Declared)
-			tc.info.SymbolTypes[sym] = sym.Declared
-			// The frame tracks the RHS-derived type within the
-			// current flow: a typed local can have a stricter
-			// type than Declared at a given point (after `x =
-			// 5` inside a branch, x is int even though declared
-			// int|str). On a mismatch the runtime would error;
-			// the frame stays at Declared so downstream reads
-			// don'\''t cascade.
-			actual := sym.Declared
-			if sym.Declared.IsAssignableFrom(valType) {
-				actual = valType
+			valType := tc.synth(val)
+			if i >= len(a.Targets) {
+				continue
 			}
-			tc.frame = tc.frame.With(sym, actual)
-			continue
+			tc.bindAssignTarget(a.Targets[i], val, valType, false)
 		}
-		// Unannotated: SymbolTypes records the base/initial inferred
-		// type for hover and for join'\''s "branch didn'\''t narrow this"
-		// fallback. The frame holds the flow-sensitive override,
-		// which gets unioned at branch joins.
-		tc.info.SymbolTypes[sym] = valType
-		tc.frame = tc.frame.With(sym, valType)
 	}
 	// Walk the catch block (if any) with assignment targets narrowed
 	// to their error component. The catch runs when the RHS errored,
@@ -2284,7 +2252,7 @@ func (tc *typeChecker) walkAssign(a *rl.Assign) {
 	// For a typed local `x: int|error = parse_int(...)` the override
 	// is the error arm of the declared type. For an unannotated
 	// local where the RHS synthed to int|error, we pick out the
-	// error arm. Falls back to a bare TypingErrorT when we can'\''t
+	// error arm. Falls back to a bare TypingErrorT when we can't
 	// extract one (the runtime guarantee is "RHS errored," so error
 	// is always sound).
 	if a.Catch != nil {
@@ -2313,6 +2281,149 @@ func (tc *typeChecker) walkAssign(a *rl.Assign) {
 		tc.walkStmts(a.Catch.Stmts)
 		tc.frame = savedFrame
 	}
+}
+
+// bindAssignTarget records the type flowing into one assignment target. Shared
+// by direct (`x = v`) and unpacking (`x, y = pair()`) assignment so both honor
+// the same indexed-assign, declared-type, and flow-typing rules.
+//
+// fromUnpack distinguishes the two callers. On the direct path valNode is the
+// actual RHS value, so the declared/element checks walk it structurally (a
+// literal can match a tuple/struct target that its widened synth type can't).
+// On the unpack path valNode is the *shared* RHS expression for every target -
+// re-synthesizing it would recover the whole tuple/list, not the per-target
+// element distributed into valType - so we check valType directly instead.
+func (tc *typeChecker) bindAssignTarget(target rl.Node, valNode rl.Node, valType rl.TypingT, fromUnpack bool) {
+	// Indexed assignment (`xs[i] = v`, `m[k] = v`): the target is a VarPath
+	// whose last segment is a bracket-index. We deliberately don't update
+	// SymbolTypes or frame: an indexed assign mutates the container's
+	// contents, not the binding, so the symbol's type is unchanged.
+	if vp, ok := target.(*rl.VarPath); ok {
+		// asTarget=true so the final (write) segment doesn't fire the
+		// unknown-key check - writing an undeclared key is a legal runtime
+		// add - while intermediate reads still do.
+		_ = tc.synthVarPath(vp, true)
+		tc.checkIndexedAssignTarget(vp, valNode, valType, fromUnpack)
+		return
+	}
+	ident, ok := target.(*rl.Identifier)
+	if !ok {
+		return
+	}
+	sym, ok := tc.resolved.Uses[ident]
+	if !ok {
+		return
+	}
+	if sym.Declared != nil && !isMandatoryTypedKind(sym.Kind) {
+		if fromUnpack {
+			tc.checkAssignTypeAgainstDeclared(target, valType, sym.Declared)
+		} else {
+			tc.checkAssignAgainstDeclared(valNode, valType, sym.Declared)
+		}
+		tc.info.SymbolTypes[sym] = sym.Declared
+		// The frame tracks the RHS-derived type within the current flow: a
+		// typed local can have a stricter type than Declared at a given
+		// point (after `x = 5` in a branch, x is int even though declared
+		// int|str). On a mismatch the frame stays at Declared so downstream
+		// reads don't cascade.
+		actual := sym.Declared
+		if rl.IsAssignable(sym.Declared, valType) {
+			actual = valType
+		}
+		tc.frame = tc.frame.With(sym, actual)
+		return
+	}
+	// Unannotated locals - and args-block vars, whose type is mandatory
+	// rather than an opt-in contract (see isMandatoryTypedKind) - flow-type:
+	// the binding takes the new RHS type going forward. SymbolTypes records
+	// the base/initial inferred type for hover and for join's "branch didn't
+	// narrow this" fallback; the frame holds the flow-sensitive override,
+	// unioned at branch joins.
+	tc.info.SymbolTypes[sym] = valType
+	tc.frame = tc.frame.With(sym, valType)
+}
+
+// isMandatoryTypedKind reports whether a symbol's declared type was forced by
+// the language rather than opted into by the user. Args-block entries (`args:`
+// and cmd-block args) have no untyped form, so pinning them to their declared
+// type for their whole lifetime would reject idiomatic, runtime-correct
+// reassignment - e.g. folding a `str[]` arg into a string with `.join(",")`.
+// Explicitly annotated locals and params, by contrast, are a deliberate
+// contract the user chose, so they stay pinned.
+func isMandatoryTypedKind(k SymbolKind) bool {
+	return k == SymArg || k == SymCmdArg
+}
+
+// distributeUnpack computes the static type bound to each of n targets in an
+// unpacking assignment `t0, t1, ... = rhs`, mirroring the runtime
+// (assignRightsToLefts): a list/tuple RHS distributes element-wise (targets
+// past the known arity get null), a union RHS distributes per-arm and unions
+// each position, and any other RHS lands wholly on the first target with the
+// rest null.
+func distributeUnpack(rhs rl.TypingT, n int) []rl.TypingT {
+	out := make([]rl.TypingT, n)
+	for _, arm := range unionArms(rhs) {
+		armTypes := distributeUnpackArm(arm, n)
+		for i := 0; i < n; i++ {
+			out[i] = unionOf(out[i], armTypes[i])
+		}
+	}
+	return out
+}
+
+// distributeUnpackArm distributes a single (non-union) RHS type across n
+// unpack targets. See distributeUnpack for the shape rules.
+func distributeUnpackArm(t rl.TypingT, n int) []rl.TypingT {
+	out := make([]rl.TypingT, n)
+	switch tt := t.(type) {
+	case *rl.TypingTupleT:
+		elems := tt.Types()
+		for i := 0; i < n; i++ {
+			if i < len(elems) {
+				out[i] = elems[i]
+			} else {
+				out[i] = rl.NewNullType()
+			}
+		}
+	case *rl.TypingListT:
+		// Homogeneous list: every position carries the element type. (Targets
+		// past the list's runtime length get null, but the length is unknown
+		// statically; the element type matches the expected-enough case.)
+		for i := 0; i < n; i++ {
+			out[i] = tt.Elem()
+		}
+	case *rl.TypingAnyListT:
+		for i := 0; i < n; i++ {
+			out[i] = rl.NewDynamicType()
+		}
+	case *rl.TypingOptionalT:
+		// `[int, str]?` (or `int[]?`): if the value is non-null it unpacks by
+		// the inner shape; if it's null the unpack errors at runtime. Statically
+		// we can't tell, so each target carries its inner-shape type unioned with
+		// null - the same per-position nullability the value itself has.
+		inner := distributeUnpackArm(tt.Inner(), n)
+		for i := 0; i < n; i++ {
+			out[i] = unionOf(inner[i], rl.NewNullType())
+		}
+	default:
+		if isDynamicLike(t) {
+			// Can't tell whether a dynamic value is a list at runtime, so stay
+			// permissive and hand every target dynamic.
+			for i := 0; i < n; i++ {
+				out[i] = rl.NewDynamicType()
+			}
+			return out
+		}
+		// Non-list scalar: the runtime puts it on the first target, nulls rest.
+		for i := 0; i < n; i++ {
+			if i == 0 {
+				out[i] = t
+			} else {
+				out[i] = rl.NewNullType()
+			}
+		}
+	}
+	return out
 }
 
 // checkAssignAgainstDeclared emits a type-mismatch when the assigned
@@ -2357,6 +2468,38 @@ func (tc *typeChecker) checkAssignAgainstDeclared(valNode rl.Node, valType, decl
 	})
 }
 
+// checkAssignTypeAgainstDeclared is the type-based counterpart to
+// checkAssignAgainstDeclared, for when we hold the value's type directly and
+// have no per-value node to walk structurally - the unpacking case, where each
+// target's type is distributed from a shared RHS (see bindAssignTarget). It
+// mirrors recordReturn's no-node fallback: provable mismatches gate as Errors,
+// uncertain ones (gradual containers, unions whose arms might fit) stay Hints.
+// spanNode is the target the diagnostic points at.
+func (tc *typeChecker) checkAssignTypeAgainstDeclared(spanNode rl.Node, valType, declared rl.TypingT) {
+	if valType == nil || isErrorType(valType) || isDynamicLike(valType) {
+		return
+	}
+	if rl.IsAssignable(declared, valType) {
+		return
+	}
+	severity := IssueHint
+	if typeIsGateable(valType) {
+		severity = IssueError
+	}
+	var suggestion string
+	if _, isNull := valType.(*rl.TypingNullT); isNull {
+		suggestion = fmt.Sprintf("To allow null here, declare the slot as '%s?'", declared.Name())
+	}
+	tc.info.Issues = append(tc.info.Issues, BindIssue{
+		Span:     spanNode.Span(),
+		Severity: severity,
+		Code:     rl.ErrTypeMismatch,
+		Message: fmt.Sprintf("Value of type '%s' is not assignable to declared type '%s'",
+			valType.Name(), declared.Name()),
+		Suggestion: suggestion,
+	})
+}
+
 // checkIndexedAssignTarget fires the ErrCollectionElementMismatch
 // diagnostic when an indexed assignment like `xs[i] = v` or
 // `m[k] = v` would put a value of the wrong type into a statically
@@ -2382,7 +2525,7 @@ func (tc *typeChecker) checkAssignAgainstDeclared(valNode rl.Node, valType, decl
 // and check downgrades to a Hint when the value is unknown. Other forms
 // of mutation (struct field assignment, slice assignment) aren't checked
 // here.
-func (tc *typeChecker) checkIndexedAssignTarget(target *rl.VarPath, valNode rl.Node, valType rl.TypingT) {
+func (tc *typeChecker) checkIndexedAssignTarget(target *rl.VarPath, valNode rl.Node, valType rl.TypingT, fromUnpack bool) {
 	if valType == nil || isErrorType(valType) || isDynamicLike(valType) {
 		return
 	}
@@ -2424,6 +2567,25 @@ func (tc *typeChecker) checkIndexedAssignTarget(target *rl.VarPath, valNode rl.N
 		return
 	}
 	if isErrorType(expected) || isDynamicLike(expected) {
+		return
+	}
+	// On the unpack path valNode is the shared RHS, not this target's element,
+	// so check the distributed valType directly rather than re-synthesizing.
+	if fromUnpack {
+		if rl.IsAssignable(expected, valType) {
+			return
+		}
+		severity := IssueHint
+		if typeIsGateable(valType) {
+			severity = IssueError
+		}
+		tc.info.Issues = append(tc.info.Issues, BindIssue{
+			Span:     target.Span(),
+			Severity: severity,
+			Code:     rl.ErrCollectionElementMismatch,
+			Message: fmt.Sprintf("Value of type '%s' is not assignable to element type '%s'",
+				valType.Name(), expected.Name()),
+		})
 		return
 	}
 	res := tc.check(valNode, expected)
@@ -2497,7 +2659,7 @@ func (tc *typeChecker) synth(n rl.Node) rl.TypingT {
 	case *rl.Identifier:
 		return tc.synthIdentifier(v)
 	case *rl.Call:
-		return tc.synthCall(v, 0)
+		return tc.synthCall(v, 0, nil)
 	case *rl.VarPath:
 		return tc.synthVarPath(v, false)
 	case *rl.OpBinary:
@@ -2539,7 +2701,7 @@ func (tc *typeChecker) synth(n rl.Node) rl.TypingT {
 // (`expr.method(args)`), where the receiver of the chain is the
 // implicit first positional argument. The arity check then expects
 // `len(args) + implicitReceiverCount` to match the formal signature.
-func (tc *typeChecker) synthCall(call *rl.Call, implicitReceiverCount int) rl.TypingT {
+func (tc *typeChecker) synthCall(call *rl.Call, implicitReceiverCount int, recvType rl.TypingT) rl.TypingT {
 	// Always synth the args themselves so identifier-uses get recorded.
 	for _, a := range call.Args {
 		_ = tc.synth(a)
@@ -2559,9 +2721,104 @@ func (tc *typeChecker) synthCall(call *rl.Call, implicitReceiverCount int) rl.Ty
 	tc.checkCall(call, typing, implicitReceiverCount)
 
 	if typing.ReturnT != nil {
-		return tc.record(call, tc.maybeStripFallible(call, *typing.ReturnT))
+		ret := tc.refineBuiltinReturn(call, recvType, *typing.ReturnT)
+		return tc.record(call, tc.maybeStripFallible(call, ret))
 	}
 	return tc.record(call, rl.NewDynamicType())
+}
+
+// refineBuiltinReturn sharpens a few builtin return types the signature DSL
+// can't express precisely. The signatures are deliberately wide because they
+// must cover every input shape: `sort(...) -> list|str` can't say "returns its
+// argument's type", and `clamp(...) -> int|float|error` can't say "int when all
+// args are int". For a *given* call we often know more, and the wide type
+// otherwise leaks downstream (`sort(str[])` iterating to `any|str`, `clamp` of
+// ints widening `n-1` to `int|float`). This is a deliberately tight allow-list,
+// not a general mechanism - resist growing it without a concrete need.
+func (tc *typeChecker) refineBuiltinReturn(call *rl.Call, recvType rl.TypingT, ret rl.TypingT) rl.TypingT {
+	ident, ok := call.Func.(*rl.Identifier)
+	if !ok {
+		return ret
+	}
+	sym, ok := tc.resolved.Uses[ident]
+	if !ok || sym == nil || sym.Kind != SymBuiltin {
+		return ret
+	}
+	// For UFCS calls (`v.clamp(...)`) the receiver is the implicit first
+	// argument and isn't in call.Args; prepend it so refinement reasons over
+	// every argument, not just the written ones.
+	args := tc.positionalArgTypes(call)
+	if recvType != nil {
+		args = append([]rl.TypingT{recvType}, args...)
+	}
+	switch ident.Name {
+	case "sort":
+		// Single-list/str sort returns its argument unchanged in shape, so the
+		// element type survives. Parallel sort (`sort(xs, ys)`) returns a
+		// list-of-lists, not args[0], so only refine the single-arg form;
+		// otherwise keep the signature's wide type.
+		if len(args) == 1 {
+			switch args[0].(type) {
+			case *rl.TypingListT, *rl.TypingAnyListT, *rl.TypingStrT:
+				return args[0]
+			}
+		}
+	case "clamp", "min", "max", "abs":
+		// These select/transform among numeric inputs without changing
+		// int-ness, so all-int scalar args produce an int result. The
+		// `float` arm of the signature only matters once a float is in play.
+		// (List-valued min/max args are left at the wide type - no harm,
+		// just less precise.)
+		if len(args) > 0 && allIntScalar(args) {
+			return collapseNumericToInt(ret)
+		}
+	}
+	return ret
+}
+
+// positionalArgTypes returns the synthesized types of a call's positional
+// arguments, read from the type index populated when the call's args were
+// synthed. nil entries mark args whose type we couldn't pin.
+func (tc *typeChecker) positionalArgTypes(call *rl.Call) []rl.TypingT {
+	out := make([]rl.TypingT, len(call.Args))
+	for i, a := range call.Args {
+		out[i] = tc.info.ExprTypes[a]
+	}
+	return out
+}
+
+// allIntScalar reports whether every type is a plain int (not a list, float,
+// or union). Drives the all-int return refinement for numeric builtins.
+func allIntScalar(types []rl.TypingT) bool {
+	for _, t := range types {
+		if _, ok := t.(*rl.TypingIntT); !ok {
+			return false
+		}
+	}
+	return true
+}
+
+// collapseNumericToInt rewrites the int/float arms of a type to int, preserving
+// every other arm (notably the error arm of a fallible signature, so fallible
+// detection still fires). `int|float|error` becomes `int|error`. Arms are
+// deduped by Name so the collapsed int arms don't pile up.
+func collapseNumericToInt(t rl.TypingT) rl.TypingT {
+	seen := make(map[string]bool)
+	var arms []rl.TypingT
+	for _, arm := range unionArms(t) {
+		if isInt(arm) || isFloat(arm) {
+			arm = rl.NewIntType()
+		}
+		if seen[arm.Name()] {
+			continue
+		}
+		seen[arm.Name()] = true
+		arms = append(arms, arm)
+	}
+	if len(arms) == 1 {
+		return arms[0]
+	}
+	return rl.NewUnionType(arms...)
 }
 
 // maybeStripFallible models Rad's panic-promotion. Every call except
@@ -2637,7 +2894,9 @@ func (tc *typeChecker) synthVarPath(v *rl.VarPath, asTarget bool) rl.TypingT {
 		switch {
 		case seg.IsUFCS:
 			if call, ok := seg.Index.(*rl.Call); ok {
-				cur = tc.synthCall(call, 1)
+				// The chain so far (cur) is the implicit first argument; pass it
+				// so builtin-return refinement sees the receiver's type too.
+				cur = tc.synthCall(call, 1, cur)
 			} else {
 				// Defensive: the converter always sets Index to the
 				// Call when IsUFCS, so this branch is unreachable.
@@ -3041,12 +3300,55 @@ func (tc *typeChecker) synthOpBinary(n *rl.OpBinary) rl.TypingT {
 		return tc.record(n, rl.NewDynamicType())
 	}
 
-	result, ok := binaryOpResult(n.Op, left, right)
+	result, ok := binaryOpResultOverUnions(n.Op, left, right)
 	if !ok {
 		tc.addOpIssue(n.Span(), n.Op, left, right, n.IsCompound)
 		return tc.record(n, rl.NewErrorTypeType())
 	}
 	return tc.record(n, result)
+}
+
+// unionArms returns the members of a union, or the type itself as a single-arm
+// slice. Lets callers treat union and non-union operands uniformly.
+func unionArms(t rl.TypingT) []rl.TypingT {
+	if u, ok := t.(*rl.TypingUnionT); ok {
+		return u.Types()
+	}
+	return []rl.TypingT{t}
+}
+
+// binaryOpResultOverUnions distributes a binary op across union operands. An
+// `int|float - int` should be valid (both arms are numeric) and yield
+// `int|float`; a `str[]|list += str[]` should reduce to a clean list op. We try
+// the op on the cartesian product of the operands' arms: only when *every*
+// combination is individually valid do we return the union of their results.
+// A single invalid combination returns ok=false so the caller falls through to
+// its normal mismatch handling - which already treats a union operand as a
+// non-gating Hint (one arm might fit), exactly the right severity here.
+//
+// Non-union operands have a single arm, so this is a transparent passthrough to
+// binaryOpResult for the common scalar case.
+func binaryOpResultOverUnions(op rl.Operator, l, r rl.TypingT) (rl.TypingT, bool) {
+	lArms := unionArms(l)
+	rArms := unionArms(r)
+	if len(lArms) == 1 && len(rArms) == 1 {
+		return binaryOpResult(op, l, r)
+	}
+	var result rl.TypingT
+	for _, la := range lArms {
+		for _, ra := range rArms {
+			res, ok := binaryOpResult(op, la, ra)
+			if !ok {
+				return nil, false
+			}
+			if result == nil {
+				result = res
+			} else {
+				result = unionOf(result, res)
+			}
+		}
+	}
+	return result, result != nil
 }
 
 func (tc *typeChecker) synthOpUnary(n *rl.OpUnary) rl.TypingT {
@@ -3488,9 +3790,9 @@ func (tc *typeChecker) addUnaryOpIssue(span rl.Span, op rl.Operator, operand rl.
 // already describes for hoisted fns.
 func (tc *typeChecker) synthLambda(n *rl.Lambda) rl.TypingT {
 	enclosing := tc.frame
-	// Lambdas inherit the enclosing frame'\''s narrowings - that'\''s
-	// closure semantics. Pyright'\''s closure rule: drop narrowings
-	// on any captured path that gets reassigned AFTER the lambda'\''s
+	// Lambdas inherit the enclosing frame's narrowings - that's
+	// closure semantics. Pyright's closure rule: drop narrowings
+	// on any captured path that gets reassigned AFTER the lambda's
 	// definition in the enclosing scope. The lambda may run after
 	// such a reassignment, at which point the captured narrowing
 	// no longer holds. The overrides layer on top of the enclosing
@@ -3512,7 +3814,7 @@ func (tc *typeChecker) synthLambda(n *rl.Lambda) rl.TypingT {
 	tc.pushReturnFrame(declaredReturn)
 
 	// Swap reassignedInScope so any lambda nested inside this one
-	// sees this body'\''s reassignments as its enclosing scope.
+	// sees this body's reassignments as its enclosing scope.
 	prevReassigned := tc.reassignedInScope
 	tc.reassignedInScope = tc.scanReassignments(n.Body)
 
@@ -3520,7 +3822,7 @@ func (tc *typeChecker) synthLambda(n *rl.Lambda) rl.TypingT {
 	// node directly in Body (verified against the converter output -
 	// it does not wrap in ExprStmt). Each body entry is the value to
 	// return; synth it to feed the inferred return type. We pass
-	// the body node itself as the diagnostic span - it'\''s the
+	// the body node itself as the diagnostic span - it's the
 	// implicit return for these. Block-form lambdas walk via
 	// walkStmts and rely on the `*rl.Return` case to populate
 	// returnStack.
@@ -3554,7 +3856,7 @@ func (tc *typeChecker) synthLambda(n *rl.Lambda) rl.TypingT {
 		}
 	}
 
-	// Construct a fresh TypingFnT so we don'\''t mutate the parsed
+	// Construct a fresh TypingFnT so we don't mutate the parsed
 	// l.Typing (other readers - signature display, hover - rely on
 	// the AST being immutable). Params are shared by value; the
 	// caller never writes through ReturnT, so a fresh pointer is

--- a/rts/check/type_check_test.go
+++ b/rts/check/type_check_test.go
@@ -841,7 +841,7 @@ y = x
 	require.NotNil(t, ySym)
 	got := info.SymbolTypes[ySym]
 	require.NotNil(t, got)
-	// Union dedupes by Name; order isn'\''t guaranteed because the
+	// Union dedupes by Name; order isn't guaranteed because the
 	// joined symbol map iterates Go maps. Accept either ordering.
 	name := got.Name()
 	assert.Contains(t, []string{"int|str", "str|int"}, name,
@@ -966,7 +966,7 @@ func TestUnionJoin_AllNeverGivesNever(t *testing.T) {
 }
 
 func TestUnionJoin_AnyDoesNotSwallowConcrete(t *testing.T) {
-	// `int | any` keeps both arms - gradual any shouldn'\''t silently
+	// `int | any` keeps both arms - gradual any shouldn't silently
 	// erase the concrete int.
 	got := check.UnionJoinForTest([]rl.TypingT{
 		rl.NewIntType(),
@@ -1068,7 +1068,7 @@ func TestTypeCheck_ReassignmentWidens(t *testing.T) {
 
 func TestTypeCheck_WhileSorbetDropsBodyAssignedNarrowing(t *testing.T) {
 	// The body reassigns x; the post-loop frame must not assume x is
-	// the WhenFalse-narrowed type for x'\''s base. We just verify the
+	// the WhenFalse-narrowed type for x's base. We just verify the
 	// reassigned var has its widened type post-loop.
 	src := `fn f(x: int|str):
     while type_of(x) == "int":
@@ -1156,7 +1156,7 @@ func TestTypeCheck_ForLoopVarFromStringIsStr(t *testing.T) {
 }
 
 func TestTypeCheck_ForLoopVarDynamicForUnknownIter(t *testing.T) {
-	// A function call we can'\''t resolve yields Dynamic.
+	// A function call we can't resolve yields Dynamic.
 	src := `for v in unknown_fn():
     print(v)
 `
@@ -1274,7 +1274,7 @@ func TestTypeCheck_IfDoesNotLeakNarrowingAfter(t *testing.T) {
 	// After a non-exiting if, the narrowing should not persist into
 	// subsequent statements at the same scope. Use a fn param so the
 	// base type stays int? - a top-level `x: int? = 5` would narrow
-	// x to int on assignment, and the if'\''s null-predicate would have
+	// x to int on assignment, and the if's null-predicate would have
 	// nothing to strip.
 	src := `fn f(x: int?):
     if x != null:
@@ -1290,7 +1290,7 @@ func TestTypeCheck_IfDoesNotLeakNarrowingAfter(t *testing.T) {
 	// Branches contribute int (truthy exit) and int? (acc = base).
 	// The dedupe-by-Name union keeps them as int|int?; semantically
 	// equivalent to int? (since int <: int?), but a tighter
-	// representation would need union-arm subsumption that we don'\''t
+	// representation would need union-arm subsumption that we don't
 	// have today.
 	name := gotXUse.Name()
 	assert.Contains(t, []string{"int?", "int|int?", "int?|int"}, name,

--- a/rts/embedded_funcs/colorize.md
+++ b/rts/embedded_funcs/colorize.md
@@ -37,5 +37,3 @@ strings
 | `skip_if_single` | `bool = false` | Don't colorize if only one value in set        |
 
 Useful for automatically coloring table data or distinguishing values in lists.
-
-**Examples:**

--- a/rts/embedded_funcs/delete_path.md
+++ b/rts/embedded_funcs/delete_path.md
@@ -21,3 +21,5 @@ io
 ## Notes
 
 Returns `true` if the path was successfully deleted, `false` if it didn't exist or couldn't be deleted.
+
+A leading `~` in `_path` is expanded to your home directory.

--- a/rts/embedded_funcs/filter.md
+++ b/rts/embedded_funcs/filter.md
@@ -20,5 +20,3 @@ lists
 ## Notes
 
 For lists, function receives `fn(value)`. For maps, function receives `fn(key, value)`.
-
-**Examples:**

--- a/rts/embedded_funcs/find_paths.md
+++ b/rts/embedded_funcs/find_paths.md
@@ -39,4 +39,6 @@ io
 - `"cwd"` - Relative to current directory
 - `"absolute"` - Full absolute paths
 
+A leading `~` in `_path` is expanded to your home directory.
+
 **Examples:**

--- a/rts/embedded_funcs/find_paths.md
+++ b/rts/embedded_funcs/find_paths.md
@@ -40,5 +40,3 @@ io
 - `"absolute"` - Full absolute paths
 
 A leading `~` in `_path` is expanded to your home directory.
-
-**Examples:**

--- a/rts/embedded_funcs/flat_map.md
+++ b/rts/embedded_funcs/flat_map.md
@@ -41,5 +41,3 @@ lists
 **With function:** The function must return a list. Results are flattened.
 
 For lists, function receives `fn(value)`. For maps, function receives `fn(key, value)` and is required.
-
-**Examples:**

--- a/rts/embedded_funcs/get_path.md
+++ b/rts/embedded_funcs/get_path.md
@@ -42,5 +42,3 @@ system
 - `size_bytes?: int` - File size (only for files)
 - `modified_millis?: int` - Modification time as epoch milliseconds
 - `accessed_millis?: int` - Access time as epoch milliseconds (Unix/macOS only)
-
-**Examples:**

--- a/rts/embedded_funcs/get_path.md
+++ b/rts/embedded_funcs/get_path.md
@@ -32,7 +32,7 @@ system
 **Always returns:**
 
 - `exists: bool` - Whether the path exists
-- `full_path: str` - Absolute path
+- `full_path: str` - Absolute path (a leading `~` in `_path` is expanded to your home directory)
 
 **When path exists, also returns:**
 

--- a/rts/embedded_funcs/index_of.md
+++ b/rts/embedded_funcs/index_of.md
@@ -37,5 +37,3 @@ strings
 | `_target`  | `any`       | The value to search for                               |
 | `n`        | `int = 0`   | Which occurrence to find (0=first, 1=second, -1=last) |
 | `start`    | `int = 0`   | Position to start searching from                      |
-
-**Examples:**

--- a/rts/embedded_funcs/input.md
+++ b/rts/embedded_funcs/input.md
@@ -39,5 +39,3 @@ io
 
 If `secret` is true, input is hidden (useful for passwords). The `hint` parameter has no effect when `secret` is
 enabled.
-
-**Examples:**

--- a/rts/embedded_funcs/load.md
+++ b/rts/embedded_funcs/load.md
@@ -38,5 +38,3 @@ stash
 
 If key doesn't exist, `_loader` is called and result is cached. Cannot use `reload=true` with `override` (mutually
 exclusive).
-
-**Examples:**

--- a/rts/embedded_funcs/map.md
+++ b/rts/embedded_funcs/map.md
@@ -20,5 +20,3 @@ lists
 ## Notes
 
 For lists, function receives `fn(value)`. For maps, function receives `fn(key, value)`.
-
-**Examples:**

--- a/rts/embedded_funcs/multipick.md
+++ b/rts/embedded_funcs/multipick.md
@@ -20,7 +20,7 @@ io
 
 ## Notes
 
-Shows an interactive multi-select menu where users can select zero or more options. =
+Shows an interactive multi-select menu where users can select zero or more options.
 Unlike `pick`, which returns a single selection, `multipick` returns a list of all selected items.
 
 **Parameters:**

--- a/rts/embedded_funcs/multipick.md
+++ b/rts/embedded_funcs/multipick.md
@@ -33,5 +33,3 @@ Unlike `pick`, which returns a single selection, `multipick` returns a list of a
 | `max`      | `int?`    | Maximum number of selections allowed (optional, unlimited if not set)         |
 
 The `prompt` parameter has smart defaults that adjust based on the min/max constraints.
-
-**Example:**

--- a/rts/embedded_funcs/now.md
+++ b/rts/embedded_funcs/now.md
@@ -50,5 +50,3 @@ Map values:
 | `.epoch.seconds` | Seconds since 1970-01-01 00:00:00 UTC | int    | 1576246516          |
 | `.epoch.millis`  | Millis since 1970-01-01 00:00:00 UTC  | int    | 1576246516123       |
 | `.epoch.nanos`   | Nanos since 1970-01-01 00:00:00 UTC   | int    | 1576246516123456789 |
-
-**Examples:**

--- a/rts/embedded_funcs/parse_date.md
+++ b/rts/embedded_funcs/parse_date.md
@@ -76,5 +76,3 @@ wrong results or parse errors.
 For strings without timezone information, the time is interpreted in the `tz` timezone (local by
 default). For strings with timezone info (e.g., `Z`, `+05:00`), the time is parsed in that timezone
 and then converted to the output `tz`.
-
-**Examples:**

--- a/rts/embedded_funcs/parse_epoch.md
+++ b/rts/embedded_funcs/parse_epoch.md
@@ -51,5 +51,3 @@ time
 Converts an epoch timestamp to the same format as [`now()`](#now). Auto-detects units from digit count, or specify
 explicitly. When using a float, the fractional part provides sub-unit precision (e.g., `1712345678.5` seconds includes
 500 milliseconds).
-
-**Examples:**

--- a/rts/embedded_funcs/read_file.md
+++ b/rts/embedded_funcs/read_file.md
@@ -46,5 +46,3 @@ A leading `~` in `_path` is expanded to your home directory.
 
 - `size_bytes: int` - File size in bytes
 - `content: str|list[int]` - File contents (type depends on mode)
-
-**Examples:**

--- a/rts/embedded_funcs/read_file.md
+++ b/rts/embedded_funcs/read_file.md
@@ -40,6 +40,8 @@ io
 
 In text mode, decodes as UTF-8 and returns a string. In bytes mode, returns a list of integers.
 
+A leading `~` in `_path` is expanded to your home directory.
+
 **Return map contains:**
 
 - `size_bytes: int` - File size in bytes

--- a/rts/embedded_funcs/replace.md
+++ b/rts/embedded_funcs/replace.md
@@ -21,5 +21,3 @@ strings
 ## Notes
 
 The `_find` parameter is a regex pattern. The `_replace` parameter can use regex capture groups like `$1`.
-
-**Examples:**

--- a/rts/embedded_funcs/sleep.md
+++ b/rts/embedded_funcs/sleep.md
@@ -37,5 +37,3 @@ If `title` is provided, it's printed before sleeping.
 | `ms`         | Milliseconds |
 | `us` or `µs` | Microseconds |
 | `ns`         | Nanoseconds  |
-
-**Examples:**

--- a/rts/embedded_funcs/write_file.md
+++ b/rts/embedded_funcs/write_file.md
@@ -38,6 +38,8 @@ io
 
 By default overwrites the file. Use `append=true` to append to existing content.
 
+A leading `~` in `_path` is expanded to your home directory.
+
 **Return map contains:**
 
 - `bytes_written: int` - Number of bytes written

--- a/rts/embedded_funcs/write_file.md
+++ b/rts/embedded_funcs/write_file.md
@@ -44,5 +44,3 @@ A leading `~` in `_path` is expanded to your home directory.
 
 - `bytes_written: int` - Number of bytes written
 - `path: str` - Full path to the written file
-
-**Examples:**

--- a/rts/embedded_funcs/zip.md
+++ b/rts/embedded_funcs/zip.md
@@ -37,5 +37,3 @@ lists
 - By default, truncates to the shortest list length
 - Cannot use `strict=true` with `fill` parameter (mutually exclusive)
 - Returns error if `strict=true` and lists have different lengths
-
-**Examples:**

--- a/rts/rl/migrations.go
+++ b/rts/rl/migrations.go
@@ -1,0 +1,11 @@
+package rl
+
+// RemovedFuncHints maps the name of a removed or renamed builtin to a migration
+// hint. Shared by the runtime (when a call to one of these names fails at
+// execution) and the static checker (so `rad check` surfaces the same guidance
+// instead of only a generic "did you mean" suggestion). Read from here in both
+// places rather than re-hardcoding the strings, so the two never drift.
+var RemovedFuncHints = map[string]string{
+	"get_default":   `get_default was removed. Use: map["key"] ?? default. See: https://amterp.dev/rad/migrations/v0.8/`,
+	"get_stash_dir": "get_stash_dir was renamed to get_stash_path. See: https://amterp.dev/rad/migrations/v0.9/",
+}

--- a/rts/rl/typing.go
+++ b/rts/rl/typing.go
@@ -67,6 +67,12 @@ func (r RadType) AsString() string {
 // maps and tuples stay invariant; function parameters are contravariant and
 // returns are covariant; `int` widens implicitly to `float` to mirror the
 // runtime rule.
+//
+// IsAssignableFrom decomposes a union *target* but not a union *source*. For a
+// top-level value-flow check prefer the free function IsAssignable, which
+// handles the union-source case (`str|null` into `str?`); call this method
+// directly only when other is known not to be a union (e.g. iterating a union's
+// own arms, or comparing already-decomposed element types).
 type TypingT interface {
 	Name() string
 	IsCompatibleWith(val TypingCompatVal) bool

--- a/rts/rl/typing_assignable.go
+++ b/rts/rl/typing_assignable.go
@@ -8,6 +8,43 @@ package rl
 // compatibility logic together; the runtime IsCompatibleWith methods remain
 // alongside their types.
 
+// IsAssignable reports whether a value of type source can flow into a slot of
+// type target. It is the value-flow entry point the checker should use instead
+// of calling target.IsAssignableFrom directly, because it first decomposes a
+// *union source*: a `str|null` value is assignable to `str?` (and a
+// `dynamic|list` to `list`) iff *every* arm is individually assignable.
+//
+// The per-type IsAssignableFrom methods only decompose a union when the union
+// is the *target* (TypingUnionT.IsAssignableFrom). A union *source* against a
+// non-union target - the common shape produced by `??`, ternaries, and
+// fallible-call results - would otherwise fall through to a type-switch that
+// doesn't recognise TypingUnionT and spuriously reject it. Routing through here
+// closes that gap in one place rather than teaching every target type about
+// union sources.
+//
+// This deliberately handles only a *top-level* union source. Unions nested as
+// list/map element types still go through the invariant/covariant element rules
+// in IsAssignableFrom, where decomposing would be unsound (a `(int|str)[]` is
+// not a safe `int[]`).
+func IsAssignable(target, source TypingT) bool {
+	if u, ok := source.(*TypingUnionT); ok {
+		// A zero-arm union has no inhabitant to flow in. "every arm fits" is
+		// vacuously true, which would accept anything - guard against it. No
+		// path constructs an empty union today; this is belt-and-suspenders so
+		// a future one can't silently turn this into a hole.
+		if len(u.types) == 0 {
+			return false
+		}
+		for _, arm := range u.types {
+			if !IsAssignable(target, arm) {
+				return false
+			}
+		}
+		return true
+	}
+	return target.IsAssignableFrom(source)
+}
+
 // isAnyLike reports whether other is a "flows-into-anything" type: `any`
 // (user-written escape hatch), `dynamic` (the implicit form when inference
 // can't pin a type), `never` (the bottom type, vacuously a subtype of
@@ -324,6 +361,14 @@ func (t *TypingListT) IsAssignableFrom(other TypingT) bool {
 	if isAnyLike(other) {
 		return true
 	}
+	// A bare `list` (the unparameterized AnyList, what `[]` synthesizes to and
+	// what `any[]`/`dynamic[]` collapse to) is gradual: it carries no element
+	// constraint, so it flows into any `T[]` the same way `any`/`dynamic` do.
+	// This is what lets `xs: str[] = []` and `fn f() -> str[]: ... return list`
+	// type-check without forcing an awkward seed value.
+	if _, ok := other.(*TypingAnyListT); ok {
+		return true
+	}
 	o, ok := other.(*TypingListT)
 	if !ok {
 		return false
@@ -390,6 +435,12 @@ func (t *TypingStructT) IsAssignableFrom(other TypingT) bool {
 // as List.
 func (t *TypingMapT) IsAssignableFrom(other TypingT) bool {
 	if isAnyLike(other) {
+		return true
+	}
+	// A bare `map` is gradual in the same way a bare `list` is (see
+	// TypingListT.IsAssignableFrom): no key/value constraint, so it flows into
+	// any `{K: V}`.
+	if _, ok := other.(*TypingAnyMapT); ok {
 		return true
 	}
 	o, ok := other.(*TypingMapT)

--- a/rts/rl/typing_assignable_test.go
+++ b/rts/rl/typing_assignable_test.go
@@ -398,3 +398,45 @@ func TestAssign_UnionBranchMatch(t *testing.T) {
 	assert.True(t, intOrFloatTarget.IsAssignableFrom(intOrFloat))           // int->float, float->float, both fit
 	assert.False(t, intOrStr.IsAssignableFrom(intOrFloat))                  // float doesn't fit in int|str
 }
+
+// IsAssignable is the value-flow entry point that decomposes a *union source*
+// (a union value flows into a target iff every arm does) on top of the per-type
+// IsAssignableFrom rules. Plus the gradual-container rule: bare list/map flow
+// into any parameterised T[]/{K:V}.
+
+func TestIsAssignable_UnionSourceIntoNonUnionTarget(t *testing.T) {
+	// str|null into str? - both arms fit, so the whole union does. This is the
+	// ternary-producing-optional case (#129b).
+	strOrNull := rl.NewUnionType(rl.NewStrType(), rl.NewNullType())
+	strOpt := rl.NewOptionalType(rl.NewStrType())
+	assert.True(t, rl.IsAssignable(strOpt, strOrNull))
+
+	// dynamic|list into list - dynamic is any-like, bare list is gradual (#130).
+	dynOrList := rl.NewUnionType(rl.NewDynamicType(), rl.NewAnyListType())
+	assert.True(t, rl.IsAssignable(rl.NewAnyListType(), dynOrList))
+
+	// any|str into str - any-like arm and str arm both fit (#133.4, #131).
+	anyOrStr := rl.NewUnionType(rl.NewAnyType(), rl.NewStrType())
+	assert.True(t, rl.IsAssignable(rl.NewStrType(), anyOrStr))
+
+	// int|str into int must NOT pass - the str arm can't flow into int.
+	intOrStr := rl.NewUnionType(rl.NewIntType(), rl.NewStrType())
+	assert.False(t, rl.IsAssignable(rl.NewIntType(), intOrStr))
+}
+
+func TestIsAssignable_BareListAndMapAreGradual(t *testing.T) {
+	// Bare list (what `[]` synthesises to) flows into any T[] - the gradual
+	// escape hatch (#129a).
+	assert.True(t, rl.IsAssignable(rl.NewListType(rl.NewStrType()), rl.NewAnyListType()))
+	// Bare map flows into any {K: V}.
+	typedMap := rl.NewMapType(rl.NewStrType(), rl.NewIntType())
+	assert.True(t, rl.IsAssignable(typedMap, rl.NewAnyMapType()))
+	// But a concretely-wrong element/value type still doesn't pass.
+	assert.False(t, rl.IsAssignable(rl.NewListType(rl.NewStrType()), rl.NewListType(rl.NewIntType())))
+}
+
+func TestIsAssignable_NonUnionDelegatesToIsAssignableFrom(t *testing.T) {
+	// With a non-union source, IsAssignable is a transparent passthrough.
+	assert.True(t, rl.IsAssignable(rl.NewFloatType(), rl.NewIntType())) // int->float widening
+	assert.False(t, rl.IsAssignable(rl.NewIntType(), rl.NewStrType()))
+}

--- a/rts/signatures.go
+++ b/rts/signatures.go
@@ -57,8 +57,8 @@ func GetSignature(name string) *FnSignature {
 var internalSignatures = []FnSignature{
 	newInternalFnSignature(`_rad_get_stash_id(*_)`),
 	newInternalFnSignature(`_rad_delete_stash(*_)`),
-	newInternalFnSignature(`_rad_run_check(*_)`),
-	newInternalFnSignature(`_rad_check_from_logs(_duration: str, _verbose: bool) -> void`),
+	newInternalFnSignature(`_rad_run_check(_script: str, _strict: bool) -> map`),
+	newInternalFnSignature(`_rad_check_from_logs(_duration: str, _verbose: bool, _strict: bool) -> void`),
 	newInternalFnSignature(`_rad_explain(_code: str) -> str?`),
 	newInternalFnSignature(`_rad_explain_list() -> str[]`),
 }


### PR DESCRIPTION
Five fixes that landed on this branch:

**check false positives** (the bulk) - `rad check` no longer flags
runtime-correct code. Union-into-slot assignability, numeric-union
arithmetic, tuple destructuring in multi-target assignment, sharper
builtin return types (`sort`/`clamp`/`min`/`max`/`abs`), and args-block
flow-typing on reassignment. The advisory unhandled-fallible-call hint
(RAD30011) is hidden by default and resurfaced via `rad check --strict`.
Removed builtins now show the same migration hint the runtime does.
Closes #129, #130, #131, #133.

**path builtins** - leading `~` now expands in path builtins.

**function docs** - drop a stray `=` artifact in multipick docs and
empty Examples markers from generated function docs.
