### PR TITLE
feat(fmt): rad fmt canonical formatter

### DIFF
--- a/core/cmds.go
+++ b/core/cmds.go
@@ -18,6 +18,7 @@ const (
 	EmbCmdGenId   = "gen-id"
 	EmbCmdStash   = "stash"
 	EmbCmdCheck   = "check"
+	EmbCmdFmt     = "fmt"
 	EmbCmdExplain = "explain"
 )
 
@@ -43,6 +44,7 @@ func init() {
 		createEmbeddedCmd(EmbCmdNew),
 		createEmbeddedCmd(EmbCmdDocs),
 		createEmbeddedCmd(EmbCmdCheck),
+		createEmbeddedCmd(EmbCmdFmt),
 		createEmbeddedCmd(EmbCmdHome),
 		createEmbeddedCmd(EmbCmdGenId),
 		createEmbeddedCmd(EmbCmdStash),

--- a/core/embedded/fmt
+++ b/core/embedded/fmt
@@ -1,0 +1,66 @@
+#!/usr/bin/env rad
+---
+Formats Rad scripts.
+
+Rewrites each script in place into Rad's canonical style. Use --stdout to
+preview without writing, or --check to verify formatting (e.g. in CI).
+---
+args:
+    *paths str       # Paths of Rad scripts to format.
+    stdout bool      # Print formatted output to stdout instead of writing files.
+    check bool       # Don't write; exit non-zero if any file isn't formatted.
+
+    stdout excludes check
+
+// No paths + piped stdin: format stdin to stdout (editor / pipe friendly).
+if not paths and has_stdin():
+    result = _rad_fmt(read_stdin())
+    if not result.ok:
+        print_err("stdin: could not parse.")
+        exit(1)
+    if check:
+        // In check mode, don't emit the formatted text; just signal via exit code.
+        exit(result.changed)
+    print(result.formatted, end="")
+    exit()
+
+if not paths:
+    print_err("Error: provide at least one path to format (or pipe a script via stdin).")
+    exit(1)
+
+any_unformatted = false
+any_error = false
+
+for path in paths:
+    file = read_file(path) catch:
+        pass
+    if type_of(file) == "error":
+        print_err("{path}: {file}")
+        any_error = true
+        continue
+
+    result = _rad_fmt(file.content)
+    if not result.ok:
+        print_err("{path}: could not parse, skipping.")
+        any_error = true
+        continue
+
+    if stdout:
+        print(result.formatted, end="")
+    else if check:
+        if result.changed:
+            print(path)
+            any_unformatted = true
+    else if result.changed:
+        write = write_file(path, result.formatted) catch:
+            pass
+        if type_of(write) == "error":
+            print_err("{path}: {write}")
+            any_error = true
+            continue
+        print("Formatted {path}")
+
+if any_error:
+    exit(1)
+if check and any_unformatted:
+    exit(1)

--- a/core/funcs.go
+++ b/core/funcs.go
@@ -137,6 +137,7 @@ const (
 	INTERNAL_FUNC_GET_STASH_ID    = "_rad_get_stash_id"
 	INTERNAL_FUNC_DELETE_STASH    = "_rad_delete_stash"
 	INTERNAL_FUNC_RUN_CHECK       = "_rad_run_check"
+	INTERNAL_FUNC_FMT             = "_rad_fmt"
 	INTERNAL_FUNC_CHECK_FROM_LOGS = "_rad_check_from_logs"
 	INTERNAL_FUNC_EXPLAIN         = "_rad_explain"
 	INTERNAL_FUNC_EXPLAIN_LIST    = "_rad_explain_list"

--- a/core/funcs_internal.go
+++ b/core/funcs_internal.go
@@ -7,6 +7,7 @@ import (
 
 	com "github.com/amterp/rad/core/common"
 	"github.com/amterp/rad/rts/check"
+	radfmt "github.com/amterp/rad/rts/radfmt"
 	"github.com/amterp/rad/rts/rl"
 
 	"github.com/amterp/rad/rts"
@@ -121,6 +122,19 @@ func AddInternalFuncs() {
 				}
 				radMap.SetPrimitiveList("diagnostics", diagnostics)
 
+				return newRadValues(f.i, f.callNode, radMap)
+			},
+		},
+		{
+			Name: INTERNAL_FUNC_FMT,
+			Execute: func(f FuncInvocation) RadValue {
+				// Format normalizes line endings itself, so pass the raw source.
+				formatted, changed, ok := radfmt.Format(f.GetStr("_src").Plain())
+
+				radMap := NewRadMap()
+				radMap.SetPrimitiveStr("formatted", formatted)
+				radMap.SetPrimitiveBool("changed", changed)
+				radMap.SetPrimitiveBool("ok", ok)
 				return newRadValues(f.i, f.callNode, radMap)
 			},
 		},

--- a/core/testing/snapshots/args/cmds.snap
+++ b/core/testing/snapshots/args/cmds.snap
@@ -421,6 +421,7 @@ Commands:
   completion    Generate shell tab-completion scripts.
   docs          Opens rad's documentation website.
   explain       Explains Rad error codes with detailed documentation.
+  fmt           Formats Rad scripts.
   gen-id        Generates a unique string ID. Useful for e.g. rad stash IDs.
   home          Prints out rad's home directory.
   new           Sets up a new Rad script.

--- a/core/testing/snapshots/misc/misc.snap
+++ b/core/testing/snapshots/misc/misc.snap
@@ -134,6 +134,7 @@ Commands:
   completion    Generate shell tab-completion scripts.
   docs          Opens rad's documentation website.
   explain       Explains Rad error codes with detailed documentation.
+  fmt           Formats Rad scripts.
   gen-id        Generates a unique string ID. Useful for e.g. rad stash IDs.
   home          Prints out rad's home directory.
   new           Sets up a new Rad script.
@@ -223,6 +224,7 @@ Commands:
   completion    Generate shell tab-completion scripts.
   docs          Opens rad's documentation website.
   explain       Explains Rad error codes with detailed documentation.
+  fmt           Formats Rad scripts.
   gen-id        Generates a unique string ID. Useful for e.g. rad stash IDs.
   home          Prints out rad's home directory.
   new           Sets up a new Rad script.

--- a/rts/radfmt/AGENTS.md
+++ b/rts/radfmt/AGENTS.md
@@ -1,0 +1,96 @@
+# radfmt - contributor guide
+
+`radfmt` implements `rad fmt`, a gofmt-style canonical re-printer for Rad
+scripts. It is **rule-based**: every formatting decision is a numbered rule in
+[`RULES.md`](./RULES.md), which is the source of truth. The code enforces the
+rules, the snapshots demonstrate them, and `rules_test.go` keeps all three in
+lockstep.
+
+## The golden rule
+
+**Behavior and `RULES.md` move together.** If you change what the formatter
+emits, you are changing a rule - update `RULES.md` in the same change. The
+coverage test fails the build if you don't.
+
+## To add, change, or remove a rule
+
+1. **`RULES.md`** - add or edit the rule. New rules take the next free `Fn`
+   (IDs are append-only - never renumber, never reuse). A removed rule becomes a
+   tombstone in the Changelog; its number is retired. Keep the heading shape
+   exact: `### Fn - Title \`status\`` (the status is the only backticked word -
+   nothing may follow it, or the coverage test rejects the heading). Place the
+   rule in the topical section it belongs to, not in numeric order, so IDs read
+   out of sequence in the file (F36 sits among the comment rules, F31 among the
+   statements). That's expected: the section gives context, the ID is just
+   append-order.
+2. **Code** - implement it and tag the enforcing site with `// [Fn]`. One tag
+   per rule is enough; put it where the decision lives.
+3. **Snapshot** - add or update a case under `snapshots/` whose title contains
+   `[Fn]` (e.g. `[F27] List spacing`). A case may demonstrate several rules:
+   `[F12][F13] ...`. Author the messy input and the canonical output. The
+   coverage test only checks the `[Fn]` tag is present in some title - it can't
+   tell whether the case actually exercises the rule. Write one that genuinely
+   does: for an `implemented` rule, the input must differ from the output, or the
+   snapshot proves nothing.
+4. **Run** `go test ./rts/radfmt/`. Regenerate snapshot outputs after an
+   intentional behavior change with `-run TestFmtSnapshots -update`, then read
+   the diff before committing.
+
+### Status values (drive enforcement - see the legend in `RULES.md`)
+
+| status        | needs code tag | needs snapshot | meaning                                  |
+|---------------|:---:|:---:|------------------------------------------|
+| `implemented` | yes | yes | active canonicalizing rule               |
+| `passthrough` | yes | yes | deliberate non-action, locked by a test  |
+| `limitation`  | optional | no | known gap to close later               |
+| `deferred` / `roadmap` | no | no | decided/planned, not built          |
+
+### Byte-level rules and `[raw]` snapshots
+
+Rules about characters the line-based snapshot text can't hold - CR bytes
+(the scanner strips them), trailing whitespace (editors strip it), the exact
+trailing newline - still get real snapshots. Mark the case title `[raw]` and
+write its `### INPUT ###` and `### STDOUT ###` as a single Go-quoted string:
+
+```
+### TITLE ###
+[F2][raw] CRLF and bare CR normalized to LF
+### INPUT ###
+"x = 1\r\ny = 2\r\n"
+### STDOUT ###
+"x = 1\ny = 2\n"
+```
+
+The harness decodes both with `strconv.Unquote` and compares byte-for-byte (no
+trailing-newline trim). Every rule is a snapshot; there is no unenforced status.
+
+## Safety model (do not weaken)
+
+Three layers guarantee `rad fmt` can never corrupt code:
+
+1. **Parse-error no-op** - a tree with invalid nodes is returned unchanged
+   (`ok=false`).
+2. **Panic recovery** - a panic during formatting degrades to a safe no-op.
+3. **Structural-equivalence guard** - the output is re-parsed and its
+   named-node + comment structure compared to the input; a mismatch discards the
+   formatting and returns the original.
+
+A construct with no dedicated formatter falls through to `verbatim`, which
+re-emits its exact source span - always safe, just not canonicalized. This is
+what lets us grow rules incrementally. **The structural guard compares node
+kinds, not text**, so a rule that rewrites token *content* (e.g. string quote
+normalization, F30) needs its own value-preservation check and tests - that's
+why F30 is deferred.
+
+## Layout
+
+| file | role |
+|------|------|
+| `doc.go`, `render.go` | the Doc IR + Wadler render machine (the engine) |
+| `printer.go` | `format(node)` dispatch + `formatSeq` + `verbatim` |
+| `print_stmt.go`, `print_expr.go`, `print_lit.go` | construct formatters |
+| `cst.go`, `safety.go` | CST helpers and the structural-equivalence guard |
+| `RULES.md` | the rule catalog (source of truth) |
+| `rules_test.go` | coverage test linking spec ↔ code ↔ snapshots |
+| `snapshots/*.snap` | `### INPUT ###` / `### STDOUT ###` cases, titled by rule |
+| `DESIGN.md` | design-time research (Doc IR + comment attachment theory) |

--- a/rts/radfmt/DESIGN.md
+++ b/rts/radfmt/DESIGN.md
@@ -1,0 +1,536 @@
+# Implementing a gofmt-style Canonical Re-printer ("rad fmt") on a Tree-sitter CST: Doc IR + Comment Attachment
+
+> **Note:** This is the design-time research that informed the formatter, kept as
+> a reference for the theory (Doc IR + comment attachment). It describes the
+> *intended* design and may run ahead of, or diverge from, the current code - e.g.
+> the comment-attachment side-table is only partially adopted, and `Fill` is a
+> stub. For what the formatter actually does today, read the package source and
+> the `doc.go` package comment.
+
+## TL;DR
+- **Doc IR:** Port Prettier's stack/worklist `printDocToString` (a productionized Wadler `best`/`be`) with a `cmds` stack of `{ind, mode, doc}` tuples, two modes `MODE_FLAT`/`MODE_BREAK`, a lookahead `fits` that measures the flat width of the next group plus the rest-of-line, a `groupModeMap` for group-ids, a buffered `lineSuffix` list flushed before every newline, and a one-time `propagateBreaks` pass so `hardline`/`break-parent` force every ancestor group to `MODE_BREAK`.
+- **Comment attachment:** Treat tree-sitter `extras` as floating trivia; classify each as leading/trailing/dangling using Prettier's exact rule — `hasNewline(text, locStart, {backwards})` decides own-line vs end-of-line, then `precedingNode`/`enclosingNode`/`followingNode` (found by descending the CST by byte offset) decide attachment — and emit Doc nodes accordingly (own-line leading → `text + hardline`; same-line trailing → `lineSuffix(" " + text) + breakParent`; dangling-in-empty → `indent([hardline, text])`).
+- **Blank lines:** They are NOT nodes; reconstruct them from row gaps between adjacent CST items/comments. Apply Go's exact policy: cap consecutive newlines at `maxNewlines = 2` (one blank line), preserve a single blank line, and emit none at the start/end of a block or file.
+
+## Key Findings
+
+**1. The rendering machine is a backtracking stack machine, not a recursive tree-walk.** Wadler's `best w k x = be k [(0,x)]` generalizes each document operation "to work on a list of indentation-document pairs" — i.e., a stack of `(indent, doc)` items. Prettier productionizes this into `printDocToString` with an explicit `cmds` stack of `{ind, mode, doc}` triples. The decision of flat vs broken is local and greedy ("locally optimal but not globally optimal"), made by the `fits` lookahead at each group.
+
+**2. `fits` measures the flat rendering of the candidate plus the remaining command stack, stopping at the first hard line break or when the width budget goes negative.** Verbatim from Prettier 3.x's bundled printer, `fits(next, restCommands, width, hasLineSuffix, groupModeMap, mustBeFlat)` walks a local copy of the work with `restIdx = restCommands.length`; on `DOC_TYPE_STRING` it does `width -= getStringWidth(doc)`; on a `DOC_TYPE_LINE` it returns `true` if `mode === MODE_BREAK || doc.hard` (a forced break ends the line, so it fits); the loop condition is `while (width >= 0)` and the function returns `false` only when width goes negative.
+
+**3. Breaks propagate UP the tree, statically, before rendering.** `propagateBreaks(doc)` is called once after the printer builds the doc (`docUtils.propagateBreaks(doc)` in `printAstToDoc`). `hardline` and `literalline` carry an implicit `break-parent`; any group containing a `break-parent` (transitively) has its `.break` flag set to `true`, forcing `MODE_BREAK` regardless of `fits`. Per Prettier's own docs, the printer "will try to fit everything on one line, but if it doesn't fit it will break the outermost group first and try again. It will continue breaking groups until everything fits (or there are no more groups to break)."
+
+**4. `lineSuffix` buffers trailing comments and flushes them before any newline.** The buffer (`lineSuffix` array in the printer) accumulates docs; when a real line break is emitted, the buffer is spliced back onto the command stack ahead of the newline so the comment lands at the end of the current line. `lineSuffixBoundary` forces a flush even without a newline.
+
+**5. Go and Prettier agree on the blank-line policy, derived from source byte/row positions.** Go's `go/printer` caps newlines at `maxNewlines = 2` (the source constant is literally `maxNewlines = 2 // max. number of newlines between source text`, lowered from 3 to 2 in an early Go change) via `nlimit(n int) int { return min(n, maxNewlines) }`. Prettier's Rationale states: "The approach that Prettier takes is to preserve empty lines the way they were in the original source code. There are two additional rules: Prettier collapses multiple blank lines into a single blank line. Empty lines at the start and end of blocks (and whole files) are removed. (Files always end with a single newline, though.)" Both reconstruct blank lines from line-number deltas, never from AST nodes.
+
+**6. Comment classification is a two-axis decision: own-line vs end-of-line (from newlines in source), then leading/trailing/dangling (from surrounding nodes).** Prettier's `attach()` first checks `hasNewline(text, locStart(comment), {backwards:true})` (is the comment alone on its line?), then within each branch falls back to: `followingNode` → leading; `precedingNode` → trailing; `enclosingNode` → dangling; else attach to root. Go's `CommentMap` uses an equivalent line-based heuristic, but binds to the *largest* enclosing node.
+
+## Details
+
+### PART 1 — Doc IR and the Wadler/Prettier rendering machine
+
+#### 1.1 The document algebra
+
+Wadler's core algebra (from "A prettier printer") has six constructors. In his notation the laid-out form is `Doc` and the buildable form is `DOC`:
+
+```
+DOC = NIL | DOC :<> DOC | NEST Int DOC | TEXT String | LINE | DOC :<|> DOC
+```
+
+`:<>` is concatenation, `NEST i x` adds `i` to the indentation, `TEXT s` is literal text, `LINE` is a line break that becomes a space (or nothing) when flattened, and `:<|>` is the *choice* between a wide (flat) and narrow (broken) layout. `group(x)` is defined as `flatten(x) :<|> x`. Prettier expands this minimal set into a richer builder vocabulary, but every builder reduces to these primitives plus the greedy `fits` choice.
+
+**The full node set (Prettier `commands.md`, mapped to Go):**
+
+| Doc node | Constant (`DOC_TYPE_*`) | Meaning |
+|---|---|---|
+| `text(s)` | `"string"` | Literal text; must contain no newline char |
+| `line` | `"line"` (`{soft:false,hard:false}`) | Becomes `" "` when flat, newline+indent when broken |
+| `softline` | `"line"` `{soft:true}` | Becomes `""` when flat, newline+indent when broken |
+| `hardline` | `"line"` `{hard:true}` + `break-parent` | Always a newline; forces parents to break |
+| `literalline` | `"line"` `{hard:true,literal:true}` + `break-parent` | Newline with no indent; preserves trailing whitespace |
+| `concat(parts)` / array | `"array"` | Sequence of docs printed in order |
+| `indent(doc)` | `"indent"` | +1 indent level on the contents |
+| `align(n, doc)` | `"align"` | Indent by a fixed n spaces/string |
+| `group(doc, {shouldBreak,id})` | `"group"` | Try flat; if it doesn't fit, break |
+| `conditionalGroup([a,b,c])` | `"group"` w/ `expandedStates` | Try each alternative least-to-most expanded |
+| `fill(parts)` | `"fill"` | Break only the separators that don't fit (text-flow) |
+| `ifBreak(brk, flat, {groupId})` | `"if-break"` | Print `brk` if the (referenced) group broke, else `flat` |
+| `indentIfBreak(doc, {groupId})` | `"indent-if-break"` | Indent only if the referenced group broke |
+| `lineSuffix(doc)` | `"line-suffix"` | Buffer doc; flush before next newline |
+| `lineSuffixBoundary` | `"line-suffix-boundary"` | Force a lineSuffix flush even without a newline |
+| `breakParent` | `"break-parent"` | Force all enclosing groups to break |
+| `trim` | `"trim"` | Trim trailing whitespace on the current line |
+
+#### 1.2 Wadler's `best`/`be`/`fits` (the kernel to port)
+
+The Haskell kernel (verbatim from the paper) is:
+
+```
+best w k x = be k [(0,x)]
+  be k [] = Nil
+  be k ((i,NIL):z)      = be k z
+  be k ((i,x :<> y):z)  = be k ((i,x):(i,y):z)
+  be k ((i,NEST j x):z) = be k ((i+j,x):z)
+  be k ((i,TEXT s):z)   = Text s (be (k+length s) z)
+  be k ((i,LINE):z)     = Line i (be i z)
+  be k ((i,x :<|> y):z) = better k (be k ((i,x):z)) (be k ((i,y):z))
+  better k x y = if fits (w-k) x then x else y
+
+fits w x | w < 0 = False
+fits w Nil               = True
+fits w (Text s x)        = fits (w - length s) x
+fits w (Line i x)        = True
+```
+
+Two behavioral subtleties (made explicit in Hodgson's imperative port) that you MUST preserve:
+- **`fits` measures `x` *and* the rest of the stack `z`, not just `x`.** Choosing flat for `x` can still overflow later in the same line, so the choice operator concatenates the candidate onto the remaining document before measuring. This is why Prettier's `fits` takes `restCommands`.
+- **`fits` only reads to the end of the current line** (it returns `True` on the first `Line`/break), bounding lookahead to ~`printWidth` characters — in Haskell via laziness, in an imperative port by returning early on a hard/break-mode line. This keeps the algorithm O(n).
+
+#### 1.3 Prettier's `printDocToString` main loop (verbatim structure)
+
+The modern engine replaces Wadler's two layouts with two **modes** (`MODE_BREAK`, `MODE_FLAT`) carried per stack frame, plus a `groupModeMap` keyed by group-id, a `pos` column counter, and a `lineSuffix` buffer. The loop pops `{ind, mode, doc}` from `cmds` and dispatches on `getDocType(doc)`:
+
+- `DOC_TYPE_STRING`: `out.push(doc); pos += getStringWidth(doc)`.
+- `DOC_TYPE_ARRAY`: push parts in reverse so they pop in order: `for (let i = doc.length - 1; i >= 0; i--) cmds.push({ind, mode, doc: doc[i]})`.
+- `DOC_TYPE_INDENT`: `cmds.push({ind: makeIndent(ind, options), mode, doc: doc.contents})`.
+- `DOC_TYPE_ALIGN`: `makeAlign(ind, doc.n, options)`.
+- `DOC_TYPE_TRIM`: `pos -= trim(out)` (strip trailing whitespace already emitted).
+- `DOC_TYPE_GROUP`: see §1.4 below.
+- `DOC_TYPE_IF_BREAK` / `DOC_TYPE_INDENT_IF_BREAK`: resolve the controlling mode — `const groupMode = doc.groupId ? groupModeMap[doc.groupId] || MODE_FLAT : mode;` then choose `doc.breakContents` (if `MODE_BREAK`) or `doc.flatContents`.
+- `DOC_TYPE_LINE`: if `mode === MODE_BREAK` (or `doc.hard`): flush lineSuffix if present, then emit newline + indentation (`pos = ind.length`); else if `!doc.soft`, emit `" "` and `pos++`.
+- `DOC_TYPE_LINE_SUFFIX`: `lineSuffix.push({ind, mode, doc: doc.contents})` — buffer, don't print.
+- `DOC_TYPE_LINE_SUFFIX_BOUNDARY`: if `lineSuffix.length`, inject a synthetic hardline frame to force a flush.
+- `DOC_TYPE_BREAK_PARENT`: no-op at print time (already consumed by `propagateBreaks`).
+
+After the main pop, if the frame's doc had an `id`, record `groupModeMap[doc.id] = <the mode it resolved to>` so later `ifBreak(..., {groupId})` can reference it.
+
+**lineSuffix flush rule:** when a newline is about to be emitted (a `DOC_TYPE_LINE` in `MODE_BREAK`/hard) and `lineSuffix.length > 0`, the printer pushes the current line doc back and splices the buffered suffix frames ahead of it, so trailing comments print at the end of the line *before* the break. At end-of-document, any remaining lineSuffix is flushed.
+
+#### 1.4 How `group` chooses flat vs broken
+
+In the `DOC_TYPE_GROUP` case the printer branches on the current `mode`:
+
+- **`MODE_FLAT` and `!shouldRemeasure`**: stay flat — `cmds.push({ind, mode: doc.break ? MODE_BREAK : MODE_FLAT, doc: doc.contents})`.
+- **`MODE_BREAK`** (or remeasure): compute `rem = width - pos` and `hasLineSuffix = lineSuffix.length > 0`, build a flat candidate `next = {ind, mode: MODE_FLAT, doc: doc.contents}`, and test:
+  ```js
+  if (!doc.break && fits(next, cmds, rem, hasLineSuffix, groupModeMap)) {
+    cmds.push(next);                 // group fits flat
+  } else {
+    cmds.push({ind, mode: MODE_BREAK, doc: doc.contents}); // break it
+  }
+  ```
+  If `doc.break` is set (via `propagateBreaks` or `shouldBreak`), the `fits` test is skipped and the group goes straight to `MODE_BREAK`. Because the printer breaks the **outermost** group first and re-tests inner groups, breaking cascades from the outside in until everything fits or there are no more groups to break.
+
+**Conditional groups / `expandedStates`:** when a group carries `expandedStates` (from `conditionalGroup([a, b, c])`), the printer tries each state least-expanded first: if `doc.break`, it jumps to the most-expanded (`expandedStates[last]`); otherwise it loops `for (let i = 1; i < expandedStates.length + 1; i++)`, testing `fits` on `expandedStates[i]` in `MODE_FLAT`, taking the first that fits, and falling back to the most-expanded state if none do. Prettier's `commands.md` documents the exact contract and the cost: "This should be used as last resort as it triggers an exponential complexity when nested… This will try to print the first alternative, if it fit use it, otherwise go to the next one and so on. The alternatives is an array of documents going from the least expanded (most flattened) representation first to the most expanded." Use sparingly.
+
+#### 1.5 `fits` — verbatim and annotated (Prettier 3.x)
+
+```js
+function fits(next, restCommands, width, hasLineSuffix, groupModeMap, mustBeFlat) {
+  let restIdx = restCommands.length;
+  const cmds = [next];
+  const out = [];
+  while (width >= 0) {
+    if (cmds.length === 0) {
+      if (restIdx === 0) return true;        // consumed whole rest-of-line: it fits
+      cmds.push(restCommands[--restIdx]);    // pull next rest-command (backwards)
+      continue;
+    }
+    const { mode, doc } = cmds.pop();
+    switch (getDocType(doc)) {
+      case DOC_TYPE_STRING:
+        out.push(doc); width -= getStringWidth(doc); break;
+      case DOC_TYPE_ARRAY: case DOC_TYPE_FILL: {
+        const parts = getDocParts(doc);
+        for (let i = parts.length - 1; i >= 0; i--) cmds.push({ mode, doc: parts[i] });
+        break;
+      }
+      case DOC_TYPE_INDENT: case DOC_TYPE_ALIGN:
+      case DOC_TYPE_INDENT_IF_BREAK: case DOC_TYPE_LABEL:
+        cmds.push({ mode, doc: doc.contents }); break;
+      case DOC_TYPE_TRIM: width += trim(out); break;
+      case DOC_TYPE_GROUP: {
+        if (mustBeFlat && doc.break) return false;
+        const groupMode = doc.break ? MODE_BREAK : mode;
+        const contents = doc.expandedStates && groupMode === MODE_BREAK
+          ? doc.expandedStates.at(-1) : doc.contents;
+        cmds.push({ mode: groupMode, doc: contents }); break;
+      }
+      case DOC_TYPE_IF_BREAK: {
+        const groupMode = doc.groupId ? groupModeMap[doc.groupId] || MODE_FLAT : mode;
+        const contents = groupMode === MODE_BREAK ? doc.breakContents : doc.flatContents;
+        if (contents) cmds.push({ mode, doc: contents });
+        break;
+      }
+      case DOC_TYPE_LINE:
+        if (mode === MODE_BREAK || doc.hard) return true;  // line ends here -> fits
+        if (!doc.soft) { out.push(" "); width--; }
+        break;
+      case DOC_TYPE_LINE_SUFFIX: hasLineSuffix = true; break;
+      case DOC_TYPE_LINE_SUFFIX_BOUNDARY: if (hasLineSuffix) return false; break;
+    }
+  }
+  return false;     // width went negative
+}
+```
+
+Key semantics: `fits` returns **true** when it consumes the candidate and the entire rest-of-line without exhausting the width budget, OR it hits a line break that would end the current line (`MODE_BREAK` line or `doc.hard`). It returns **false** when `width` goes negative, when a `mustBeFlat` candidate contains a forced-break group, or when a `lineSuffixBoundary` is reached with a pending line-suffix. (Note: across versions the signature has a minor variation — current `main` inserts an `options` parameter: `fits(next, restCommands, width, options, hasLineSuffix, groupModeMap, mustBeFlat)`; the body logic is identical.)
+
+#### 1.6 `propagateBreaks` (break-parent propagation)
+
+Before printing, traverse the doc bottom-up. Any `break-parent` (and the implicit one inside every `hardline`/`literalline`) marks its nearest enclosing group `.break = true`; that propagates outward so **every** ancestor group breaks. This is a static, one-pass analysis — "this only matters for 'hard' breaks … that can be statically analyzed." A `group` containing a deeply nested `hardline` therefore always renders broken; this is the mechanism behind Prettier's rule that "Functions always break after the opening curly brace no matter what, so the array breaks as well for consistent formatting" — a multiline function body's hardline forces every enclosing call/array group open.
+
+#### 1.7 Worked example A — function call argument list
+
+Doc construction (the canonical Prettier `ArrayExpression`/call shape):
+
+```
+group([
+  "foo(",
+  indent([ softline, join([",", line], args) ]),
+  softline,
+  ")"
+])
+```
+
+With `args = [reallyLongArg(), omgSoManyParameters(), IShouldRefactorThis(), isThereSeriouslyAnotherOne()]` at width 100:
+
+- **Flat (fits):** `softline`→`""`, `line`→`" "`:
+  `foo(reallyLongArg(), omgSoManyParameters(), IShouldRefactorThis(), isThereSeriouslyAnotherOne())`
+- **Broken (exceeds 100, group → MODE_BREAK):** each `softline`/`line` becomes a newline+indent:
+  ```
+  foo(
+    reallyLongArg(),
+    omgSoManyParameters(),
+    IShouldRefactorThis(),
+    isThereSeriouslyAnotherOne(),
+  )
+  ```
+The trailing comma in broken mode is produced with `ifBreak(",")` after the last element. The decision is made once, at the group, by `fits(flatCandidate, restCommands, 100 - pos, …)`.
+
+#### 1.8 Worked example B — trailing comment surviving a wrap
+
+`["a", lineSuffix(" // comment"), ";", hardline]` renders as:
+
+```
+a; // comment
+```
+
+The `lineSuffix(" // comment")` is buffered when first popped; `";"` prints normally; when the `hardline` is reached the buffer is flushed *before* the newline, so the comment lands at end-of-line after the semicolon — never inside the code. If the line wraps, the same flush-before-newline rule guarantees the comment stays attached to the visual end of the construct's line, and the `break-parent` inside `hardline` forces the enclosing group broken.
+
+#### 1.9 Go-flavored Doc IR types and render worklist
+
+```go
+type Mode uint8
+const ( ModeFlat Mode = iota; ModeBreak )
+
+// Doc is the sealed interface implemented by every node kind.
+type Doc interface{ isDoc() }
+
+type Text  struct{ S string }                       // no '\n' allowed
+type Line  struct{ Soft, Hard, Literal bool }        // hard/literal carry implicit break-parent
+type Concat struct{ Parts []Doc }
+type Indent struct{ Contents Doc }
+type Align  struct{ N int; Contents Doc }
+type Group  struct {
+    Contents       Doc
+    Break          bool      // set by propagateBreaks or shouldBreak
+    ID             GroupID   // 0 = none
+    ExpandedStates []Doc      // conditionalGroup; nil if plain group
+}
+type Fill          struct{ Parts []Doc }
+type IfBreak       struct{ BreakContents, FlatContents Doc; GroupID GroupID }
+type IndentIfBreak struct{ Contents Doc; GroupID GroupID }
+type LineSuffix    struct{ Contents Doc }
+type LineSuffixBoundary struct{}
+type BreakParent   struct{}
+type Trim          struct{}
+
+func (Text) isDoc() {}; func (Line) isDoc() {} /* …all kinds… */
+
+type GroupID uint32
+
+type cmd struct{ ind Indentation; mode Mode; doc Doc }
+type Indentation struct{ value string }   // accumulated indent string
+
+func PrintDocToString(doc Doc, width int) string {
+    groupModeMap := map[GroupID]Mode{}
+    var out []string
+    pos := 0
+    cmds := []cmd{{Indentation{}, ModeBreak, doc}}
+    var lineSuffix []cmd
+    shouldRemeasure := false
+
+    for len(cmds) > 0 {
+        c := cmds[len(cmds)-1]; cmds = cmds[:len(cmds)-1]
+        switch d := c.doc.(type) {
+
+        case Text:
+            out = append(out, d.S); pos += stringWidth(d.S)
+
+        case Concat:
+            for i := len(d.Parts) - 1; i >= 0; i-- {
+                cmds = append(cmds, cmd{c.ind, c.mode, d.Parts[i]})
+            }
+        case Indent:
+            cmds = append(cmds, cmd{makeIndent(c.ind), c.mode, d.Contents})
+        case Align:
+            cmds = append(cmds, cmd{makeAlign(c.ind, d.N), c.mode, d.Contents})
+        case Trim:
+            pos -= trimTrailing(&out)
+
+        case Group:
+            switch c.mode {
+            case ModeFlat:
+                if !shouldRemeasure {
+                    m := ModeFlat; if d.Break { m = ModeBreak }
+                    cmds = append(cmds, cmd{c.ind, m, d.Contents})
+                    break
+                }
+                fallthrough
+            case ModeBreak:
+                shouldRemeasure = false
+                next := cmd{c.ind, ModeFlat, d.Contents}
+                rem := width - pos
+                hasLS := len(lineSuffix) > 0
+                if !d.Break && fits(next, cmds, rem, hasLS, groupModeMap, false) {
+                    cmds = append(cmds, next)
+                } else if d.ExpandedStates != nil {
+                    cmds = append(cmds, chooseExpanded(d, c.ind, cmds, rem, hasLS, groupModeMap))
+                } else {
+                    cmds = append(cmds, cmd{c.ind, ModeBreak, d.Contents})
+                }
+            }
+            if d.ID != 0 {
+                groupModeMap[d.ID] = cmds[len(cmds)-1].mode
+            }
+
+        case IfBreak:
+            gm := c.mode
+            if d.GroupID != 0 { gm = groupModeMap[d.GroupID] } // default ModeFlat (zero value)
+            chosen := d.FlatContents
+            if gm == ModeBreak { chosen = d.BreakContents }
+            if chosen != nil { cmds = append(cmds, cmd{c.ind, c.mode, chosen}) }
+
+        case IndentIfBreak:
+            gm := groupModeMap[d.GroupID]
+            inner := d.Contents
+            if gm == ModeBreak { inner = Indent{d.Contents} }
+            cmds = append(cmds, cmd{c.ind, c.mode, inner})
+
+        case LineSuffix:
+            lineSuffix = append(lineSuffix, cmd{c.ind, c.mode, d.Contents})
+
+        case LineSuffixBoundary:
+            if len(lineSuffix) > 0 {
+                cmds = append(cmds, cmd{c.ind, c.mode, Line{Hard: true}})
+            }
+
+        case BreakParent: // no-op at print time
+
+        case Line:
+            if c.mode == ModeFlat && !d.Hard {
+                if !d.Soft { out = append(out, " "); pos++ }
+                break
+            }
+            // MODE_BREAK or hard line: flush buffered trailing comments first
+            if len(lineSuffix) > 0 {
+                cmds = append(cmds, c)                 // re-process this Line after suffix
+                for i := len(lineSuffix) - 1; i >= 0; i-- {
+                    cmds = append(cmds, lineSuffix[i])
+                }
+                lineSuffix = nil
+                break
+            }
+            if d.Literal {
+                out = append(out, "\n"); pos = 0
+            } else {
+                trimTrailing(&out)
+                out = append(out, "\n"+c.ind.value); pos = len(c.ind.value)
+            }
+        }
+    }
+    // flush any trailing line-suffix at EOF
+    for _, ls := range lineSuffix { /* append rendered ls */ _ = ls }
+    return strings.Join(out, "")
+}
+
+func fits(next cmd, rest []cmd, width int, hasLineSuffix bool,
+          gmm map[GroupID]Mode, mustBeFlat bool) bool {
+    restIdx := len(rest)
+    cmds := []cmd{next}
+    var out []string
+    for width >= 0 {
+        if len(cmds) == 0 {
+            if restIdx == 0 { return true }
+            restIdx--; cmds = append(cmds, rest[restIdx]); continue
+        }
+        c := cmds[len(cmds)-1]; cmds = cmds[:len(cmds)-1]
+        switch d := c.doc.(type) {
+        case Text:
+            out = append(out, d.S); width -= stringWidth(d.S)
+        case Concat:
+            for i := len(d.Parts) - 1; i >= 0; i-- {
+                cmds = append(cmds, cmd{c.ind, c.mode, d.Parts[i]})
+            }
+        case Fill:
+            for i := len(d.Parts) - 1; i >= 0; i-- {
+                cmds = append(cmds, cmd{c.ind, c.mode, d.Parts[i]})
+            }
+        case Indent:        cmds = append(cmds, cmd{c.ind, c.mode, d.Contents})
+        case Align:         cmds = append(cmds, cmd{c.ind, c.mode, d.Contents})
+        case IndentIfBreak: cmds = append(cmds, cmd{c.ind, c.mode, d.Contents})
+        case Trim:          width += /* trim */ 0
+        case Group:
+            if mustBeFlat && d.Break { return false }
+            gm := c.mode; if d.Break { gm = ModeBreak }
+            contents := d.Contents
+            if d.ExpandedStates != nil && gm == ModeBreak {
+                contents = d.ExpandedStates[len(d.ExpandedStates)-1]
+            }
+            cmds = append(cmds, cmd{c.ind, gm, contents})
+        case IfBreak:
+            gm := c.mode
+            if d.GroupID != 0 { gm = gmm[d.GroupID] }
+            chosen := d.FlatContents
+            if gm == ModeBreak { chosen = d.BreakContents }
+            if chosen != nil { cmds = append(cmds, cmd{c.ind, c.mode, chosen}) }
+        case Line:
+            if c.mode == ModeBreak || d.Hard { return true }
+            if !d.Soft { out = append(out, " "); width-- }
+        case LineSuffix:          hasLineSuffix = true
+        case LineSuffixBoundary:  if hasLineSuffix { return false }
+        }
+    }
+    return false
+}
+```
+
+`propagateBreaks` runs once before `PrintDocToString`:
+
+```go
+func propagateBreaks(d Doc) (containsForcedBreak bool) {
+    switch n := d.(type) {
+    case BreakParent: return true
+    case Line:        return n.Hard       // hardline/literalline force breaks
+    case *Group:
+        child := propagateBreaks(n.Contents)
+        for _, st := range n.ExpandedStates { if propagateBreaks(st) { child = true } }
+        if child { n.Break = true }
+        return n.Break
+    case Concat:
+        forced := false
+        for _, p := range n.Parts { if propagateBreaks(p) { forced = true } }
+        return forced
+    /* …recurse into Indent/Align/IfBreak/LineSuffix contents… */
+    }
+    return false
+}
+```
+(Use pointer receivers for `Group` so the `.Break` mutation persists.)
+
+---
+
+### PART 2 — Comment & blank-line attachment
+
+#### 2.1 Reference approaches
+
+**Prettier (`src/main/comments/attach.js`).** Comments are decorated then attached. `decorateComment(node, comment, text)` finds, by binary search over `getSortedChildNodes(node)` (children sorted by `[locStart, locEnd]`), the child that encloses the comment (`locStart(child) <= locStart(comment) && locEnd(comment) <= locEnd(child)`) and recurses into it; the deepest such node becomes `enclosingNode`. Among the enclosing node's children, the nearest child ending at/before the comment is `precedingNode`, and the nearest child starting at/after it is `followingNode`. Then `attach()` dispatches on three cases:
+
+1. **`hasNewline(text, locStart(comment), {backwards:true})`** — the comment starts its own line (own-line): after language-specific handlers, fall back to `followingNode ? addLeadingComment : precedingNode ? addTrailingComment : enclosingNode ? addDanglingComment : addDanglingComment(ast)`.
+2. **else if `hasNewline(text, locEnd(comment))`** — there's code before but not after the comment on its line (end-of-line): fall back to `precedingNode ? addTrailingComment : followingNode ? addLeadingComment : addDanglingComment`.
+3. **else** — the comment is wedged between code on both sides (remaining): prefer attaching as trailing/leading per language handlers.
+
+Printing (`printComments`): for each attached comment, `leading` comments print before the node and, if `hasNewline` after the comment, add a `hardline`; `trailing` comments print via `printTrailingComment` (using `lineSuffix` for same-line ones); dangling comments print via `printDanglingComments`, which returns `indent([hardline, join(hardline, parts)])` (or `join(hardline, parts)` when `sameIndent`).
+
+**Go (`go/ast/commentmap.go` + `go/printer/printer.go`).** `NewCommentMap` associates a `*CommentGroup` `g` with node `n` if: (1) `g` starts on the same line as `n` ends; (2) `g` starts on the line immediately following `n` AND there's an empty line after `g` before the next node; or (3) `g` starts before `n` and isn't already associated with the previous node. It associates to the **largest** node possible (a trailing line-comment binds to the whole assignment, not the last operand). The printer's `intersperseComments` writes pending comments before the next token; it then ensures a line break "after a //-style comment, before EOF, and before a closing '}'", and for a `/*…*/` comment followed on the same line by a non-comma/non-closing token it inserts a single separating space.
+
+**Biome (CST trivia model).** Biome attaches trivia directly to tokens. Its architecture docs state the rule verbatim: "Every trivia up to the token/keyword (including line breaks) will be the leading trivia; everything until the next linebreak (but not including it) will be the trailing trivia." In their worked example, `// comment 1` is trailing trivia of the `;` token and `// comment 2` is leading trivia of the next `const` keyword (the CST shows `CONST_KW@27..45 "const" [Newline("\n"), Comments("// comment 2"), Newline("\n")]`). This is a purely position/newline-driven split — the same two-axis rule as Prettier, but resolved at the token level rather than by node search.
+
+#### 2.2 Concrete algorithm for rad fmt (tree-sitter CST, Go, width 100)
+
+**Inputs:** the CST root, the original `source []byte`, and a flat list of comment nodes (the tree-sitter `extras`, gathered by walking the tree and collecting nodes whose `IsExtra()` / kind is `comment`). Each node exposes `StartByte/EndByte` and `StartPoint/EndPoint` (row, column).
+
+**Step 0 — gather and sort.** Collect all extra/comment nodes; sort by `StartByte`. Collect the "real" (non-extra, named) nodes for sibling/offset queries.
+
+**Step 1 — find enclosing/preceding/following for each comment** (port of `decorateComment`):
+```
+func locate(root, comment):
+    enclosing = root
+    descend:
+      children = namedChildren(enclosing) sorted by StartByte   // skip extras
+      pick child where child.StartByte <= comment.StartByte
+                    && comment.EndByte <= child.EndByte
+      if found: enclosing = child; repeat descend
+      else: break
+    preceding = last child of enclosing with child.EndByte <= comment.StartByte
+    following = first child of enclosing with child.StartByte >= comment.EndByte
+    return preceding, enclosing, following
+```
+Use byte offsets for containment (robust against multibyte columns); use **row numbers** (`StartPoint.Row`) for the newline tests below.
+
+**Step 2 — classify own-line vs end-of-line trailing.** Let `prevTok` be the last token/node ending before the comment and `nextTok` the first starting after it.
+- **Own-line** iff there is a newline between `prevTok.EndPoint.Row` and `comment.StartPoint.Row` (i.e., `comment.StartPoint.Row > prevTok.EndPoint.Row`), or the comment is the first thing in the file/block. Equivalent to Prettier's `hasNewline(text, locStart, {backwards:true})`.
+- **End-of-line (same-line trailing)** iff `comment.StartPoint.Row == prevTok.EndPoint.Row` (code precedes it on the line) AND a newline follows (`nextTok.StartPoint.Row > comment.EndPoint.Row`). Equivalent to `hasNewline(text, locEnd)`.
+- **Remaining** (rare): code on both sides, same line — treat as trailing of `preceding`.
+
+**Step 3 — leading/trailing/dangling decision** (port of `attach` fallbacks):
+- Own-line: `following ? leading(following) : preceding ? trailing(preceding) : dangling(enclosing)`.
+- End-of-line: `preceding ? trailing(preceding) : following ? leading(following) : dangling(enclosing)`.
+- If neither `preceding` nor `following` exists (empty container), always `dangling(enclosing)`.
+
+**Step 4 — emit Doc nodes per situation** (the mapping table in §2.3).
+
+**Step 5 — blank-line reconstruction** (port of Go's `nlimit`/`maxNewlines = 2` and Prettier's collapse rule). Blank lines are NOT CST nodes; derive them from row gaps. For any two adjacent emitted items `A` then `B` (statements, decls, or comments) inside a block:
+```
+gap   = B.StartPoint.Row - A.EndPoint.Row   // rows strictly between them
+blanks = gap - 1                            // number of empty source lines
+// normal separator between block items is one hardline;
+// if blanks >= 1, emit a SECOND hardline (one blank line)
+```
+Concretely: the normal separator between block items is a single `hardline`; if `blanks >= 1` (≥1 empty source line between them), emit `hardline, hardline` (one blank line). Never emit more than one blank line — this is exactly Go's cap, whose source constant is `maxNewlines = 2 // max. number of newlines between source text` enforced by `func nlimit(n int) int { return min(n, maxNewlines) }`. Suppress the leading separator before the first item and the trailing separator after the last item of a block/file; Prettier's Rationale states the equivalent rule: "Empty lines at the start and end of blocks (and whole files) are removed. (Files always end with a single newline, though.)" Prettier implements blank-line preservation with `isNextLineEmpty`/`isPreviousLineEmpty` over the original text.
+
+**`isNextLineEmpty(source, node)`** for rad fmt: starting at `node.EndByte`, skip spaces/tabs and one inline/trailing comment, skip one newline, then check whether the next char (after more spaces) is another newline — if so, a blank line follows the node.
+
+#### 2.3 Edge-case table (situation → chosen model → Doc nodes)
+
+| # | Edge case | How the model handles it | Doc nodes to emit |
+|---|---|---|---|
+| 1 | Comment between block-opening `{` and first child | `preceding = {` token, `following =` first stmt, comment on its own line → **leading** of first child | `text(comment) + hardline` prepended to first child; if a blank line followed in source, `hardline + hardline` |
+| 2 | Trailing comment on a construct that line-wraps | End-of-line trailing of `preceding`; `lineSuffix` guarantees flush-before-newline so it can't fall inside wrapped code; `hardline`'s `break-parent` keeps the wrapped group broken | `lineSuffix(" " + text) + breakParent` |
+| 3 | Comment at EOF (after last statement) | `following = nil`, `preceding =` last stmt → **trailing** of last stmt (or **dangling** of root if no preceding). Go forces a newline before EOF | own-line → `hardline + text`; trailing → `lineSuffix(" " + text)`; always end file with single `hardline` |
+| 4 | Leading file/license comment above first statement | Own-line, `following =` first decl → **leading**; preserve the blank line gap to the first decl | `text + hardline (+ hardline if blank-line gap)` then the decl |
+| 5 | Dangling comment in empty block/container `{}` / `()` | No `preceding`/`following` inside the container → **dangling** of `enclosing`; container must still render its delimiters | `group(["{", indent([hardline, join(hardline, comments)]), hardline, "}"])` → i.e. `indent([hardline, text])` + closing `hardline` |
+| 6 | Comment between elements of a delimited list | If own-line → **leading** of the following element (prints above it inside the indented list); if same-line after a `,` → **trailing** of the preceding element | own-line: `text + hardline` before next element; trailing: `lineSuffix(" " + text)` after the element's comma |
+
+#### 2.4 Doc-node mapping summary
+
+- **Leading own-line comment** → `text(comment)`, then `hardline` (plus a second `hardline` if a blank line separated it from the node). The `hardline` propagates `break-parent` to enclosing groups, which is correct: a node with an own-line leading comment can't stay flat.
+- **Leading same-line comment** (block `/* */` before code on same line) → `text(comment) + " "` (a space, no break).
+- **Trailing same-line comment** → `lineSuffix(" " + text)` (+ implicit `breakParent` if it's a `//` line comment, since the rest of the line must end). For Go, every `//` comment forces a following newline.
+- **Trailing own-line comment** (comment owned as trailing but on its own line below) → `lineSuffix([hardline, text])`.
+- **Dangling comment (empty block)** → `indent([hardline, text])` before the closing delimiter's `hardline`.
+- **Blank line** → a second `hardline` (a doubled `hardline`), capped so 2+ source blanks collapse to one.
+
+## Recommendations
+
+**Stage 1 — build and validate the Doc engine first (in isolation).** Implement the IR types and `PrintDocToString`/`fits`/`propagateBreaks` from §1.9 exactly as Prettier's, with a hand-written `cmds` stack (no recursion). Validate against the two worked examples (call-arg wrapping at width 100; trailing-comment lineSuffix) and a property test: **idempotence** — `format(format(x)) == format(x)`. This is the single most important correctness invariant for a canonical re-printer and the one Prettier's own `--debug-check` enforces. *Benchmark to advance:* idempotent on a corpus of ≥1000 real Go files and byte-identical to a reference on round-tripping already-formatted code.
+
+**Stage 2 — implement comment attachment as a separate pass over the CST**, producing per-node `leadingComments`/`trailingComments`/`danglingComments` slices (mutating a side-table keyed by node ID, not the immutable CST). Port `locate()` (§2.2 step 1) and the two-axis classifier (steps 2–3) verbatim from Prettier's `attach`. Add the language-specific handlers you need **only** for the edge cases in §2.3 — start with cases 1 (open-brace), 5 (empty block), and 6 (list elements), which cause the most visible misplacement. *Benchmark:* every comment in the corpus is emitted exactly once (port Prettier's `ensureAllCommentsPrinted` assertion — a dropped comment is a hard failure) and lands on the same logical line as in gofmt's output.
+
+**Stage 3 — blank-line reconstruction.** Implement `isNextLineEmpty`/`isPreviousLineEmpty` over the source bytes and the `gap-1`/`maxNewlines=2` collapse from §2.2 step 5. Wire the doubled-`hardline` separator into block/statement-sequence printers, suppressing it at block start/end. *Benchmark:* blank-line placement byte-identical to gofmt on the corpus.
+
+**Thresholds that change the plan:**
+- If idempotence fails, **stop and fix the Doc engine** before touching comments — non-idempotence almost always traces to `fits` measuring the wrong rest-of-line or a missing `propagateBreaks`.
+- If comments land on the wrong node, prefer Go's "attach to the largest node" rule over Prettier's deepest-enclosing rule for statement-level comments (it matches gofmt expectations and avoids the gosec-style `#nosec` misattachment bug where a comment binds to a sub-expression instead of the whole `if`).
+- If `conditionalGroup`/`expandedStates` causes blowups, replace with a plain `group` + `ifBreak`; reserve conditional groups for the few constructs that truly need 3+ layouts.
+
+## Caveats
+
+- **Source/version drift in `fits`.** The verbatim `fits` above is from Prettier 3.0.0-alpha.1's bundled `doc.mjs`; current `main` inserts an `options` parameter (`fits(next, restCommands, width, options, hasLineSuffix, groupModeMap, mustBeFlat)`) but the body logic is unchanged. The un-bundled `src/document/printer.js` uses the same logic with names `getDocType`/`getStringWidth`/`getDocParts`/`trim`/`at`. GitHub raw/blob fetches were blocked during research, so exact upstream line numbers for the un-bundled file are not quoted.
+- **CST vs AST.** Prettier and Go both attach comments to an **AST**; you are working on a tree-sitter **CST** where comments are `extras` that appear as un-fielded siblings anywhere. This is actually *easier* for attachment (comments are already in the tree in source order) but means you must (a) skip `extras` when computing `namedChildren` for `locate()`, and (b) reconstruct blank lines from `StartPoint.Row`/`EndByte` because tree-sitter discards whitespace. Use byte offsets for containment and row numbers for newline tests.
+- **Go's "largest node" heuristic is deliberately different from Prettier's "deepest enclosing."** They produce different attachments for trailing comments on compound statements. For a gofmt-*style* tool, the Go rule is the safer default; adopt it explicitly rather than copying Prettier's deepest-node search wholesale.
+- **`go/printer` is not Wadler-based.** Go's printer is a single-pass tabwriter-backed emitter, not a Doc/`fits` engine; it never does width-based group breaking the way Prettier does. Use it as the authority for **comment interspersing and blank-line policy** (`intersperseComments`, `nlimit`, `maxNewlines`), and use Prettier as the authority for the **Doc IR and line-breaking**. Mixing the two is the core design of rad fmt.
+- **`printWidth` is a target, not a hard cap.** Per Prettier's own docs, the engine "will make both shorter and longer lines" — e.g. a long unbreakable string or a `//` comment can exceed 100 columns. Don't assert a hard 100-column maximum in tests; assert idempotence and structural correctness instead.
+- **Known hard cases the references still get wrong**, which you should expect and test: multiple comments on one line between two statements (Prettier PR #9672 had to fix reordering), comments around `else`/`else if` and ternary branches, and comments wedged between a selector expression and its `.` — documented in golang/go issue #70978 ("go/printer: Comment-LineBreak-LineBreak-SelectorExpr-Comment AST modification issue", reported on go1.23.4), where lengthening the selector's operand makes go/printer intersperse a following comment *in the middle of* the selector expression. Handle these with explicit per-construct handlers rather than relying on the generic fallback.

--- a/rts/radfmt/RULES.md
+++ b/rts/radfmt/RULES.md
@@ -1,0 +1,287 @@
+# Rad Formatter Rules
+
+This is the authoritative catalog of every formatting decision `rad fmt` makes.
+It is the source of truth: the code enforces these rules, the snapshots
+demonstrate them, and a coverage test (`rules_test.go`) keeps all three in sync.
+
+## How to read this
+
+Each rule has a stable ID (`F12`), a one-line statement, a `before → after`
+example, and a pointer to the code that enforces it. Rule headings are
+machine-parsed, so keep the shape exactly (real headings use a number; this
+illustrative one uses `Fn` so the coverage test doesn't read it as a rule):
+
+```
+### Fn - Short rule title `status`
+```
+
+- **IDs are stable and append-only.** A new rule takes the next free number. A
+  removed rule becomes a tombstone (see Changelog) - its number is never reused
+  and never renumbered, so references in code, commits, and discussion stay
+  valid forever.
+- **Status** (the backticked word in each heading) drives enforcement:
+  - `implemented` - an active canonicalizing rule. Must have a `// [Fn]` code
+    tag and at least one snapshot whose title contains `[Fn]`.
+  - `passthrough` - a deliberate non-action (we intentionally leave something
+    alone). Same enforcement as `implemented` - tag + snapshot - because "we
+    don't touch this" is a decision worth locking with a test.
+  - `limitation` - a known gap we mean to close. Documented and code-tagged by
+    convention (the tag is not enforced); exempt from the snapshot requirement.
+  - `deferred` / `roadmap` - decided or planned but not built. Documented only.
+
+Byte-level rules (line endings, trailing whitespace, the exact trailing newline)
+can't be written as literal snapshot text - the test scanner strips CRs and
+editors strip trailing spaces. Those cases mark their title with `[raw]` and
+carry their input and expected output as Go-quoted strings (e.g. `"x = 1\r\n"`),
+which the harness decodes and compares byte-for-byte. So every rule, including
+these, is a real snapshot - there is no "trust me, it's tested elsewhere" status.
+
+The target style derives from existing idiom (`core/embedded/*`) and the
+decisions recorded in the git history of this package.
+
+---
+
+## Whitespace & file
+
+### F1 - Four-space indentation `implemented`
+Each block level indents four spaces; never tabs.
+Code: `render.go` `IndentUnit`, `print_stmt.go` `indentedBody`
+
+### F2 - Line endings normalized to LF `implemented`
+CRLF and bare CR become `\n`.
+`x = 1\r\n` → `x = 1\n`
+Code: `fmt.go` `normalizeLineEndings`
+
+### F3 - Exactly one trailing newline `implemented`
+The file ends in a single `\n`, no more, no less.
+Code: `printer.go` `formatSourceFile`
+
+### F4 - Trailing whitespace stripped `implemented`
+Every line has its trailing spaces/tabs removed.
+Code: `render.go` `trimTrailing`
+
+### F5 - Target line width 120 `implemented`
+Calls and collections wrap when a line would exceed 120 columns. It is a
+target, not a hard cap - long unbreakable tokens (strings, comments) may exceed
+it.
+Code: `render.go` `MaxWidth`
+
+---
+
+## Blank lines & comments
+
+### F6 - Collapse multiple blank lines `implemented`
+Two or more consecutive blank lines become one.
+`a\n\n\n\nb` → `a\n\nb`
+Code: `printer.go` `formatSeq`
+
+### F7 - Strip blank lines at edges `implemented`
+No blank lines at the start or end of a file or block body.
+Code: `printer.go` `formatSeq`
+
+### F8 - Preserve a single blank line `implemented`
+One blank line is kept wherever the source had at least one, as a separator.
+Code: `printer.go` `formatSeq`
+
+### F9 - Standalone comment keeps its line `implemented`
+A comment on its own line stays on its own line.
+Code: `printer.go` `formatSeq`
+
+### F10 - Trailing same-line comment stays `implemented`
+A comment after code on the same line stays there (it attaches as a
+line-suffix, so it never falls inside wrapped code).
+`x = 1 // note` → `x = 1 // note`
+Code: `printer.go` `formatSeq`
+
+### F11 - Header-trailing comment stays on the header `implemented`
+A comment trailing a block header (`if x: // why`) stays on the header line
+rather than being pushed into the body.
+Code: `print_stmt.go` `blockTail`
+
+### F36 - Comment-bearing expressions emitted verbatim `limitation`
+An expression containing an interior comment is emitted verbatim rather than
+risk dropping the comment during reflow. To be removed as per-construct interior
+comment attachment matures (see `DESIGN.md`).
+Code: `print_expr.go` `formatExpr`
+
+---
+
+## Statements
+
+### F12 - Assignment spacing `implemented`
+One space on each side of `=`.
+`a=1` → `a = 1`
+Code: `print_stmt.go` `formatAssign`
+
+### F13 - Multi-assignment spacing `implemented`
+`", "` between targets; spaces around `=`.
+`a,b=f()` → `a, b = f()`
+Code: `print_stmt.go` `formatAssign`
+
+### F14 - Compound assignment spacing `implemented`
+One space around `+=`, `-=`, `*=`, `/=`, `%=`.
+`x+=1` → `x += 1`
+Code: `print_stmt.go` `formatCompoundAssign`
+
+### F15 - Increment / decrement bind tight `implemented`
+No inner space.
+`i ++` → `i++`
+Code: `print_stmt.go` `formatIncrDecr`
+
+### F16 - Return / yield keyword spacing `implemented`
+A single space between the keyword and its expression.
+`return  1` → `return 1`
+Code: `print_stmt.go` `formatKeywordExpr`
+
+### F17 - If / else-if / else `implemented`
+Header ends in `:`, body indented; `else if` collapses onto one line.
+Code: `print_stmt.go` `formatIf`
+
+### F18 - For loop `implemented`
+`", "` between loop variables, single spaces around `in`, header ends in `:`.
+`for i,x in items:` → `for i, x in items:`
+Code: `print_stmt.go` `formatFor`
+
+### F19 - While loop `implemented`
+`while <cond>:`, body indented.
+Code: `print_stmt.go` `formatWhile`
+
+### F31 - Typed assignment `implemented`
+A space after the type colon and around `=`. The declared type is emitted
+verbatim for now (canonical `|`-union spacing is a follow-up). A trailing
+`catch` block falls back to verbatim until postfix-catch is handled.
+`x:int=1` → `x: int = 1`
+Code: `print_stmt.go` `formatTypedAssign`
+
+---
+
+## Expressions & operators
+
+### F20 - Binary operator spacing `implemented`
+Single spaces around binary operators - `and`/`or`, comparisons, `in`/`not in`,
+and arithmetic.
+`1+2*3` → `1 + 2 * 3`
+Code: `print_expr.go` `formatBinary`
+
+### F21 - Unary operator spacing `implemented`
+Word operators (`not`) take a trailing space; symbolic ones (`-`, `!`) bind
+tight.
+`not  c` → `not c`
+Code: `print_expr.go` `formatUnary`
+
+### F22 - Ternary spacing `implemented`
+Spaces around `?` and `:`.
+`cond?a:b` → `cond ? a : b`
+Code: `print_expr.go` `formatTernary`
+
+### F23 - Parentheses preserved `implemented`
+Tight inside the parens; parens are never added or removed, so author grouping
+is respected.
+`( 1 + 2 )` → `(1 + 2)`
+Code: `print_expr.go` `formatParen`
+
+---
+
+## Calls, paths, indexing
+
+### F24 - Call argument spacing `implemented`
+Tight parens, `", "` between arguments.
+`f( a ,b )` → `f(a, b)`
+Code: `print_expr.go` `formatCall`
+
+### F32 - Named call arguments bind tight `implemented`
+No spaces around `=` in a named argument - distinguishing a call-site binding
+from an assignment statement.
+`f(key = val)` → `f(key=val)`
+Code: `print_expr.go` `formatNamedArg`
+
+### F25 - Paths are tight `implemented`
+No spaces around `.` or `[]` in a postfix chain.
+`obj . method( 1 )` → `obj.method(1)`
+Code: `print_expr.go` `formatPath`
+
+### F26 - Slices are tight `implemented`
+No spaces around the slice colons.
+`data[ 1 : 2 ]` → `data[1:2]`
+Code: `print_expr.go` `formatSlice`
+
+---
+
+## Collections
+
+### F27 - List spacing `implemented`
+`", "` after each element, tight brackets; empty list is `[]`.
+`[ 1,2 ]` → `[1, 2]`
+Code: `print_lit.go` `formatList`
+
+### F28 - Map spacing `implemented`
+Space-padded braces and a space after each key colon; `", "` between entries.
+Empty map stays tight `{}`. Keys keep their original form - a bareword key is an
+identifier and a quoted key is a string literal, which are semantically distinct
+in Rad, so we never convert between them.
+`{"x":1, y:2}` → `{ "x": 1, y: 2 }`
+Code: `print_lit.go` `formatMap`
+
+### F29 - Over-width collections and calls wrap `implemented`
+When a call/list/map would exceed the target width, it breaks to one item per
+line, indented one level, with a trailing comma and the closing delimiter on its
+own line. A trailing comma in a flat (non-wrapped) collection is removed.
+Code: `print_expr.go` `delimited`
+
+---
+
+## Strings & literals
+
+### F30 - String quote normalization `deferred`
+Not implemented; quotes are left exactly as written. Decided direction for when
+we revisit: normalize single-quoted strings to double quotes, but only when the
+swap introduces no new escapes (no raw `"` in the content); unescape now-
+redundant `\'`; leave backtick, raw (`r"..."`), and triple-quoted strings alone.
+Backticks in particular signal shell-command intent and may later gain inner
+quotes, so they are never rewritten.
+
+### F33 - Number / bool / null literals preserved `passthrough`
+Literal value text is emitted exactly as written - no `3.140` → `3.14`
+rewriting, which would be a semantic change.
+Code: `print_expr.go` `formatExpr`
+
+---
+
+## File preamble
+
+### F34 - Shebang preserved `passthrough`
+The `#!` line is emitted verbatim.
+Code: `printer.go` `verbatim`
+
+### F35 - File header preserved `passthrough`
+The `--- ... ---` header block is free text and is emitted verbatim.
+Code: `printer.go` `verbatim`
+
+---
+
+## Roadmap
+
+Decided or planned, not yet built. These are emitted verbatim today (structurally
+safe, just not canonicalized) and will graduate to numbered rules when
+implemented.
+
+- **Block constructs** - `args:`, `command:`, `rad`/`request`/`display`, `fn` /
+  lambda, `switch`, `defer`/`errdefer`. Each shares the `:`-header skeleton but
+  has a bespoke body grammar; the rad block additionally carries a fields-first
+  ordering rule (fields, then options, then field modifiers, then `rad_if`).
+- **String interpolation reflow** - reformatting expressions inside `{...}`.
+- **Long-expression wrapping** - breaking long boolean/arithmetic chains at
+  operators with continuation indent.
+- **Arg-block column alignment** - optional gofmt-style alignment of arg types
+  and comments.
+- **Slice spacing for complex operands** - spacing slice colons when operands
+  are non-trivial (`x[a + 1 : b]`).
+
+---
+
+## Changelog / tombstones
+
+Removed or superseded rules are recorded here; their IDs are retired, never
+reused.
+
+_(none yet)_

--- a/rts/radfmt/cst.go
+++ b/rts/radfmt/cst.go
@@ -1,0 +1,60 @@
+package radfmt
+
+import (
+	"github.com/amterp/rad/rts/rl"
+	ts "github.com/tree-sitter/go-tree-sitter"
+)
+
+// children returns all child nodes (named, anonymous tokens, and extras such as
+// comments) in source order. Comment extras appear here, which is how the
+// statement sequencer and construct formatters see and place them.
+func children(n *ts.Node) []ts.Node {
+	cursor := n.Walk()
+	defer cursor.Close()
+	return n.Children(cursor)
+}
+
+// childByField returns the single child stored under fieldName, or nil.
+func childByField(n *ts.Node, fieldName string) *ts.Node {
+	return n.ChildByFieldName(fieldName)
+}
+
+// isComment reports whether n is a `//` comment node.
+func isComment(n *ts.Node) bool { return n.Kind() == rl.K_COMMENT }
+
+// nodeText returns the exact source span of n.
+func (p *printer) nodeText(n *ts.Node) string {
+	return p.src[n.StartByte():n.EndByte()]
+}
+
+// startRow / endRow are the 0-based source rows a node spans.
+func startRow(n *ts.Node) uint { return n.StartPosition().Row }
+func endRow(n *ts.Node) uint   { return n.EndPosition().Row }
+
+// blankBetween reports whether at least one fully blank source line separates a
+// (above) from b (below).
+func blankBetween(a, b *ts.Node) bool {
+	return startRow(b) > endRow(a)+1
+}
+
+// sameRow reports whether b begins on the row a ends on (used to detect trailing
+// same-line comments).
+func sameRow(a, b *ts.Node) bool {
+	return startRow(b) == endRow(a)
+}
+
+// containsComment reports whether n's subtree contains any comment node. Used as
+// a safety guard: a construct formatter that doesn't explicitly handle interior
+// comments falls back to verbatim when one is present, so comments are never
+// dropped.
+func containsComment(n *ts.Node) bool {
+	if isComment(n) {
+		return true
+	}
+	for _, ch := range children(n) {
+		if containsComment(&ch) {
+			return true
+		}
+	}
+	return false
+}

--- a/rts/radfmt/doc.go
+++ b/rts/radfmt/doc.go
@@ -1,0 +1,179 @@
+// Package radfmt implements `rad fmt`, a gofmt-style canonical re-printer for
+// Rad scripts. It operates on the tree-sitter CST (not the typed AST, which
+// drops comments) and is structured as two cores:
+//
+//   - a Doc IR + render machine (doc.go, render.go) ported closely from
+//     Prettier's productionized Wadler printer, and
+//   - construct formatters that turn CST nodes into Docs (printer.go + friends).
+//
+// The Doc IR is the engine: construct formatters only ever *build* Docs, and a
+// single width-aware render machine decides where lines break. See DESIGN.md
+// for the full reference (Doc semantics, fits, comment attachment).
+package radfmt
+
+// Doc is the sealed document IR. Every node kind implements isDoc. Construct
+// formatters assemble a Doc tree; render.go turns it into a string, choosing
+// flat vs broken layout for each Group against the target width.
+type Doc interface{ isDoc() }
+
+// GroupID identifies a Group so that IfBreak / IndentIfBreak can react to
+// whether that specific group broke. The zero value means "no id".
+type GroupID uint32
+
+// Text is literal output. It must not contain a newline - line breaks are only
+// ever produced by Line nodes, so the render machine can track columns.
+type Text struct{ S string }
+
+// Line is a breakable position. Flat: Soft renders as "", otherwise " ". Broken:
+// a newline followed by the current indent. Hard forces a break regardless of
+// fit and (via propagateBreaks) breaks every enclosing Group. Literal is a hard
+// break that emits no indent (used for content that must keep column 0).
+type Line struct {
+	Soft    bool
+	Hard    bool
+	Literal bool
+}
+
+// Concat prints its parts in order.
+type Concat struct{ Parts []Doc }
+
+// Indent increases the indentation of its contents by one level.
+type Indent struct{ Contents Doc }
+
+// Align increases indentation by a fixed number of spaces (for alignment that
+// isn't a whole indent level).
+type Align struct {
+	N        int
+	Contents Doc
+}
+
+// Group is the unit of layout choice: the render machine tries to print
+// Contents flat, and if that doesn't fit the remaining width it prints broken.
+// Break (set by propagateBreaks when Contents contains a hard break, or up front
+// via the Group constructor's shouldBreak) forces broken mode without measuring.
+// ExpandedStates, when non-nil, makes this a conditional group (see render.go).
+//
+// Group is referenced by pointer so propagateBreaks can set Break in place.
+type Group struct {
+	Contents       Doc
+	Break          bool
+	ID             GroupID
+	ExpandedStates []Doc
+}
+
+// Fill is a flow layout: each separator independently breaks only if the next
+// content doesn't fit. Used for word-wrap-like flows.
+type Fill struct{ Parts []Doc }
+
+// IfBreak prints BreakContents when its controlling group broke, else
+// FlatContents. The controlling group is GroupID if set, otherwise the nearest
+// enclosing group.
+type IfBreak struct {
+	BreakContents Doc
+	FlatContents  Doc
+	GroupID       GroupID
+}
+
+// IndentIfBreak indents Contents only when the referenced group broke.
+type IndentIfBreak struct {
+	Contents Doc
+	GroupID  GroupID
+}
+
+// LineSuffix defers its contents to the end of the current line - it's buffered
+// and flushed just before the next newline. This is how trailing comments
+// attach without participating in width measurement of the code before them.
+type LineSuffix struct{ Contents Doc }
+
+// LineSuffixBoundary forces any buffered LineSuffix to flush even without a
+// newline (by injecting a hard break if the buffer is non-empty).
+type LineSuffixBoundary struct{}
+
+// BreakParent forces every enclosing Group to break. hardline carries one
+// implicitly. It's a no-op at print time; propagateBreaks consumes it.
+type BreakParent struct{}
+
+// Trim removes trailing whitespace already emitted on the current line.
+type Trim struct{}
+
+func (Text) isDoc()               {}
+func (Line) isDoc()               {}
+func (Concat) isDoc()             {}
+func (Indent) isDoc()             {}
+func (Align) isDoc()              {}
+func (*Group) isDoc()             {}
+func (Fill) isDoc()               {}
+func (IfBreak) isDoc()            {}
+func (IndentIfBreak) isDoc()      {}
+func (LineSuffix) isDoc()         {}
+func (LineSuffixBoundary) isDoc() {}
+func (BreakParent) isDoc()        {}
+func (Trim) isDoc()               {}
+
+// --- Constructors -----------------------------------------------------------
+//
+// These keep call sites readable and centralize a few normalizations (e.g.
+// flattening nested concats, dropping nils).
+
+// text returns a literal-text Doc.
+func text(s string) Doc { return Text{S: s} }
+
+// softLine is "" when flat, a newline when broken.
+func softLine() Doc { return Line{Soft: true} }
+
+// lineOrSpace is " " when flat, a newline when broken.
+func lineOrSpace() Doc { return Line{} }
+
+// hardLine always breaks and forces enclosing groups to break.
+func hardLine() Doc { return Line{Hard: true} }
+
+// literalLine is a hard break that emits no indentation.
+func literalLine() Doc { return Line{Hard: true, Literal: true} }
+
+// concat builds a Concat, flattening nested Concats and skipping nil parts so
+// callers can pass optional pieces without guarding each one.
+func concat(parts ...Doc) Doc {
+	flat := make([]Doc, 0, len(parts))
+	for _, p := range parts {
+		switch p := p.(type) {
+		case nil:
+			continue
+		case Concat:
+			flat = append(flat, p.Parts...)
+		default:
+			flat = append(flat, p)
+		}
+	}
+	if len(flat) == 1 {
+		return flat[0]
+	}
+	return Concat{Parts: flat}
+}
+
+// indent increases the indent level of d by one.
+func indent(d Doc) Doc { return Indent{Contents: d} }
+
+// group wraps d so the renderer chooses flat-or-broken to fit the width. The
+// returned value holds a *Group, so propagateBreaks can set Break in place.
+func group(d Doc) Doc { return &Group{Contents: d} }
+
+// ifBreak prints brk when the enclosing group broke, else flat.
+func ifBreak(brk, flat Doc) Doc { return IfBreak{BreakContents: brk, FlatContents: flat} }
+
+// lineSuffix defers d to end-of-line.
+func lineSuffix(d Doc) Doc { return LineSuffix{Contents: d} }
+
+// join interleaves sep between docs.
+func join(sep Doc, docs []Doc) Doc {
+	if len(docs) == 0 {
+		return Concat{}
+	}
+	parts := make([]Doc, 0, len(docs)*2-1)
+	for i, d := range docs {
+		if i > 0 {
+			parts = append(parts, sep)
+		}
+		parts = append(parts, d)
+	}
+	return Concat{Parts: parts}
+}

--- a/rts/radfmt/fmt.go
+++ b/rts/radfmt/fmt.go
@@ -10,6 +10,7 @@ import (
 // line-ending agnostic and output is canonical. (radfmt is below core in the
 // import graph, so it can't reuse core's helper - and this handles bare CR,
 // which core's CRLF-only version does not.)
+// [F2] normalize line endings to LF
 func normalizeLineEndings(s string) string {
 	s = strings.ReplaceAll(s, "\r\n", "\n")
 	return strings.ReplaceAll(s, "\r", "\n")

--- a/rts/radfmt/fmt.go
+++ b/rts/radfmt/fmt.go
@@ -1,0 +1,85 @@
+package radfmt
+
+import (
+	"strings"
+
+	"github.com/amterp/rad/rts"
+)
+
+// normalizeLineEndings converts CRLF and bare CR to LF so formatting is
+// line-ending agnostic and output is canonical. (radfmt is below core in the
+// import graph, so it can't reuse core's helper - and this handles bare CR,
+// which core's CRLF-only version does not.)
+func normalizeLineEndings(s string) string {
+	s = strings.ReplaceAll(s, "\r\n", "\n")
+	return strings.ReplaceAll(s, "\r", "\n")
+}
+
+// Format canonically re-formats a Rad script.
+//
+// It returns the formatted source, whether it differs from the input, and
+// whether formatting succeeded. Formatting is deliberately conservative about
+// failure: if the source has syntax errors, or the formatter panics on some
+// construct, Format returns the original source unchanged with ok=false. This
+// guarantees `rad fmt` can never emit corrupted output - the worst case is a
+// no-op.
+func Format(src string) (out string, changed bool, ok bool) {
+	// Compare against the original input (not the normalized form) so a
+	// line-ending-only fix (CRLF -> LF) still reports changed=true and is
+	// actually written. On any failure we return this original untouched.
+	original := src
+
+	// Any panic in the format pass degrades to a safe no-op rather than
+	// producing (or persisting) corrupted output.
+	defer func() {
+		if r := recover(); r != nil {
+			out, changed, ok = original, false, false
+		}
+	}()
+
+	src = normalizeLineEndings(src)
+
+	formatted, wantSig, wantComments, ok := formatRaw(src)
+	if !ok {
+		return original, false, false
+	}
+
+	// Last line of defense: never emit output that parses to a different code
+	// structure, or that dropped/duplicated a comment. If the formatter got it
+	// wrong, degrade to a safe no-op rather than corrupting the user's script.
+	if !structurallyEquivalent(formatted, wantSig, wantComments) {
+		return original, false, false
+	}
+
+	return formatted, formatted != original, true
+}
+
+// formatRaw parses src and renders the formatted output WITHOUT the
+// structural-equivalence guard. It returns the formatted text plus the input's
+// structural signature and comment count so the caller (Format) can verify
+// equivalence. ok is false when src has parse errors. Tests use formatRaw to
+// inspect raw formatter output (and assert structure preservation with a
+// readable diff) rather than getting a silent no-op from the guard.
+func formatRaw(src string) (out string, wantSig string, wantComments int, ok bool) {
+	parser, err := rts.NewRadParser()
+	if err != nil {
+		return src, "", 0, false
+	}
+	defer parser.Close()
+
+	tree := parser.Parse(src)
+	if tree.HasInvalidNodes() {
+		return src, "", 0, false
+	}
+
+	root := tree.Root()
+	if root == nil {
+		return src, "", 0, false
+	}
+
+	wantSig, wantComments = structuralSig(root)
+
+	p := &printer{src: src}
+	out = PrintDocToString(p.format(root), MaxWidth)
+	return out, wantSig, wantComments, true
+}

--- a/rts/radfmt/fmt_test.go
+++ b/rts/radfmt/fmt_test.go
@@ -2,16 +2,17 @@ package radfmt
 
 import "testing"
 
-// Pipeline-spine guarantee: while every construct is still verbatim, Format must
-// return valid source byte-for-byte unchanged (changed=false, ok=true). This is
-// the safety net that lets us grow construct formatters incrementally.
+// Stability guarantee: already-canonical source must round-trip byte-for-byte
+// unchanged (changed=false, ok=true). These cases mix formatted constructs with
+// still-verbatim ones (the args block), so they double as a regression net that
+// formatting an idiomatic script is a no-op.
 func TestFormat_SpineRoundTrips(t *testing.T) {
 	cases := []string{
 		"a = 1\n",
 		"#!/usr/bin/env rad\nprint(\"hi\")\n",
 		"args:\n    name str\n    age int = 30 # An age.\n\nprint(name)\n",
 		"// leading comment\nx = 1 // trailing\n",
-		"a = {\"x\": 1, y: 2}\nb = [1, 2, 3]\n",
+		"a = { \"x\": 1, y: 2 }\nb = [1, 2, 3]\n",
 	}
 	for _, src := range cases {
 		out, changed, ok := Format(src)

--- a/rts/radfmt/fmt_test.go
+++ b/rts/radfmt/fmt_test.go
@@ -1,0 +1,64 @@
+package radfmt
+
+import "testing"
+
+// Pipeline-spine guarantee: while every construct is still verbatim, Format must
+// return valid source byte-for-byte unchanged (changed=false, ok=true). This is
+// the safety net that lets us grow construct formatters incrementally.
+func TestFormat_SpineRoundTrips(t *testing.T) {
+	cases := []string{
+		"a = 1\n",
+		"#!/usr/bin/env rad\nprint(\"hi\")\n",
+		"args:\n    name str\n    age int = 30 # An age.\n\nprint(name)\n",
+		"// leading comment\nx = 1 // trailing\n",
+		"a = {\"x\": 1, y: 2}\nb = [1, 2, 3]\n",
+	}
+	for _, src := range cases {
+		out, changed, ok := Format(src)
+		if !ok {
+			t.Errorf("ok=false for valid source:\n%q", src)
+			continue
+		}
+		if out != src {
+			t.Errorf("spine altered source:\n in: %q\nout: %q", src, out)
+		}
+		if changed {
+			t.Errorf("changed=true but spine should be verbatim:\n%q", src)
+		}
+	}
+}
+
+// A file whose only problem is CRLF line endings must be reported as changed
+// (and normalized to LF), not silently passed over - changed is compared against
+// the original input, not the normalized form.
+func TestFormat_CRLFOnlyIsChanged(t *testing.T) {
+	out, changed, ok := Format("x = 1\r\ny = 2\r\n")
+	if !ok {
+		t.Fatal("ok=false for valid CRLF source")
+	}
+	if !changed {
+		t.Error("CRLF-only difference should report changed=true")
+	}
+	if out != "x = 1\ny = 2\n" {
+		t.Errorf("CRLF not normalized to LF: %q", out)
+	}
+}
+
+// Safety: source with syntax errors must be returned unchanged with ok=false -
+// the formatter never touches code it couldn't fully parse.
+func TestFormat_InvalidSourceIsNoOp(t *testing.T) {
+	bad := []string{
+		"a = = 1\n",
+		"if x\n", // missing colon / body
+		"print(\n",
+	}
+	for _, src := range bad {
+		out, changed, ok := Format(src)
+		if ok {
+			t.Errorf("expected ok=false for invalid source: %q", src)
+		}
+		if out != src || changed {
+			t.Errorf("invalid source should be an unchanged no-op: in=%q out=%q changed=%v", src, out, changed)
+		}
+	}
+}

--- a/rts/radfmt/print_expr.go
+++ b/rts/radfmt/print_expr.go
@@ -1,0 +1,254 @@
+package radfmt
+
+import (
+	"github.com/amterp/rad/rts/rl"
+	ts "github.com/tree-sitter/go-tree-sitter"
+)
+
+// Node kinds / tokens not exported as rl constants.
+const (
+	kMapEntry  = "map_entry"
+	kEmptyList = "empty_list"
+	tColon     = ":"
+	tComma     = ","
+	tDot       = "."
+	tLBracket  = "["
+	tRBracket  = "]"
+	tLParen    = "("
+	tRParen    = ")"
+)
+
+// namedChildrenOf returns stable pointers to a node's named children only.
+func namedChildrenOf(n *ts.Node) []*ts.Node {
+	var out []*ts.Node
+	for _, c := range childPtrs(n) {
+		if c.IsNamed() {
+			out = append(out, c)
+		}
+	}
+	return out
+}
+
+// unwrap collapses transparent wrapper nodes: a node whose sole named child
+// spans exactly the same bytes carries no syntax of its own (it's a link in the
+// expression-precedence chain, or a `literal`/`primary_expr` wrapper). Descend
+// until we reach a node that actually contributes structure.
+func unwrap(n *ts.Node) *ts.Node {
+	for {
+		named := namedChildrenOf(n)
+		if len(named) == 1 &&
+			named[0].StartByte() == n.StartByte() &&
+			named[0].EndByte() == n.EndByte() {
+			n = named[0]
+			continue
+		}
+		return n
+	}
+}
+
+// formatExpr formats an expression node, collapsing the precedence-chain
+// wrappers first. Anything not explicitly handled - or any subtree containing a
+// comment we don't place - falls back to verbatim, which is always safe.
+func (p *printer) formatExpr(n *ts.Node) Doc {
+	if n == nil {
+		return text("")
+	}
+	n = unwrap(n)
+
+	// Known limitation: comments between statements (and in block bodies) are
+	// placed by formatSeq, but comments *inside* an expression aren't attached
+	// yet. Rather than risk dropping one, emit any comment-bearing expression
+	// verbatim - structurally safe, just not reflowed. Per-construct interior
+	// comment handling (see DESIGN.md) can replace this as constructs mature.
+	if containsComment(n) {
+		return p.verbatim(n)
+	}
+
+	switch n.Kind() {
+	case rl.K_IDENTIFIER, rl.K_INT, rl.K_FLOAT, rl.K_BOOL, rl.K_NULL:
+		return text(p.nodeText(n))
+
+	case kEmptyList:
+		return text("[]")
+
+	case rl.K_STRING:
+		// Strings are emitted verbatim for now: contents, escapes, and
+		// interpolation expressions are preserved exactly. (Quote-style
+		// normalization is a deliberate follow-up.)
+		return p.verbatim(n)
+
+	case rl.K_OR_EXPR, rl.K_AND_EXPR, rl.K_COMPARE_EXPR, rl.K_ADD_EXPR, rl.K_MULT_EXPR:
+		return p.formatBinary(n)
+
+	case rl.K_UNARY_EXPR:
+		return p.formatUnary(n)
+
+	case rl.K_TERNARY_EXPR:
+		return p.formatTernary(n)
+
+	case rl.K_CALL:
+		return p.formatCall(n)
+
+	case rl.K_VAR_PATH, rl.K_INDEXED_EXPR:
+		return p.formatPath(n)
+
+	case rl.K_PARENTHESIZED_EXPR:
+		return p.formatParen(n)
+
+	case rl.K_LIST:
+		return p.formatList(n)
+
+	case rl.K_MAP:
+		return p.formatMap(n)
+
+	default:
+		return p.verbatim(n)
+	}
+}
+
+// formatBinary renders `left op right` with single spaces around the operator.
+func (p *printer) formatBinary(n *ts.Node) Doc {
+	left := childByField(n, rl.F_LEFT)
+	op := childByField(n, rl.F_OP)
+	right := childByField(n, rl.F_RIGHT)
+	if left == nil || op == nil || right == nil {
+		return p.verbatim(n)
+	}
+	return concat(
+		p.formatExpr(left),
+		text(" "), text(p.nodeText(op)), text(" "),
+		p.formatExpr(right),
+	)
+}
+
+// formatUnary renders a prefix operator. Word operators (not) take a trailing
+// space; symbolic ones (-, !) bind tight to their operand.
+func (p *printer) formatUnary(n *ts.Node) Doc {
+	op := childByField(n, rl.F_OP)
+	arg := childByField(n, rl.F_ARG)
+	if op == nil || arg == nil {
+		return p.verbatim(n)
+	}
+	opText := p.nodeText(op)
+	sep := ""
+	if isWordOp(opText) {
+		sep = " "
+	}
+	return concat(text(opText), text(sep), p.formatExpr(arg))
+}
+
+// formatTernary renders `cond ? a : b`.
+func (p *printer) formatTernary(n *ts.Node) Doc {
+	cond := childByField(n, rl.F_CONDITION)
+	tb := childByField(n, rl.F_TRUE_BRANCH)
+	fb := childByField(n, rl.F_FALSE_BRANCH)
+	if cond == nil || tb == nil || fb == nil {
+		return p.verbatim(n)
+	}
+	return concat(
+		p.formatExpr(cond),
+		text(" ? "), p.formatExpr(tb),
+		text(" : "), p.formatExpr(fb),
+	)
+}
+
+// formatCall renders a function call: `f(a, b)`, wrapping one-arg-per-line with
+// a trailing comma when it exceeds the line width.
+func (p *printer) formatCall(n *ts.Node) Doc {
+	fn := childByField(n, rl.F_FUNC)
+	var fnDoc Doc = text("")
+	if fn != nil {
+		fnDoc = p.formatExpr(fn)
+	}
+
+	var args []Doc
+	for _, c := range childPtrs(n) {
+		switch c.Kind() {
+		case tLParen, tRParen, tComma:
+			continue
+		}
+		// Skip the function-name child (matched by node id - childByField and
+		// childPtrs return distinct *Node values for the same node, so pointer
+		// equality would never hold).
+		if fn != nil && c.Id() == fn.Id() {
+			continue
+		}
+		if !c.IsNamed() {
+			continue
+		}
+		args = append(args, p.formatExpr(c))
+	}
+
+	return concat(fnDoc, p.delimited(tLParen, tRParen, args))
+}
+
+// formatParen renders `(expr)` tightly around its single inner expression.
+func (p *printer) formatParen(n *ts.Node) Doc {
+	for _, c := range namedChildrenOf(n) {
+		return concat(text(tLParen), p.formatExpr(c), text(tRParen))
+	}
+	return p.verbatim(n)
+}
+
+// formatPath renders a variable path / postfix chain (`a.b.c`, `a[0]`,
+// `obj.method(1)`) tightly, with no stray spaces, formatting interior index and
+// call expressions.
+func (p *printer) formatPath(n *ts.Node) Doc {
+	var parts []Doc
+	for i, c := range childPtrs(n) {
+		field := n.FieldNameForChild(uint32(i))
+		switch {
+		case c.Kind() == tDot || c.Kind() == tLBracket || c.Kind() == tRBracket:
+			parts = append(parts, text(c.Kind()))
+		case c.Kind() == rl.K_SLICE:
+			parts = append(parts, p.formatSlice(c))
+		case field == rl.F_ROOT || field == rl.F_INDEXING || c.IsNamed():
+			parts = append(parts, p.formatExpr(c))
+		default:
+			parts = append(parts, text(p.nodeText(c)))
+		}
+	}
+	return concat(parts...)
+}
+
+// formatSlice renders `start:end` (and `::step` forms) tightly.
+func (p *printer) formatSlice(n *ts.Node) Doc {
+	var parts []Doc
+	for _, c := range childPtrs(n) {
+		if c.Kind() == tColon {
+			parts = append(parts, text(tColon))
+		} else if c.IsNamed() {
+			parts = append(parts, p.formatExpr(c))
+		}
+	}
+	return concat(parts...)
+}
+
+// delimited renders a comma-separated list inside open/close delimiters, flat
+// when it fits and one-item-per-line (with a trailing comma) when it doesn't.
+func (p *printer) delimited(open, close string, items []Doc) Doc {
+	if len(items) == 0 {
+		return concat(text(open), text(close))
+	}
+	return group(concat(
+		text(open),
+		indent(concat(
+			softLine(),
+			join(concat(text(tComma), lineOrSpace()), items),
+			ifBreak(text(tComma), text("")),
+		)),
+		softLine(),
+		text(close),
+	))
+}
+
+// isWordOp reports whether an operator is alphabetic (and so needs spacing
+// around it as a word) rather than symbolic.
+func isWordOp(op string) bool {
+	for _, r := range op {
+		if !(r >= 'a' && r <= 'z') {
+			return false
+		}
+	}
+	return op != ""
+}

--- a/rts/radfmt/print_expr.go
+++ b/rts/radfmt/print_expr.go
@@ -60,11 +60,14 @@ func (p *printer) formatExpr(n *ts.Node) Doc {
 	// yet. Rather than risk dropping one, emit any comment-bearing expression
 	// verbatim - structurally safe, just not reflowed. Per-construct interior
 	// comment handling (see DESIGN.md) can replace this as constructs mature.
+	//
+	// [F36] an expression containing an interior comment is emitted verbatim
 	if containsComment(n) {
 		return p.verbatim(n)
 	}
 
 	switch n.Kind() {
+	// [F33] number/bool/null/identifier literals are preserved verbatim
 	case rl.K_IDENTIFIER, rl.K_INT, rl.K_FLOAT, rl.K_BOOL, rl.K_NULL:
 		return text(p.nodeText(n))
 
@@ -106,7 +109,10 @@ func (p *printer) formatExpr(n *ts.Node) Doc {
 	}
 }
 
-// formatBinary renders `left op right` with single spaces around the operator.
+// formatBinary renders `left op right` with single spaces around the operator -
+// covers and/or, comparisons, in/not in, and arithmetic.
+//
+// [F20] binary operators get single spaces around them
 func (p *printer) formatBinary(n *ts.Node) Doc {
 	left := childByField(n, rl.F_LEFT)
 	op := childByField(n, rl.F_OP)
@@ -123,6 +129,8 @@ func (p *printer) formatBinary(n *ts.Node) Doc {
 
 // formatUnary renders a prefix operator. Word operators (not) take a trailing
 // space; symbolic ones (-, !) bind tight to their operand.
+//
+// [F21] unary: word ops (`not`) spaced, symbolic ops (`-`, `!`) tight
 func (p *printer) formatUnary(n *ts.Node) Doc {
 	op := childByField(n, rl.F_OP)
 	arg := childByField(n, rl.F_ARG)
@@ -138,6 +146,8 @@ func (p *printer) formatUnary(n *ts.Node) Doc {
 }
 
 // formatTernary renders `cond ? a : b`.
+//
+// [F22] ternary: spaces around `?` and `:`
 func (p *printer) formatTernary(n *ts.Node) Doc {
 	cond := childByField(n, rl.F_CONDITION)
 	tb := childByField(n, rl.F_TRUE_BRANCH)
@@ -153,7 +163,11 @@ func (p *printer) formatTernary(n *ts.Node) Doc {
 }
 
 // formatCall renders a function call: `f(a, b)`, wrapping one-arg-per-line with
-// a trailing comma when it exceeds the line width.
+// a trailing comma when it exceeds the line width. Positional and named args are
+// selected by field name (the func, parens, and commas have other/no field, so
+// they're skipped without special-casing).
+//
+// [F24] call args: tight parens, ", " between args
 func (p *printer) formatCall(n *ts.Node) Doc {
 	fn := childByField(n, rl.F_FUNC)
 	var fnDoc Doc = text("")
@@ -162,27 +176,37 @@ func (p *printer) formatCall(n *ts.Node) Doc {
 	}
 
 	var args []Doc
-	for _, c := range childPtrs(n) {
-		switch c.Kind() {
-		case tLParen, tRParen, tComma:
-			continue
+	for i, c := range childPtrs(n) {
+		switch n.FieldNameForChild(uint32(i)) {
+		case rl.F_ARG:
+			args = append(args, p.formatExpr(c))
+		case rl.F_NAMED_ARG:
+			args = append(args, p.formatNamedArg(c))
 		}
-		// Skip the function-name child (matched by node id - childByField and
-		// childPtrs return distinct *Node values for the same node, so pointer
-		// equality would never hold).
-		if fn != nil && c.Id() == fn.Id() {
-			continue
-		}
-		if !c.IsNamed() {
-			continue
-		}
-		args = append(args, p.formatExpr(c))
 	}
 
-	return concat(fnDoc, p.delimited(tLParen, tRParen, args))
+	return concat(fnDoc, p.delimited(tLParen, tRParen, args, false))
+}
+
+// formatNamedArg formats a named call argument `key=val` tightly - no spaces
+// around `=`. This distinguishes a call-site binding from an assignment
+// statement (which does space its `=`).
+//
+// [F32] named call args bind tight: `f(key=val)`
+func (p *printer) formatNamedArg(n *ts.Node) Doc {
+	name := childByField(n, rl.F_NAME)
+	value := childByField(n, rl.F_VALUE)
+	if name == nil || value == nil {
+		return p.verbatim(n)
+	}
+	return concat(text(p.nodeText(name)), text("="), p.formatExpr(value))
 }
 
 // formatParen renders `(expr)` tightly around its single inner expression.
+// Parens are preserved exactly as written - never added or removed - so the
+// author's grouping is respected.
+//
+// [F23] parentheses tight inside; never added or removed
 func (p *printer) formatParen(n *ts.Node) Doc {
 	for _, c := range namedChildrenOf(n) {
 		return concat(text(tLParen), p.formatExpr(c), text(tRParen))
@@ -193,6 +217,8 @@ func (p *printer) formatParen(n *ts.Node) Doc {
 // formatPath renders a variable path / postfix chain (`a.b.c`, `a[0]`,
 // `obj.method(1)`) tightly, with no stray spaces, formatting interior index and
 // call expressions.
+//
+// [F25] paths/postfix chains are tight (no spaces around `.` or `[]`)
 func (p *printer) formatPath(n *ts.Node) Doc {
 	var parts []Doc
 	for i, c := range childPtrs(n) {
@@ -212,6 +238,8 @@ func (p *printer) formatPath(n *ts.Node) Doc {
 }
 
 // formatSlice renders `start:end` (and `::step` forms) tightly.
+//
+// [F26] slices are tight (no spaces around the slice colons)
 func (p *printer) formatSlice(n *ts.Node) Doc {
 	var parts []Doc
 	for _, c := range childPtrs(n) {
@@ -226,18 +254,27 @@ func (p *printer) formatSlice(n *ts.Node) Doc {
 
 // delimited renders a comma-separated list inside open/close delimiters, flat
 // when it fits and one-item-per-line (with a trailing comma) when it doesn't.
-func (p *printer) delimited(open, close string, items []Doc) Doc {
+// When pad is set, the flat form keeps a space just inside each delimiter
+// (`{ a, b }`); otherwise it's tight (`[a, b]`, `f(a, b)`). The broken form is
+// identical either way. An empty collection is always tight (`[]`, `{}`).
+//
+// [F29] over-width calls/collections wrap one item per line with a trailing comma
+func (p *printer) delimited(open, close string, items []Doc, pad bool) Doc {
 	if len(items) == 0 {
 		return concat(text(open), text(close))
+	}
+	gap := softLine()
+	if pad {
+		gap = lineOrSpace()
 	}
 	return group(concat(
 		text(open),
 		indent(concat(
-			softLine(),
+			gap,
 			join(concat(text(tComma), lineOrSpace()), items),
 			ifBreak(text(tComma), text("")),
 		)),
-		softLine(),
+		gap,
 		text(close),
 	))
 }

--- a/rts/radfmt/print_lit.go
+++ b/rts/radfmt/print_lit.go
@@ -1,0 +1,44 @@
+package radfmt
+
+import (
+	"github.com/amterp/rad/rts/rl"
+	ts "github.com/tree-sitter/go-tree-sitter"
+)
+
+// formatList renders `[a, b, c]`, wrapping one-element-per-line with a trailing
+// comma when it exceeds the line width.
+func (p *printer) formatList(n *ts.Node) Doc {
+	var items []Doc
+	for _, c := range childPtrs(n) {
+		switch c.Kind() {
+		case tLBracket, tRBracket, tComma:
+			continue
+		}
+		if c.IsNamed() {
+			items = append(items, p.formatExpr(c))
+		}
+	}
+	return p.delimited(tLBracket, tRBracket, items)
+}
+
+// formatMap renders `{key: value, ...}`, wrapping one-entry-per-line when it
+// exceeds the line width. Keys keep their original form (string or bareword);
+// the canonical shape is `key: value` with a single space after the colon.
+func (p *printer) formatMap(n *ts.Node) Doc {
+	var entries []Doc
+	for _, c := range childPtrs(n) {
+		if c.Kind() == kMapEntry {
+			entries = append(entries, p.formatMapEntry(c))
+		}
+	}
+	return p.delimited("{", "}", entries)
+}
+
+func (p *printer) formatMapEntry(n *ts.Node) Doc {
+	key := childByField(n, rl.F_KEY)
+	value := childByField(n, rl.F_VALUE)
+	if key == nil || value == nil {
+		return p.verbatim(n)
+	}
+	return concat(p.formatExpr(key), text(": "), p.formatExpr(value))
+}

--- a/rts/radfmt/print_lit.go
+++ b/rts/radfmt/print_lit.go
@@ -7,6 +7,8 @@ import (
 
 // formatList renders `[a, b, c]`, wrapping one-element-per-line with a trailing
 // comma when it exceeds the line width.
+//
+// [F27] list: ", " after each element, tight brackets
 func (p *printer) formatList(n *ts.Node) Doc {
 	var items []Doc
 	for _, c := range childPtrs(n) {
@@ -18,12 +20,17 @@ func (p *printer) formatList(n *ts.Node) Doc {
 			items = append(items, p.formatExpr(c))
 		}
 	}
-	return p.delimited(tLBracket, tRBracket, items)
+	return p.delimited(tLBracket, tRBracket, items, false)
 }
 
-// formatMap renders `{key: value, ...}`, wrapping one-entry-per-line when it
-// exceeds the line width. Keys keep their original form (string or bareword);
-// the canonical shape is `key: value` with a single space after the colon.
+// formatMap renders `{ key: value, ... }`, wrapping one-entry-per-line when it
+// exceeds the line width. Keys keep their original form (string or bareword -
+// these are semantically distinct in Rad, a string literal vs an identifier, so
+// we never convert between them). The canonical shape is `key: value` with a
+// single space after the colon, and the braces are space-padded (empty `{}`
+// stays tight).
+//
+// [F28] map: space-padded braces `{ key: value }`, ", " between entries
 func (p *printer) formatMap(n *ts.Node) Doc {
 	var entries []Doc
 	for _, c := range childPtrs(n) {
@@ -31,7 +38,7 @@ func (p *printer) formatMap(n *ts.Node) Doc {
 			entries = append(entries, p.formatMapEntry(c))
 		}
 	}
-	return p.delimited("{", "}", entries)
+	return p.delimited("{", "}", entries, true)
 }
 
 func (p *printer) formatMapEntry(n *ts.Node) Doc {

--- a/rts/radfmt/print_stmt.go
+++ b/rts/radfmt/print_stmt.go
@@ -20,6 +20,8 @@ func (p *printer) formatExprStmt(n *ts.Node) Doc {
 }
 
 // formatAssign formats `a = expr` and multi-assign `a, b = expr`.
+//
+// [F12] one space around `=`    [F13] multi-assign: ", " between targets
 func (p *printer) formatAssign(n *ts.Node) Doc {
 	var lefts []Doc
 	var right *ts.Node
@@ -37,7 +39,32 @@ func (p *printer) formatAssign(n *ts.Node) Doc {
 	return concat(join(text(", "), lefts), text(" = "), p.formatExpr(right))
 }
 
+// formatTypedAssign formats a typed assignment `x: int = 1` - a space after the
+// type colon and around `=`. The declared type is emitted verbatim for now
+// (canonical spacing of `|`-union types is a noted follow-up). A trailing catch
+// block (`... catch:`) is not yet handled, so fall back to verbatim when present
+// rather than silently dropping it.
+//
+// [F31] typed assignment `x: int = 1`
+func (p *printer) formatTypedAssign(n *ts.Node) Doc {
+	if childByField(n, rl.F_CATCH) != nil {
+		return p.verbatim(n)
+	}
+	left := childByField(n, rl.F_LEFT)
+	typ := childByField(n, rl.F_DECLARED_TYPE)
+	right := childByField(n, rl.F_RIGHT)
+	if left == nil || typ == nil || right == nil {
+		return p.verbatim(n)
+	}
+	return concat(
+		text(p.nodeText(left)), text(": "), rawText(p.nodeText(typ)),
+		text(" = "), p.formatExpr(right),
+	)
+}
+
 // formatCompoundAssign formats `x += expr` (and -=, *=, /=, %=).
+//
+// [F14] one space around compound-assignment operators
 func (p *printer) formatCompoundAssign(n *ts.Node) Doc {
 	left := childByField(n, rl.F_LEFT)
 	op := childByField(n, rl.F_OP)
@@ -49,6 +76,8 @@ func (p *printer) formatCompoundAssign(n *ts.Node) Doc {
 }
 
 // formatIncrDecr formats `i++` / `i--` tightly.
+//
+// [F15] increment/decrement bind tight (no inner space)
 func (p *printer) formatIncrDecr(n *ts.Node) Doc {
 	left := childByField(n, rl.F_LEFT)
 	op := childByField(n, rl.F_OP)
@@ -60,6 +89,8 @@ func (p *printer) formatIncrDecr(n *ts.Node) Doc {
 
 // formatKeywordExpr formats statements that are a keyword optionally followed by
 // an expression: `return`, `return expr`, `yield expr`.
+//
+// [F16] single space after return/yield keyword
 func (p *printer) formatKeywordExpr(keyword string, n *ts.Node) Doc {
 	for _, c := range namedChildrenOf(n) {
 		return concat(text(keyword+" "), p.formatExpr(c))
@@ -68,6 +99,8 @@ func (p *printer) formatKeywordExpr(keyword string, n *ts.Node) Doc {
 }
 
 // formatIf formats an if / else-if / else chain, each clause's body indented.
+//
+// [F17] if/else-if/else: header ends in `:`, body indented; `else if` on one line
 func (p *printer) formatIf(n *ts.Node) Doc {
 	var parts []Doc
 	sawElse := false
@@ -112,6 +145,8 @@ func (p *printer) formatClause(prefix string, alt *ts.Node, leadingBreak bool) D
 }
 
 // formatFor formats `for x in expr:` (and `for i, x in expr:`).
+//
+// [F18] for loop: ", " between loop vars, " in ", header ends in `:`
 func (p *printer) formatFor(n *ts.Node) Doc {
 	lefts := childByField(n, rl.F_LEFTS)
 	right := childByField(n, rl.F_RIGHT)
@@ -135,6 +170,8 @@ func (p *printer) formatForLefts(n *ts.Node) Doc {
 }
 
 // formatWhile formats `while cond:`.
+//
+// [F19] while loop: `while <cond>:`, body indented
 func (p *printer) formatWhile(n *ts.Node) Doc {
 	cond := childByField(n, rl.F_CONDITION)
 	if cond == nil {
@@ -157,6 +194,8 @@ func (p *printer) indentedBody(items []*ts.Node) Doc {
 // blockTail renders the `:` that opens a block, an optional comment that
 // trailed the header on the same line (kept on the header line as a line-suffix
 // rather than pulled into the body), and the indented body.
+//
+// [F11] a comment trailing a block header stays on the header line
 func (p *printer) blockTail(n *ts.Node) Doc {
 	headerComment, body := blockBody(n)
 	tail := Doc(text(tColon))

--- a/rts/radfmt/print_stmt.go
+++ b/rts/radfmt/print_stmt.go
@@ -1,0 +1,191 @@
+package radfmt
+
+import (
+	"github.com/amterp/rad/rts/rl"
+	ts "github.com/tree-sitter/go-tree-sitter"
+)
+
+const (
+	kIfAlt   = "if_alt"
+	kElseAlt = "else_alt"
+	tElse    = "else"
+)
+
+// formatExprStmt formats a bare expression statement (e.g. a call).
+func (p *printer) formatExprStmt(n *ts.Node) Doc {
+	if e := childByField(n, rl.F_EXPR); e != nil {
+		return p.formatExpr(e)
+	}
+	return p.verbatim(n)
+}
+
+// formatAssign formats `a = expr` and multi-assign `a, b = expr`.
+func (p *printer) formatAssign(n *ts.Node) Doc {
+	var lefts []Doc
+	var right *ts.Node
+	for i, c := range childPtrs(n) {
+		switch n.FieldNameForChild(uint32(i)) {
+		case rl.F_LEFT, rl.F_LEFTS:
+			lefts = append(lefts, p.formatExpr(c))
+		case rl.F_RIGHT:
+			right = c
+		}
+	}
+	if len(lefts) == 0 || right == nil {
+		return p.verbatim(n)
+	}
+	return concat(join(text(", "), lefts), text(" = "), p.formatExpr(right))
+}
+
+// formatCompoundAssign formats `x += expr` (and -=, *=, /=, %=).
+func (p *printer) formatCompoundAssign(n *ts.Node) Doc {
+	left := childByField(n, rl.F_LEFT)
+	op := childByField(n, rl.F_OP)
+	right := childByField(n, rl.F_RIGHT)
+	if left == nil || op == nil || right == nil {
+		return p.verbatim(n)
+	}
+	return concat(p.formatExpr(left), text(" "), text(p.nodeText(op)), text(" "), p.formatExpr(right))
+}
+
+// formatIncrDecr formats `i++` / `i--` tightly.
+func (p *printer) formatIncrDecr(n *ts.Node) Doc {
+	left := childByField(n, rl.F_LEFT)
+	op := childByField(n, rl.F_OP)
+	if left == nil || op == nil {
+		return p.verbatim(n)
+	}
+	return concat(p.formatExpr(left), text(p.nodeText(op)))
+}
+
+// formatKeywordExpr formats statements that are a keyword optionally followed by
+// an expression: `return`, `return expr`, `yield expr`.
+func (p *printer) formatKeywordExpr(keyword string, n *ts.Node) Doc {
+	for _, c := range namedChildrenOf(n) {
+		return concat(text(keyword+" "), p.formatExpr(c))
+	}
+	return text(keyword)
+}
+
+// formatIf formats an if / else-if / else chain, each clause's body indented.
+func (p *printer) formatIf(n *ts.Node) Doc {
+	var parts []Doc
+	sawElse := false
+	first := true
+	for _, c := range childPtrs(n) {
+		switch c.Kind() {
+		case tElse:
+			sawElse = true
+		case kIfAlt:
+			prefix := "if "
+			if sawElse {
+				prefix = "else if "
+			}
+			parts = append(parts, p.formatClause(prefix, c, !first))
+			sawElse = false
+			first = false
+		case kElseAlt:
+			parts = append(parts, p.formatClause("else", c, !first))
+			sawElse = false
+			first = false
+		}
+	}
+	if len(parts) == 0 {
+		return p.verbatim(n)
+	}
+	return concat(parts...)
+}
+
+// formatClause renders one if/else-if/else clause: a header line ending in `:`
+// and an indented body. leadingBreak puts the clause on its own line after a
+// preceding clause's body.
+func (p *printer) formatClause(prefix string, alt *ts.Node, leadingBreak bool) Doc {
+	header := Doc(text(prefix))
+	if cond := childByField(alt, rl.F_CONDITION); cond != nil {
+		header = concat(text(prefix), p.formatExpr(cond))
+	}
+	clause := concat(header, p.blockTail(alt))
+	if leadingBreak {
+		return concat(hardLine(), clause)
+	}
+	return clause
+}
+
+// formatFor formats `for x in expr:` (and `for i, x in expr:`).
+func (p *printer) formatFor(n *ts.Node) Doc {
+	lefts := childByField(n, rl.F_LEFTS)
+	right := childByField(n, rl.F_RIGHT)
+	if lefts == nil || right == nil {
+		return p.verbatim(n)
+	}
+	header := concat(text("for "), p.formatForLefts(lefts), text(" in "), p.formatExpr(right))
+	return concat(header, p.blockTail(n))
+}
+
+func (p *printer) formatForLefts(n *ts.Node) Doc {
+	// The loop-variable identifiers carry field name "left" but are anonymous
+	// tokens in the grammar, so select them by field rather than by IsNamed.
+	var ids []Doc
+	for i, c := range childPtrs(n) {
+		if n.FieldNameForChild(uint32(i)) == rl.F_LEFT {
+			ids = append(ids, text(p.nodeText(c)))
+		}
+	}
+	return join(text(", "), ids)
+}
+
+// formatWhile formats `while cond:`.
+func (p *printer) formatWhile(n *ts.Node) Doc {
+	cond := childByField(n, rl.F_CONDITION)
+	if cond == nil {
+		return p.verbatim(n)
+	}
+	header := concat(text("while "), p.formatExpr(cond))
+	return concat(header, p.blockTail(n))
+}
+
+// indentedBody renders a block body (the statements after a `:`) indented one
+// level, each on its own line.
+func (p *printer) indentedBody(items []*ts.Node) Doc {
+	body := p.formatSeq(items)
+	if body == nil {
+		return text("")
+	}
+	return indent(concat(hardLine(), body))
+}
+
+// blockTail renders the `:` that opens a block, an optional comment that
+// trailed the header on the same line (kept on the header line as a line-suffix
+// rather than pulled into the body), and the indented body.
+func (p *printer) blockTail(n *ts.Node) Doc {
+	headerComment, body := blockBody(n)
+	tail := Doc(text(tColon))
+	if headerComment != nil {
+		tail = concat(tail, lineSuffix(concat(text(" "), text(p.nodeText(headerComment)))))
+	}
+	return concat(tail, p.indentedBody(body))
+}
+
+// blockBody splits a block opened by `:` into an optional same-line header
+// comment and the remaining body items (statements and interleaved comments).
+// A comment on the same row as the `:` documents the header, so it must stay on
+// the header line rather than becoming the first body statement.
+func blockBody(n *ts.Node) (headerComment *ts.Node, items []*ts.Node) {
+	ch := childPtrs(n)
+	colonIdx := -1
+	for i, c := range ch {
+		if c.Kind() == tColon {
+			colonIdx = i
+			break
+		}
+	}
+	if colonIdx < 0 {
+		return nil, nil
+	}
+	colon := ch[colonIdx]
+	rest := ch[colonIdx+1:]
+	if len(rest) > 0 && isComment(rest[0]) && sameRow(colon, rest[0]) {
+		return rest[0], rest[1:]
+	}
+	return nil, rest
+}

--- a/rts/radfmt/printer.go
+++ b/rts/radfmt/printer.go
@@ -23,7 +23,7 @@ type printer struct {
 //   - arg_block, cmd_block, rad_block
 //   - fn_named / fn_lambda
 //   - switch_stmt, defer_block, shell_stmt
-//   - typed_assign, list_comprehension
+//   - list_comprehension
 //
 // To add one: handle its kind here (or in formatExpr for expressions), build a
 // Doc from its fields, and add a snapshot case. The structural-equivalence guard
@@ -38,6 +38,8 @@ func (p *printer) format(node *ts.Node) Doc {
 		return p.formatExprStmt(node)
 	case rl.K_ASSIGN:
 		return p.formatAssign(node)
+	case rl.K_TYPED_ASSIGN:
+		return p.formatTypedAssign(node)
 	case rl.K_COMPOUND_ASSIGN:
 		return p.formatCompoundAssign(node)
 	case rl.K_INCR_DECR:
@@ -71,6 +73,8 @@ func (p *printer) format(node *ts.Node) Doc {
 // file edges), comments placed as leading/standalone/trailing, and exactly one
 // trailing newline. Individual statements are formatted by format(); any not yet
 // handled fall through to verbatim.
+//
+// [F3] exactly one trailing newline at end of file
 func (p *printer) formatSourceFile(node *ts.Node) Doc {
 	body := p.formatSeq(childPtrs(node))
 	if body == nil {
@@ -87,6 +91,10 @@ func (p *printer) formatSourceFile(node *ts.Node) Doc {
 //     line-suffix rather than starting a new line.
 //
 // It returns nil for an empty sequence so callers can special-case emptiness.
+//
+// [F6] collapse 2+ blank lines to one    [F7] strip blanks at block/file edges
+// [F8] preserve a single blank line       [F9] standalone comment keeps its line
+// [F10] trailing same-line comment stays on the statement's line
 func (p *printer) formatSeq(items []*ts.Node) Doc {
 	if len(items) == 0 {
 		return nil
@@ -100,18 +108,18 @@ func (p *printer) formatSeq(items []*ts.Node) Doc {
 		item := items[i]
 
 		if emitted {
-			parts = append(parts, hardLine())
+			parts = append(parts, hardLine()) // [F8] one hardline between items
 			if blankBetween(prev, item) {
-				parts = append(parts, hardLine())
+				parts = append(parts, hardLine()) // [F6][F8] at most one blank line
 			}
 		}
 
 		if isComment(item) {
-			parts = append(parts, text(p.nodeText(item)))
+			parts = append(parts, text(p.nodeText(item))) // [F9] standalone comment
 			prev = item
 		} else {
 			doc := p.format(item)
-			// Fold a trailing same-line comment into this statement's line.
+			// Fold a trailing same-line comment into this statement's line. [F10]
 			if i+1 < len(items) && isComment(items[i+1]) && sameRow(item, items[i+1]) {
 				c := items[i+1]
 				doc = concat(doc, lineSuffix(concat(text(" "), text(p.nodeText(c)))))
@@ -145,6 +153,10 @@ func childPtrs(n *ts.Node) []*ts.Node {
 // comments and original layout are preserved because they're part of the span;
 // embedded newlines render as literal (no-indent) breaks so the column counter
 // stays correct.
+//
+// This is also the path by which deliberately-untouched constructs are emitted:
+// [F34] the shebang line and [F35] the `--- ... ---` file header are preserved
+// exactly (along with any construct not yet given a dedicated formatter).
 func (p *printer) verbatim(node *ts.Node) Doc {
 	raw := strings.TrimRight(p.src[node.StartByte():node.EndByte()], "\n")
 	return rawText(raw)

--- a/rts/radfmt/printer.go
+++ b/rts/radfmt/printer.go
@@ -1,0 +1,171 @@
+package radfmt
+
+import (
+	"strings"
+
+	"github.com/amterp/rad/rts/rl"
+	ts "github.com/tree-sitter/go-tree-sitter"
+)
+
+// printer turns a CST into a Doc. It holds the original source so it can emit
+// verbatim spans for constructs that don't yet have a dedicated formatter.
+type printer struct {
+	src string
+}
+
+// format dispatches on node kind. As construct formatters are implemented they
+// get their own case; everything else falls through to verbatim, which is always
+// safe (it re-emits the node's exact original source).
+//
+// Deliberately not yet formatted (they fall through to verbatim and are emitted
+// unchanged - structurally safe, just not canonicalized):
+//   - strings: quote-style normalization and interpolation reflow
+//   - arg_block, cmd_block, rad_block
+//   - fn_named / fn_lambda
+//   - switch_stmt, defer_block, shell_stmt
+//   - typed_assign, list_comprehension
+//
+// To add one: handle its kind here (or in formatExpr for expressions), build a
+// Doc from its fields, and add a snapshot case. The structural-equivalence guard
+// will reject any formatter that changes what the code parses to.
+func (p *printer) format(node *ts.Node) Doc {
+	switch node.Kind() {
+	case rl.K_SOURCE_FILE:
+		return p.formatSourceFile(node)
+
+	// Statements.
+	case rl.K_EXPR_STMT:
+		return p.formatExprStmt(node)
+	case rl.K_ASSIGN:
+		return p.formatAssign(node)
+	case rl.K_COMPOUND_ASSIGN:
+		return p.formatCompoundAssign(node)
+	case rl.K_INCR_DECR:
+		return p.formatIncrDecr(node)
+	case rl.K_RETURN_STMT:
+		return p.formatKeywordExpr("return", node)
+	case rl.K_YIELD_STMT:
+		return p.formatKeywordExpr("yield", node)
+	case rl.K_IF_STMT:
+		return p.formatIf(node)
+	case rl.K_FOR_LOOP:
+		return p.formatFor(node)
+	case rl.K_WHILE_LOOP:
+		return p.formatWhile(node)
+
+	// Expression nodes, in case format() is called on one directly.
+	case rl.K_EXPR, rl.K_TERNARY_EXPR, rl.K_OR_EXPR, rl.K_AND_EXPR,
+		rl.K_COMPARE_EXPR, rl.K_ADD_EXPR, rl.K_MULT_EXPR, rl.K_UNARY_EXPR,
+		rl.K_CALL, rl.K_VAR_PATH, rl.K_INDEXED_EXPR, rl.K_PARENTHESIZED_EXPR,
+		rl.K_LIST, rl.K_MAP, rl.K_STRING, rl.K_IDENTIFIER, rl.K_INT,
+		rl.K_FLOAT, rl.K_BOOL, rl.K_NULL:
+		return p.formatExpr(node)
+
+	default:
+		return p.verbatim(node)
+	}
+}
+
+// formatSourceFile lays out the top-level statement sequence: each statement on
+// its own line(s), single blank lines preserved (multiples collapsed, none at
+// file edges), comments placed as leading/standalone/trailing, and exactly one
+// trailing newline. Individual statements are formatted by format(); any not yet
+// handled fall through to verbatim.
+func (p *printer) formatSourceFile(node *ts.Node) Doc {
+	body := p.formatSeq(childPtrs(node))
+	if body == nil {
+		return text("")
+	}
+	return concat(body, hardLine())
+}
+
+// formatSeq renders an ordered sequence of statements and comments (the body of
+// a file or block) with canonical separators:
+//   - one hardline between adjacent items,
+//   - a second hardline where the source had at least one blank line,
+//   - a same-line comment following a statement attaches as a trailing
+//     line-suffix rather than starting a new line.
+//
+// It returns nil for an empty sequence so callers can special-case emptiness.
+func (p *printer) formatSeq(items []*ts.Node) Doc {
+	if len(items) == 0 {
+		return nil
+	}
+
+	var parts []Doc
+	emitted := false
+	var prev *ts.Node
+
+	for i := 0; i < len(items); i++ {
+		item := items[i]
+
+		if emitted {
+			parts = append(parts, hardLine())
+			if blankBetween(prev, item) {
+				parts = append(parts, hardLine())
+			}
+		}
+
+		if isComment(item) {
+			parts = append(parts, text(p.nodeText(item)))
+			prev = item
+		} else {
+			doc := p.format(item)
+			// Fold a trailing same-line comment into this statement's line.
+			if i+1 < len(items) && isComment(items[i+1]) && sameRow(item, items[i+1]) {
+				c := items[i+1]
+				doc = concat(doc, lineSuffix(concat(text(" "), text(p.nodeText(c)))))
+				prev = c
+				i++
+			} else {
+				prev = item
+			}
+			parts = append(parts, doc)
+		}
+		emitted = true
+	}
+
+	return concat(parts...)
+}
+
+// childPtrs returns stable pointers to a node's children (named, anonymous, and
+// comment extras) in source order, suitable for sequence walking.
+func childPtrs(n *ts.Node) []*ts.Node {
+	cs := children(n)
+	out := make([]*ts.Node, len(cs))
+	for i := range cs {
+		out[i] = &cs[i]
+	}
+	return out
+}
+
+// verbatim re-emits a node's exact source span, minus any trailing newline -
+// the statement sequencer owns all inter-statement spacing, so a node's own
+// trailing newline must not be emitted or it doubles up into a blank line. Inner
+// comments and original layout are preserved because they're part of the span;
+// embedded newlines render as literal (no-indent) breaks so the column counter
+// stays correct.
+func (p *printer) verbatim(node *ts.Node) Doc {
+	raw := strings.TrimRight(p.src[node.StartByte():node.EndByte()], "\n")
+	return rawText(raw)
+}
+
+// rawText turns arbitrary source text (possibly multi-line) into a Doc that
+// renders byte-for-byte identically: each line becomes Text, separated by
+// literal (no-indent) line breaks.
+func rawText(s string) Doc {
+	if !strings.Contains(s, "\n") {
+		return text(s)
+	}
+	lines := strings.Split(s, "\n")
+	parts := make([]Doc, 0, len(lines)*2-1)
+	for i, ln := range lines {
+		if i > 0 {
+			parts = append(parts, literalLine())
+		}
+		if ln != "" {
+			parts = append(parts, text(ln))
+		}
+	}
+	return concat(parts...)
+}

--- a/rts/radfmt/render.go
+++ b/rts/radfmt/render.go
@@ -13,9 +13,11 @@ func stringWidth(s string) int { return utf8.RuneCountInString(s) }
 // MaxWidth is the target line width. It is a target, not a hard cap: long
 // unbreakable tokens (string literals, comments) may exceed it. Tests assert
 // idempotence and structural equivalence, never a hard column maximum.
-const MaxWidth = 100
+// [F5] line width 120
+const MaxWidth = 120
 
 // IndentUnit is one level of indentation.
+// [F1] 4-space indentation, never tabs
 const IndentUnit = "    " // 4 spaces
 
 type mode uint8
@@ -315,6 +317,7 @@ func fits(next cmd, rest []cmd, width int, hasLineSuffix bool, gmm map[GroupID]m
 // trimTrailing strips trailing spaces/tabs from the already-emitted output's
 // last segment(s) and returns how many characters were removed (used to correct
 // the column counter).
+// [F4] strip trailing whitespace from every line
 func trimTrailing(out *[]string) int {
 	o := *out
 	trimmed := 0

--- a/rts/radfmt/render.go
+++ b/rts/radfmt/render.go
@@ -1,0 +1,393 @@
+package radfmt
+
+import (
+	"strings"
+	"unicode/utf8"
+)
+
+// stringWidth approximates the rendered column width of s. It counts runes
+// rather than bytes so multibyte UTF-8 doesn't overcount. (Wide/zero-width
+// glyphs aren't special-cased yet; width is a target, not a hard cap.)
+func stringWidth(s string) int { return utf8.RuneCountInString(s) }
+
+// MaxWidth is the target line width. It is a target, not a hard cap: long
+// unbreakable tokens (string literals, comments) may exceed it. Tests assert
+// idempotence and structural equivalence, never a hard column maximum.
+const MaxWidth = 100
+
+// IndentUnit is one level of indentation.
+const IndentUnit = "    " // 4 spaces
+
+type mode uint8
+
+const (
+	modeFlat mode = iota
+	modeBreak
+)
+
+// cmd is one frame on the render worklist: a doc to print at a given
+// indentation in a given mode.
+type cmd struct {
+	ind  string
+	mode mode
+	doc  Doc
+}
+
+// PrintDocToString renders a Doc to its final string at the given target width.
+// It is a stack machine (no recursion), a direct port of Prettier's
+// printDocToString: pop a frame, dispatch on doc kind, push children. Group
+// nodes consult fits() to choose flat vs broken. propagateBreaks must run on doc
+// before this is called.
+func PrintDocToString(doc Doc, width int) string {
+	propagateBreaks(doc)
+
+	groupModeMap := map[GroupID]mode{}
+	var out []string
+	pos := 0
+	cmds := []cmd{{ind: "", mode: modeBreak, doc: doc}}
+	var lineSuffixes []cmd
+	shouldRemeasure := false
+
+	for len(cmds) > 0 {
+		c := cmds[len(cmds)-1]
+		cmds = cmds[:len(cmds)-1]
+
+		switch d := c.doc.(type) {
+		case Text:
+			out = append(out, d.S)
+			pos += stringWidth(d.S)
+
+		case Concat:
+			for i := len(d.Parts) - 1; i >= 0; i-- {
+				cmds = append(cmds, cmd{c.ind, c.mode, d.Parts[i]})
+			}
+
+		case Fill:
+			// Simplified fill: treat like concat for now. Proper fill (per-gap
+			// breaking) lands with width-aware collection wrapping.
+			for i := len(d.Parts) - 1; i >= 0; i-- {
+				cmds = append(cmds, cmd{c.ind, c.mode, d.Parts[i]})
+			}
+
+		case Indent:
+			cmds = append(cmds, cmd{c.ind + IndentUnit, c.mode, d.Contents})
+
+		case Align:
+			cmds = append(cmds, cmd{c.ind + strings.Repeat(" ", d.N), c.mode, d.Contents})
+
+		case Trim:
+			pos -= trimTrailing(&out)
+
+		case *Group:
+			switch c.mode {
+			case modeFlat:
+				if !shouldRemeasure {
+					m := modeFlat
+					if d.Break {
+						m = modeBreak
+					}
+					cmds = append(cmds, cmd{c.ind, m, d.Contents})
+					if d.ID != 0 {
+						groupModeMap[d.ID] = m
+					}
+					break
+				}
+				fallthrough
+			case modeBreak:
+				shouldRemeasure = false
+				next := cmd{c.ind, modeFlat, d.Contents}
+				rem := width - pos
+				hasLS := len(lineSuffixes) > 0
+				if !d.Break && fits(next, cmds, rem, hasLS, groupModeMap, false) {
+					cmds = append(cmds, next)
+					if d.ID != 0 {
+						groupModeMap[d.ID] = modeFlat
+					}
+				} else if d.ExpandedStates != nil {
+					chosen := chooseExpanded(d, c.ind, cmds, rem, hasLS, groupModeMap)
+					cmds = append(cmds, chosen)
+					if d.ID != 0 {
+						groupModeMap[d.ID] = chosen.mode
+					}
+				} else {
+					cmds = append(cmds, cmd{c.ind, modeBreak, d.Contents})
+					if d.ID != 0 {
+						groupModeMap[d.ID] = modeBreak
+					}
+				}
+			}
+
+		case IfBreak:
+			gm := c.mode
+			if d.GroupID != 0 {
+				gm = groupModeMap[d.GroupID] // zero value modeFlat if unseen
+			}
+			chosen := d.FlatContents
+			if gm == modeBreak {
+				chosen = d.BreakContents
+			}
+			if chosen != nil {
+				cmds = append(cmds, cmd{c.ind, c.mode, chosen})
+			}
+
+		case IndentIfBreak:
+			gm := groupModeMap[d.GroupID]
+			inner := d.Contents
+			if gm == modeBreak {
+				inner = Indent{Contents: d.Contents}
+			}
+			cmds = append(cmds, cmd{c.ind, c.mode, inner})
+
+		case LineSuffix:
+			lineSuffixes = append(lineSuffixes, cmd{c.ind, c.mode, d.Contents})
+
+		case LineSuffixBoundary:
+			if len(lineSuffixes) > 0 {
+				cmds = append(cmds, cmd{c.ind, c.mode, Line{Hard: true}})
+			}
+
+		case BreakParent:
+			// no-op at print time; consumed by propagateBreaks
+
+		case Line:
+			if c.mode == modeFlat && !d.Hard {
+				if !d.Soft {
+					out = append(out, " ")
+					pos++
+				}
+				break
+			}
+			// Break mode or hard line: flush buffered line suffixes first, so
+			// trailing comments land before the newline.
+			if len(lineSuffixes) > 0 {
+				cmds = append(cmds, c) // re-process this Line after the suffixes
+				for i := len(lineSuffixes) - 1; i >= 0; i-- {
+					cmds = append(cmds, lineSuffixes[i])
+				}
+				lineSuffixes = nil
+				break
+			}
+			if d.Literal {
+				out = append(out, "\n")
+				pos = 0
+			} else {
+				trimTrailing(&out)
+				out = append(out, "\n"+c.ind)
+				pos = stringWidth(c.ind)
+			}
+		}
+	}
+
+	// Flush any line suffixes left at end of document.
+	if len(lineSuffixes) > 0 {
+		for _, ls := range lineSuffixes {
+			out = append(out, PrintDocToString(ls.doc, width))
+		}
+	}
+
+	return strings.Join(out, "")
+}
+
+// chooseExpanded implements conditionalGroup: try each expanded state flat,
+// least-expanded first, taking the first that fits; fall back to the most
+// expanded (broken).
+//
+// No construct builds an ExpandedStates group yet, so this is currently
+// unreachable. The loop starts at index 1 because, per Prettier, ExpandedStates[0]
+// is the group's own Contents - already measured by the caller's flat-fit check
+// before chooseExpanded is reached. Revisit this pairing when the first
+// conditionalGroup constructor is added.
+func chooseExpanded(g *Group, ind string, rest []cmd, rem int, hasLS bool, gmm map[GroupID]mode) cmd {
+	if g.Break {
+		return cmd{ind, modeBreak, g.ExpandedStates[len(g.ExpandedStates)-1]}
+	}
+	for i := 1; i < len(g.ExpandedStates); i++ {
+		state := g.ExpandedStates[i]
+		next := cmd{ind, modeFlat, state}
+		if fits(next, rest, rem, hasLS, gmm, false) {
+			return next
+		}
+	}
+	return cmd{ind, modeBreak, g.ExpandedStates[len(g.ExpandedStates)-1]}
+}
+
+// fits reports whether next, followed by the rest of the current line, fits in
+// width columns. It scans in flat mode, stops at the first hard/break line
+// (which ends the line, so it fits), and returns false as soon as width goes
+// negative. Crucially it measures next AND the remaining stack, not just next.
+func fits(next cmd, rest []cmd, width int, hasLineSuffix bool, gmm map[GroupID]mode, mustBeFlat bool) bool {
+	restIdx := len(rest)
+	cmds := []cmd{next}
+	var out []string
+
+	for width >= 0 {
+		if len(cmds) == 0 {
+			if restIdx == 0 {
+				return true
+			}
+			restIdx--
+			cmds = append(cmds, rest[restIdx])
+			continue
+		}
+
+		c := cmds[len(cmds)-1]
+		cmds = cmds[:len(cmds)-1]
+
+		switch d := c.doc.(type) {
+		case Text:
+			out = append(out, d.S)
+			width -= stringWidth(d.S)
+
+		case Concat:
+			for i := len(d.Parts) - 1; i >= 0; i-- {
+				cmds = append(cmds, cmd{c.ind, c.mode, d.Parts[i]})
+			}
+
+		case Fill:
+			for i := len(d.Parts) - 1; i >= 0; i-- {
+				cmds = append(cmds, cmd{c.ind, c.mode, d.Parts[i]})
+			}
+
+		case Indent:
+			cmds = append(cmds, cmd{c.ind, c.mode, d.Contents})
+
+		case Align:
+			cmds = append(cmds, cmd{c.ind, c.mode, d.Contents})
+
+		case IndentIfBreak:
+			cmds = append(cmds, cmd{c.ind, c.mode, d.Contents})
+
+		case Trim:
+			width += trimTrailing(&out)
+
+		case *Group:
+			if mustBeFlat && d.Break {
+				return false
+			}
+			gm := c.mode
+			if d.Break {
+				gm = modeBreak
+			}
+			contents := d.Contents
+			if d.ExpandedStates != nil && gm == modeBreak {
+				contents = d.ExpandedStates[len(d.ExpandedStates)-1]
+			}
+			cmds = append(cmds, cmd{c.ind, gm, contents})
+
+		case IfBreak:
+			gm := c.mode
+			if d.GroupID != 0 {
+				gm = gmm[d.GroupID]
+			}
+			chosen := d.FlatContents
+			if gm == modeBreak {
+				chosen = d.BreakContents
+			}
+			if chosen != nil {
+				cmds = append(cmds, cmd{c.ind, c.mode, chosen})
+			}
+
+		case Line:
+			if c.mode == modeBreak || d.Hard {
+				return true
+			}
+			if !d.Soft {
+				out = append(out, " ")
+				width--
+			}
+
+		case LineSuffix:
+			hasLineSuffix = true
+
+		case LineSuffixBoundary:
+			if hasLineSuffix {
+				return false
+			}
+
+		case BreakParent:
+			// no-op
+		}
+	}
+
+	return false
+}
+
+// trimTrailing strips trailing spaces/tabs from the already-emitted output's
+// last segment(s) and returns how many characters were removed (used to correct
+// the column counter).
+func trimTrailing(out *[]string) int {
+	o := *out
+	trimmed := 0
+	for len(o) > 0 {
+		last := o[len(o)-1]
+		stripped := strings.TrimRight(last, " \t")
+		if stripped == last {
+			break
+		}
+		trimmed += len(last) - len(stripped)
+		if stripped == "" {
+			o = o[:len(o)-1]
+			continue
+		}
+		o[len(o)-1] = stripped
+		break
+	}
+	*out = o
+	return trimmed
+}
+
+// propagateBreaks marks every Group that (transitively) contains a hard break or
+// BreakParent as Break=true, so those groups render broken without measuring. It
+// runs once before PrintDocToString and mutates *Group nodes in place.
+func propagateBreaks(d Doc) (forced bool) {
+	switch n := d.(type) {
+	case BreakParent:
+		return true
+	case Line:
+		return n.Hard
+	case *Group:
+		child := propagateBreaks(n.Contents)
+		for _, st := range n.ExpandedStates {
+			if propagateBreaks(st) {
+				child = true
+			}
+		}
+		if child {
+			n.Break = true
+		}
+		// A broken group still propagates a forced break to its parents only
+		// when it actually contains a hard break - matching Prettier, an
+		// explicit shouldBreak does not force ancestors. So return child here.
+		return child
+	case Concat:
+		for _, p := range n.Parts {
+			if propagateBreaks(p) {
+				forced = true
+			}
+		}
+		return forced
+	case Fill:
+		for _, p := range n.Parts {
+			if propagateBreaks(p) {
+				forced = true
+			}
+		}
+		return forced
+	case Indent:
+		return propagateBreaks(n.Contents)
+	case Align:
+		return propagateBreaks(n.Contents)
+	case IndentIfBreak:
+		return propagateBreaks(n.Contents)
+	case IfBreak:
+		a := propagateBreaks(n.BreakContents)
+		b := propagateBreaks(n.FlatContents)
+		return a || b
+	case LineSuffix:
+		// A break inside a line suffix should not force the enclosing group:
+		// suffixes are deferred and don't affect the current line's fit.
+		propagateBreaks(n.Contents)
+		return false
+	}
+	return false
+}

--- a/rts/radfmt/render_test.go
+++ b/rts/radfmt/render_test.go
@@ -1,0 +1,101 @@
+package radfmt
+
+import "testing"
+
+// callDoc builds the canonical Prettier call-argument shape: try to fit the args
+// on one line, otherwise break one-per-line with a trailing comma.
+func callDoc(fn string, args []Doc) Doc {
+	return group(concat(
+		text(fn+"("),
+		indent(concat(
+			softLine(),
+			join(concat(text(","), lineOrSpace()), args),
+			ifBreak(text(","), text("")),
+		)),
+		softLine(),
+		text(")"),
+	))
+}
+
+// Worked example A (research.md §1.7): a call-argument list fits flat when short
+// and breaks one-per-line with a trailing comma when it exceeds the width.
+func TestRender_CallArgs_FlatVsBroken(t *testing.T) {
+	short := callDoc("foo", []Doc{text("a()"), text("b()")})
+	if got, want := PrintDocToString(short, MaxWidth), "foo(a(), b())"; got != want {
+		t.Errorf("short call: got %q, want %q", got, want)
+	}
+
+	long := callDoc("foo", []Doc{
+		text("reallyLongArg()"),
+		text("omgSoManyParameters()"),
+		text("IShouldRefactorThis()"),
+		text("isThereSeriouslyAnotherOne()"),
+	})
+	// The flat form is 96 cols, so it fits at 100 but not at 80; at 80 the
+	// group breaks one-arg-per-line with a trailing comma.
+	if got, want := PrintDocToString(long, MaxWidth), "foo(reallyLongArg(), omgSoManyParameters(), IShouldRefactorThis(), isThereSeriouslyAnotherOne())"; got != want {
+		t.Errorf("long call at 100 should stay flat:\n got: %q\nwant: %q", got, want)
+	}
+	want := "foo(\n" +
+		"    reallyLongArg(),\n" +
+		"    omgSoManyParameters(),\n" +
+		"    IShouldRefactorThis(),\n" +
+		"    isThereSeriouslyAnotherOne(),\n" +
+		")"
+	if got := PrintDocToString(long, 80); got != want {
+		t.Errorf("long call at 80:\n got: %q\nwant: %q", got, want)
+	}
+}
+
+// Worked example B (research.md §1.8): a trailing comment buffered via lineSuffix
+// flushes before the newline, landing at the end of the line after the code.
+func TestRender_LineSuffix_TrailingComment(t *testing.T) {
+	doc := concat(text("a"), lineSuffix(text(" // comment")), text(";"), hardLine())
+	if got, want := PrintDocToString(doc, MaxWidth), "a; // comment\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// A hardline anywhere inside a group forces that group (and its ancestors) to
+// render broken, regardless of width.
+func TestRender_HardlinePropagatesBreak(t *testing.T) {
+	doc := group(concat(text("{"), indent(concat(hardLine(), text("x"))), hardLine(), text("}")))
+	if got, want := PrintDocToString(doc, MaxWidth), "{\n    x\n}"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// softline is nothing when flat and a newline when broken; line is a space when
+// flat. This pins the core Line semantics.
+func TestRender_LineSemantics(t *testing.T) {
+	flat := group(concat(text("("), softLine(), text("x"), softLine(), text(")")))
+	if got, want := PrintDocToString(flat, MaxWidth), "(x)"; got != want {
+		t.Errorf("flat softline: got %q, want %q", got, want)
+	}
+
+	// Force a break with a width of 1 so the group can't fit flat.
+	broken := group(concat(text("("), indent(concat(softLine(), text("xxxxx"))), softLine(), text(")")))
+	if got, want := PrintDocToString(broken, 3), "(\n    xxxxx\n)"; got != want {
+		t.Errorf("broken softline: got %q, want %q", got, want)
+	}
+}
+
+// Rendering is deterministic: same doc, same width, same output every time.
+func TestRender_Deterministic(t *testing.T) {
+	build := func() Doc {
+		return callDoc("foo", []Doc{text("alpha"), text("beta"), text("gamma")})
+	}
+	a := PrintDocToString(build(), 12)
+	b := PrintDocToString(build(), 12)
+	if a != b {
+		t.Errorf("non-deterministic render:\n a: %q\n b: %q", a, b)
+	}
+}
+
+// Trailing whitespace before a hard break is trimmed.
+func TestRender_TrimsTrailingWhitespaceBeforeBreak(t *testing.T) {
+	doc := concat(text("a"), text("  "), hardLine(), text("b"))
+	if got, want := PrintDocToString(doc, MaxWidth), "a\nb"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}

--- a/rts/radfmt/rules_test.go
+++ b/rts/radfmt/rules_test.go
@@ -1,0 +1,145 @@
+package radfmt_test
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+
+	radtesting "github.com/amterp/rad/core/testing"
+	"github.com/stretchr/testify/require"
+)
+
+// ruleHeadingRe matches a RULES.md rule heading and captures its ID and status,
+// e.g. "### F12 - Assignment spacing `implemented`" -> ("F12", "implemented").
+// The status is the trailing backticked word; titles must not contain backticks.
+var ruleHeadingRe = regexp.MustCompile("(?m)^###\\s+(F\\d+)\\b.*`(\\w+)`\\s*$")
+
+// looseHeadingRe matches any line that looks like a rule heading (`### F<n> ...`)
+// so parseRules can flag headings the strict ruleHeadingRe would silently ignore
+// (e.g. trailing text after the status backtick), rather than dropping the rule.
+var looseHeadingRe = regexp.MustCompile(`(?m)^###\s+F\d+\b.*$`)
+
+// ruleTagRe matches a rule reference like "[F12]" in code comments or snapshot
+// titles.
+var ruleTagRe = regexp.MustCompile(`\[(F\d+)\]`)
+
+// TestRuleCoverage is the enforcement arm of the rule system (see RULES.md and
+// AGENTS.md). It keeps the spec, the code, and the snapshots in lockstep:
+//   - every active rule is tagged in the code and demonstrated by a snapshot
+//     (byte-level rules use [raw] snapshots - see snapshot_test.go), and
+//   - nothing references a rule ID that RULES.md doesn't define.
+//
+// A dropped rule, an undocumented tag, or a rule with no demonstrating snapshot
+// fails the build - that's what stops the docs from rotting.
+func TestRuleCoverage(t *testing.T) {
+	rules := parseRules(t)
+	codeTags := collectCodeTags(t)
+	snapTags := collectSnapshotTags(t)
+
+	for _, id := range sortedRuleIDs(rules) {
+		status := rules[id]
+		switch status {
+		case "implemented", "passthrough":
+			require.Containsf(t, codeTags, id,
+				"rule %s (%s) has no `// [%s]` code tag - tag its enforcing site", id, status, id)
+			require.Containsf(t, snapTags, id,
+				"rule %s (%s) has no demonstrating snapshot - add a case titled `[%s] ...`", id, status, id)
+		case "limitation", "deferred", "roadmap":
+			// Documented only; intentionally exempt from tag/snapshot enforcement.
+		default:
+			t.Errorf("rule %s has unknown status %q (see the status legend in RULES.md)", id, status)
+		}
+	}
+
+	// No orphans: every tag in code or snapshots must name a rule RULES.md defines.
+	for id := range codeTags {
+		require.Containsf(t, rules, id, "code tag [%s] has no matching rule in RULES.md", id)
+	}
+	for id := range snapTags {
+		require.Containsf(t, rules, id, "snapshot tag [%s] has no matching rule in RULES.md", id)
+	}
+}
+
+// parseRules reads RULES.md and returns a map of rule ID to status.
+func parseRules(t *testing.T) map[string]string {
+	data, err := os.ReadFile("RULES.md")
+	require.NoError(t, err, "read RULES.md")
+
+	out := map[string]string{}
+	for _, m := range ruleHeadingRe.FindAllStringSubmatch(string(data), -1) {
+		id, status := m[1], m[2]
+		if prev, dup := out[id]; dup {
+			t.Errorf("rule %s defined twice in RULES.md (statuses %q and %q); IDs are unique", id, prev, status)
+		}
+		out[id] = status
+	}
+	require.NotEmpty(t, out, "no rules parsed from RULES.md - did the heading format change?")
+
+	// A heading that looks like a rule but the strict regex rejects (e.g. trailing
+	// text after the status backtick) would otherwise vanish silently. Fail loudly
+	// so a malformed heading can't quietly exempt a rule from coverage.
+	for _, line := range looseHeadingRe.FindAllString(string(data), -1) {
+		if !ruleHeadingRe.MatchString(line) {
+			t.Errorf("malformed rule heading in RULES.md (status must be the only "+
+				"backticked word, with nothing after it): %q", line)
+		}
+	}
+	return out
+}
+
+// collectCodeTags scans the package's non-test Go sources for `[Fn]` tags.
+func collectCodeTags(t *testing.T) map[string]bool {
+	files, err := filepath.Glob("*.go")
+	require.NoError(t, err)
+
+	out := map[string]bool{}
+	for _, f := range files {
+		if strings.HasSuffix(f, "_test.go") {
+			continue
+		}
+		data, err := os.ReadFile(f)
+		require.NoError(t, err)
+		for _, m := range ruleTagRe.FindAllStringSubmatch(string(data), -1) {
+			out[m[1]] = true
+		}
+	}
+	return out
+}
+
+// collectSnapshotTags scans every snapshot title for `[Fn]` tags.
+func collectSnapshotTags(t *testing.T) map[string]bool {
+	files, err := filepath.Glob("snapshots/*.snap")
+	require.NoError(t, err)
+
+	out := map[string]bool{}
+	for _, f := range files {
+		cases, err := radtesting.ParseSnapshotFile(f)
+		require.NoErrorf(t, err, "parse snapshot file %s", f)
+		for _, c := range cases {
+			for _, m := range ruleTagRe.FindAllStringSubmatch(c.Title, -1) {
+				out[m[1]] = true
+			}
+		}
+	}
+	return out
+}
+
+func sortedRuleIDs(rules map[string]string) []string {
+	out := make([]string, 0, len(rules))
+	for id := range rules {
+		out = append(out, id)
+	}
+	// Sort numerically (F2 before F10) so coverage failures read in rule order.
+	sort.Slice(out, func(i, j int) bool { return ruleNum(out[i]) < ruleNum(out[j]) })
+	return out
+}
+
+// ruleNum extracts the integer from a rule ID like "F12" -> 12 for ordering.
+func ruleNum(id string) int {
+	n, _ := strconv.Atoi(strings.TrimPrefix(id, "F"))
+	return n
+}

--- a/rts/radfmt/safety.go
+++ b/rts/radfmt/safety.go
@@ -1,0 +1,102 @@
+package radfmt
+
+import (
+	"strings"
+
+	"github.com/amterp/rad/rts"
+	ts "github.com/tree-sitter/go-tree-sitter"
+)
+
+// structuralSig builds a fingerprint of a tree's *code* structure: the kinds and
+// field names of every named node, in pre-order. It deliberately ignores
+// anonymous punctuation tokens (so a canonical trailing comma is allowed),
+// string quote characters (a string node is a string node regardless of quote),
+// whitespace, and positions. Comments are excluded here and counted separately,
+// since formatting may legitimately move a comment but must never drop one or
+// change what the code parses to.
+func structuralSig(n *ts.Node) (sig string, comments int) {
+	var sb strings.Builder
+	var walk func(field string, n *ts.Node)
+	walk = func(field string, n *ts.Node) {
+		if isComment(n) {
+			comments++
+			return
+		}
+		if n.IsNamed() {
+			if field != "" {
+				sb.WriteString(field)
+				sb.WriteByte('=')
+			}
+			sb.WriteString(n.Kind())
+			sb.WriteByte('(')
+		}
+		cursor := n.Walk()
+		defer cursor.Close()
+		for i, ch := range n.Children(cursor) {
+			walk(n.FieldNameForChild(uint32(i)), &ch)
+		}
+		if n.IsNamed() {
+			sb.WriteByte(')')
+		}
+	}
+	walk("", n)
+	return sb.String(), comments
+}
+
+// structuralDump renders a readable, position-free tree of named node kinds and
+// their field names (comments shown as a normalized marker). It's the
+// human-friendly twin of structuralSig: tests diff the dump of the input against
+// the dump of the formatted output to prove formatting never changed the code's
+// structure, with a clear side-by-side failure.
+func structuralDump(n *ts.Node) string {
+	var sb strings.Builder
+	var walk func(depth int, field string, n *ts.Node)
+	walk = func(depth int, field string, n *ts.Node) {
+		if isComment(n) {
+			sb.WriteString(strings.Repeat("  ", depth))
+			sb.WriteString("<comment>\n")
+			return
+		}
+		if n.IsNamed() {
+			sb.WriteString(strings.Repeat("  ", depth))
+			if field != "" {
+				sb.WriteString(field)
+				sb.WriteString(": ")
+			}
+			sb.WriteString(n.Kind())
+			sb.WriteByte('\n')
+			depth++
+		}
+		cursor := n.Walk()
+		defer cursor.Close()
+		for i, ch := range n.Children(cursor) {
+			walk(depth, n.FieldNameForChild(uint32(i)), &ch)
+		}
+	}
+	walk(0, "", n)
+	return sb.String()
+}
+
+// structurallyEquivalent reports whether formatted parses cleanly to the same
+// code structure (and same comment count) as the original, captured in wantSig /
+// wantComments. This is Format's last line of defense: if a construct formatter
+// has a bug that would change what the code means or drop a comment, Format
+// detects it here and falls back to returning the original untouched.
+func structurallyEquivalent(formatted, wantSig string, wantComments int) bool {
+	parser, err := rts.NewRadParser()
+	if err != nil {
+		return false
+	}
+	defer parser.Close()
+
+	tree := parser.Parse(formatted)
+	if tree.HasInvalidNodes() {
+		return false
+	}
+	root := tree.Root()
+	if root == nil {
+		return false
+	}
+	gotSig, gotComments := structuralSig(root)
+	return gotSig == wantSig && gotComments == wantComments
+}

--- a/rts/radfmt/snapshot_test.go
+++ b/rts/radfmt/snapshot_test.go
@@ -3,6 +3,7 @@ package radfmt_test
 import (
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -12,6 +13,19 @@ import (
 	"github.com/amterp/rad/rts/radfmt"
 	"github.com/stretchr/testify/require"
 )
+
+// rawMarker in a snapshot title marks a byte-level case whose INPUT and STDOUT
+// are Go-quoted strings (e.g. "x = 1\r\n"). Line-ending, trailing-whitespace,
+// and exact-trailing-newline rules can't be represented as literal snapshot text
+// - the scanner strips CRs and editors strip trailing spaces - so these cases
+// encode the bytes as visible escapes and are compared byte-for-byte.
+const rawMarker = "[raw]"
+
+func unquoteSnap(t *testing.T, s string) string {
+	v, err := strconv.Unquote(s)
+	require.NoErrorf(t, err, "[raw] snapshot section must be a Go-quoted string, got: %s", s)
+	return v
+}
 
 // TestFmtSnapshots runs every .snap file under rts/radfmt/snapshots/ through
 // Format and compares the result against the snapshot's STDOUT section. The
@@ -69,20 +83,41 @@ func TestFmtSnapshots(t *testing.T) {
 					t.Skip(tc.SkipReason)
 				}
 
-				out, _, ok := radfmt.Format(tc.Input)
-				require.True(t, ok, "Format returned ok=false (parse error?) for input:\n%s", tc.Input)
+				// A [raw] case carries its input and expected output as Go-quoted
+				// strings; decode them and compare byte-for-byte (no trailing-
+				// newline trim) so byte-level rules are precisely testable.
+				raw := strings.Contains(tc.Title, rawMarker)
+				input, expected := tc.Input, tc.Stdout
+				if raw {
+					input = unquoteSnap(t, tc.Input)
+					expected = unquoteSnap(t, tc.Stdout)
+				}
 
-				actual := strings.TrimRight(out, "\n")
-				if actual != tc.Stdout {
+				out, _, ok := radfmt.Format(input)
+				require.True(t, ok, "Format returned ok=false (parse error?) for input:\n%s", input)
+
+				actual := out
+				if !raw {
+					actual = strings.TrimRight(out, "\n")
+				}
+
+				if actual != expected {
 					if *radtesting.UpdateSnapshots {
 						updateMu.Lock()
-						tc.Stdout = actual
+						if raw {
+							tc.Stdout = strconv.Quote(actual)
+						} else {
+							tc.Stdout = actual
+						}
 						filesToUpdate[snapFile] = cases
 						updateMu.Unlock()
+					} else if raw {
+						t.Errorf("Snapshot mismatch for %s:\n expected %s\n   actual %s",
+							tc.Title, strconv.Quote(expected), strconv.Quote(actual))
 					} else {
 						t.Errorf("Snapshot mismatch for %s:\n%s",
 							tc.Title,
-							gd.DiffWith(tc.Stdout, actual,
+							gd.DiffWith(expected, actual,
 								gd.WithColor(true),
 								gd.WithLayout(gd.LayoutPreferSideBySide),
 								gd.WithWidth(120)))

--- a/rts/radfmt/snapshot_test.go
+++ b/rts/radfmt/snapshot_test.go
@@ -1,0 +1,112 @@
+package radfmt_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	gd "github.com/amterp/go-delta"
+	radtesting "github.com/amterp/rad/core/testing"
+	"github.com/amterp/rad/rts/radfmt"
+	"github.com/stretchr/testify/require"
+)
+
+// TestFmtSnapshots runs every .snap file under rts/radfmt/snapshots/ through
+// Format and compares the result against the snapshot's STDOUT section. The
+// INPUT is intentionally-messy Rad source; STDOUT is the canonical formatting.
+//
+// To regenerate expected outputs after intentional formatter changes:
+//
+//	go test ./rts/radfmt/ -run TestFmtSnapshots -update
+//
+// Because ParseSnapshotFile strips the trailing newline from both sections,
+// comparisons normalize the trailing newline away; the exact EOF-newline rule
+// is covered by unit tests in fmt_test.go.
+func TestFmtSnapshots(t *testing.T) {
+	snapshotDir := "snapshots"
+	if _, err := os.Stat(snapshotDir); os.IsNotExist(err) {
+		t.Skip("snapshots directory does not exist yet")
+		return
+	}
+
+	var snapFiles []string
+	err := filepath.Walk(snapshotDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if !info.IsDir() && strings.HasSuffix(path, ".snap") {
+			snapFiles = append(snapFiles, path)
+		}
+		return nil
+	})
+	require.NoError(t, err, "Failed to walk snapshot directory")
+
+	if len(snapFiles) == 0 {
+		t.Skip("No snapshot files found")
+		return
+	}
+
+	var updateMu sync.Mutex
+	filesToUpdate := make(map[string][]radtesting.SnapshotCase)
+
+	for _, snapFile := range snapFiles {
+		cases, err := radtesting.ParseSnapshotFile(snapFile)
+		require.NoError(t, err, "Failed to parse snapshot file: %s", snapFile)
+
+		for i := range cases {
+			tc := &cases[i]
+			testName := strings.TrimPrefix(snapFile, snapshotDir+"/")
+			testName = strings.TrimSuffix(testName, ".snap")
+			if tc.Title != "" {
+				testName = testName + "/" + tc.Title
+			}
+
+			t.Run(testName, func(t *testing.T) {
+				t.Parallel()
+				if tc.SkipReason != "" {
+					t.Skip(tc.SkipReason)
+				}
+
+				out, _, ok := radfmt.Format(tc.Input)
+				require.True(t, ok, "Format returned ok=false (parse error?) for input:\n%s", tc.Input)
+
+				actual := strings.TrimRight(out, "\n")
+				if actual != tc.Stdout {
+					if *radtesting.UpdateSnapshots {
+						updateMu.Lock()
+						tc.Stdout = actual
+						filesToUpdate[snapFile] = cases
+						updateMu.Unlock()
+					} else {
+						t.Errorf("Snapshot mismatch for %s:\n%s",
+							tc.Title,
+							gd.DiffWith(tc.Stdout, actual,
+								gd.WithColor(true),
+								gd.WithLayout(gd.LayoutPreferSideBySide),
+								gd.WithWidth(120)))
+					}
+				}
+
+				// Idempotence: formatting already-formatted output is a no-op.
+				reformatted, changed, ok2 := radfmt.Format(out)
+				require.True(t, ok2, "re-format returned ok=false")
+				require.Equal(t, out, reformatted, "format is not idempotent")
+				require.False(t, changed, "re-format reported a change (not idempotent)")
+			})
+		}
+	}
+
+	t.Cleanup(func() {
+		if *radtesting.UpdateSnapshots {
+			for path, cases := range filesToUpdate {
+				if err := radtesting.WriteSnapshotFile(path, cases); err != nil {
+					t.Errorf("Failed to update snapshot file %s: %v", path, err)
+				} else {
+					t.Logf("Updated snapshot file: %s", path)
+				}
+			}
+		}
+	})
+}

--- a/rts/radfmt/snapshots/assignments.snap
+++ b/rts/radfmt/snapshots/assignments.snap
@@ -1,0 +1,38 @@
+### TITLE ###
+Simple assignment spacing
+### INPUT ###
+x=1
+y   =   2
+### STDOUT ###
+x = 1
+y = 2
+### TITLE ###
+Multi-assign
+### INPUT ###
+a,b ,c = f()
+### STDOUT ###
+a, b, c = f()
+### TITLE ###
+Compound and incr/decr
+### INPUT ###
+x  +=  1
+y -=2
+i++
+j  --
+### STDOUT ###
+x += 1
+y -= 2
+i++
+j--
+### TITLE ###
+Arithmetic operators
+### INPUT ###
+x = 1+2*3-4/5%6
+### STDOUT ###
+x = 1 + 2 * 3 - 4 / 5 % 6
+### TITLE ###
+Boolean and comparison
+### INPUT ###
+ok = a>1 and b==2 or not c
+### STDOUT ###
+ok = a > 1 and b == 2 or not c

--- a/rts/radfmt/snapshots/assignments.snap
+++ b/rts/radfmt/snapshots/assignments.snap
@@ -1,5 +1,5 @@
 ### TITLE ###
-Simple assignment spacing
+[F12] Assignment spacing
 ### INPUT ###
 x=1
 y   =   2
@@ -7,13 +7,13 @@ y   =   2
 x = 1
 y = 2
 ### TITLE ###
-Multi-assign
+[F13] Multi-assign
 ### INPUT ###
 a,b ,c = f()
 ### STDOUT ###
 a, b, c = f()
 ### TITLE ###
-Compound and incr/decr
+[F14][F15] Compound assign and increment/decrement
 ### INPUT ###
 x  +=  1
 y -=2
@@ -25,14 +25,22 @@ y -= 2
 i++
 j--
 ### TITLE ###
-Arithmetic operators
+[F20] Arithmetic operators
 ### INPUT ###
 x = 1+2*3-4/5%6
 ### STDOUT ###
 x = 1 + 2 * 3 - 4 / 5 % 6
 ### TITLE ###
-Boolean and comparison
+[F20][F21] Boolean, comparison, and unary not
 ### INPUT ###
 ok = a>1 and b==2 or not c
 ### STDOUT ###
 ok = a > 1 and b == 2 or not c
+### TITLE ###
+[F31] Typed assignment
+### INPUT ###
+x:int=1
+msg : str = "hi"
+### STDOUT ###
+x: int = 1
+msg: str = "hi"

--- a/rts/radfmt/snapshots/calls_paths.snap
+++ b/rts/radfmt/snapshots/calls_paths.snap
@@ -1,17 +1,17 @@
 ### TITLE ###
-Call argument spacing
+[F24] Call argument spacing
 ### INPUT ###
 print(  a ,b )
 ### STDOUT ###
 print(a, b)
 ### TITLE ###
-Nested calls
+[F24] Nested calls
 ### INPUT ###
 x = f(g(h( 1 )), 2)
 ### STDOUT ###
 x = f(g(h(1)), 2)
 ### TITLE ###
-Dotted and indexed paths
+[F25] Dotted and indexed paths
 ### INPUT ###
 x = obj . method( 1 )
 y = a.b.c
@@ -21,21 +21,27 @@ x = obj.method(1)
 y = a.b.c
 z = a[0]
 ### TITLE ###
-Slice
+[F26] Slice
 ### INPUT ###
 s = data[ 1 : 2 ]
 ### STDOUT ###
 s = data[1:2]
 ### TITLE ###
-Ternary
+[F22] Ternary
 ### INPUT ###
 v = cond?a:b
 ### STDOUT ###
 v = cond ? a : b
 ### TITLE ###
-Long call wraps one arg per line
+[F32] Named call arguments bind tight
 ### INPUT ###
-result = compute(first_argument, second_argument, third_argument, fourth_argument, fifth_argument, sixth)
+connect( host="localhost" ,port= 8080,retries =3 )
+### STDOUT ###
+connect(host="localhost", port=8080, retries=3)
+### TITLE ###
+[F5][F29] Long call wraps one argument per line
+### INPUT ###
+result = compute(first_argument, second_argument, third_argument, fourth_argument, fifth_argument, sixth_argument, seventh)
 ### STDOUT ###
 result = compute(
     first_argument,
@@ -43,5 +49,6 @@ result = compute(
     third_argument,
     fourth_argument,
     fifth_argument,
-    sixth,
+    sixth_argument,
+    seventh,
 )

--- a/rts/radfmt/snapshots/calls_paths.snap
+++ b/rts/radfmt/snapshots/calls_paths.snap
@@ -1,0 +1,47 @@
+### TITLE ###
+Call argument spacing
+### INPUT ###
+print(  a ,b )
+### STDOUT ###
+print(a, b)
+### TITLE ###
+Nested calls
+### INPUT ###
+x = f(g(h( 1 )), 2)
+### STDOUT ###
+x = f(g(h(1)), 2)
+### TITLE ###
+Dotted and indexed paths
+### INPUT ###
+x = obj . method( 1 )
+y = a.b.c
+z = a[ 0 ]
+### STDOUT ###
+x = obj.method(1)
+y = a.b.c
+z = a[0]
+### TITLE ###
+Slice
+### INPUT ###
+s = data[ 1 : 2 ]
+### STDOUT ###
+s = data[1:2]
+### TITLE ###
+Ternary
+### INPUT ###
+v = cond?a:b
+### STDOUT ###
+v = cond ? a : b
+### TITLE ###
+Long call wraps one arg per line
+### INPUT ###
+result = compute(first_argument, second_argument, third_argument, fourth_argument, fifth_argument, sixth)
+### STDOUT ###
+result = compute(
+    first_argument,
+    second_argument,
+    third_argument,
+    fourth_argument,
+    fifth_argument,
+    sixth,
+)

--- a/rts/radfmt/snapshots/collections.snap
+++ b/rts/radfmt/snapshots/collections.snap
@@ -1,23 +1,23 @@
 ### TITLE ###
-List spacing
+[F27] List spacing
 ### INPUT ###
 l = [ 1,2 ,3 ]
 ### STDOUT ###
 l = [1, 2, 3]
 ### TITLE ###
-Nested lists
+[F27] Nested lists
 ### INPUT ###
 m = [[1,2],[3 ,4]]
 ### STDOUT ###
 m = [[1, 2], [3, 4]]
 ### TITLE ###
-Map spacing
+[F28] Map spacing
 ### INPUT ###
 m = {"x":1,  y :2}
 ### STDOUT ###
-m = {"x": 1, y: 2}
+m = { "x": 1, y: 2 }
 ### TITLE ###
-Empty collections
+[F24][F27][F28] Empty collections stay tight
 ### INPUT ###
 a = [  ]
 b = {  }
@@ -27,9 +27,9 @@ a = []
 b = {}
 c = f()
 ### TITLE ###
-Long list wraps one per line
+[F5][F29] Long list wraps one element per line
 ### INPUT ###
-items = ["alpha", "bravo", "charlie", "delta", "echo", "foxtrot", "golf", "hotel", "india", "juliet", "kilo"]
+items = ["alpha", "bravo", "charlie", "delta", "echo", "foxtrot", "golf", "hotel", "india", "juliet", "kilo", "lima", "mike", "november"]
 ### STDOUT ###
 items = [
     "alpha",
@@ -43,4 +43,7 @@ items = [
     "india",
     "juliet",
     "kilo",
+    "lima",
+    "mike",
+    "november",
 ]

--- a/rts/radfmt/snapshots/collections.snap
+++ b/rts/radfmt/snapshots/collections.snap
@@ -1,0 +1,46 @@
+### TITLE ###
+List spacing
+### INPUT ###
+l = [ 1,2 ,3 ]
+### STDOUT ###
+l = [1, 2, 3]
+### TITLE ###
+Nested lists
+### INPUT ###
+m = [[1,2],[3 ,4]]
+### STDOUT ###
+m = [[1, 2], [3, 4]]
+### TITLE ###
+Map spacing
+### INPUT ###
+m = {"x":1,  y :2}
+### STDOUT ###
+m = {"x": 1, y: 2}
+### TITLE ###
+Empty collections
+### INPUT ###
+a = [  ]
+b = {  }
+c = f(  )
+### STDOUT ###
+a = []
+b = {}
+c = f()
+### TITLE ###
+Long list wraps one per line
+### INPUT ###
+items = ["alpha", "bravo", "charlie", "delta", "echo", "foxtrot", "golf", "hotel", "india", "juliet", "kilo"]
+### STDOUT ###
+items = [
+    "alpha",
+    "bravo",
+    "charlie",
+    "delta",
+    "echo",
+    "foxtrot",
+    "golf",
+    "hotel",
+    "india",
+    "juliet",
+    "kilo",
+]

--- a/rts/radfmt/snapshots/comments_blanks.snap
+++ b/rts/radfmt/snapshots/comments_blanks.snap
@@ -1,5 +1,5 @@
 ### TITLE ###
-Leading and trailing comments
+[F9][F10] Leading and trailing comments
 ### INPUT ###
 // leading
 x = 1 // trailing
@@ -7,7 +7,7 @@ x = 1 // trailing
 // leading
 x = 1 // trailing
 ### TITLE ###
-Multiple blank lines collapse to one
+[F6][F8] Multiple blank lines collapse to one
 ### INPUT ###
 a = 1
 
@@ -19,7 +19,7 @@ a = 1
 
 b = 2
 ### TITLE ###
-Blank lines stripped at file edges
+[F7] Blank lines stripped at file edges
 ### INPUT ###
 
 
@@ -30,7 +30,7 @@ x = 1
 ### STDOUT ###
 x = 1
 ### TITLE ###
-Comment inside block
+[F9] Comment inside block
 ### INPUT ###
 if x:
     // note
@@ -40,7 +40,7 @@ if x:
     // note
     print(1)
 ### TITLE ###
-Standalone comment between statements
+[F9] Standalone comment between statements
 ### INPUT ###
 a = 1
 // a section
@@ -50,7 +50,7 @@ a = 1
 // a section
 b = 2
 ### TITLE ###
-Comment trailing a block header stays on the header line
+[F11] Comment trailing a block header stays on the header line
 ### INPUT ###
 if x: // why this
     a = 1

--- a/rts/radfmt/snapshots/comments_blanks.snap
+++ b/rts/radfmt/snapshots/comments_blanks.snap
@@ -1,0 +1,63 @@
+### TITLE ###
+Leading and trailing comments
+### INPUT ###
+// leading
+x = 1 // trailing
+### STDOUT ###
+// leading
+x = 1 // trailing
+### TITLE ###
+Multiple blank lines collapse to one
+### INPUT ###
+a = 1
+
+
+
+b = 2
+### STDOUT ###
+a = 1
+
+b = 2
+### TITLE ###
+Blank lines stripped at file edges
+### INPUT ###
+
+
+
+x = 1
+
+
+### STDOUT ###
+x = 1
+### TITLE ###
+Comment inside block
+### INPUT ###
+if x:
+    // note
+    print(1)
+### STDOUT ###
+if x:
+    // note
+    print(1)
+### TITLE ###
+Standalone comment between statements
+### INPUT ###
+a = 1
+// a section
+b = 2
+### STDOUT ###
+a = 1
+// a section
+b = 2
+### TITLE ###
+Comment trailing a block header stays on the header line
+### INPUT ###
+if x: // why this
+    a = 1
+for i in xs: // each item
+    print(i)
+### STDOUT ###
+if x: // why this
+    a = 1
+for i in xs: // each item
+    print(i)

--- a/rts/radfmt/snapshots/control_flow.snap
+++ b/rts/radfmt/snapshots/control_flow.snap
@@ -1,0 +1,52 @@
+### TITLE ###
+If else-if else
+### INPUT ###
+if x>1:
+    print(1)
+else if y:
+    print(2)
+else:
+    print(3)
+### STDOUT ###
+if x > 1:
+    print(1)
+else if y:
+    print(2)
+else:
+    print(3)
+### TITLE ###
+For loop
+### INPUT ###
+for i in range(3):
+    print(i)
+### STDOUT ###
+for i in range(3):
+    print(i)
+### TITLE ###
+For loop multiple vars
+### INPUT ###
+for i,x in items:
+    print(x)
+### STDOUT ###
+for i, x in items:
+    print(x)
+### TITLE ###
+While loop
+### INPUT ###
+while x:
+    x=x-1
+### STDOUT ###
+while x:
+    x = x - 1
+### TITLE ###
+Nested blocks
+### INPUT ###
+if a:
+    for i in xs:
+        if i>0:
+            print(i)
+### STDOUT ###
+if a:
+    for i in xs:
+        if i > 0:
+            print(i)

--- a/rts/radfmt/snapshots/control_flow.snap
+++ b/rts/radfmt/snapshots/control_flow.snap
@@ -1,5 +1,5 @@
 ### TITLE ###
-If else-if else
+[F17] If / else-if / else chain
 ### INPUT ###
 if x>1:
     print(1)
@@ -15,7 +15,7 @@ else if y:
 else:
     print(3)
 ### TITLE ###
-For loop
+[F18] For loop
 ### INPUT ###
 for i in range(3):
     print(i)
@@ -23,7 +23,7 @@ for i in range(3):
 for i in range(3):
     print(i)
 ### TITLE ###
-For loop multiple vars
+[F18] For loop with multiple vars
 ### INPUT ###
 for i,x in items:
     print(x)
@@ -31,7 +31,7 @@ for i,x in items:
 for i, x in items:
     print(x)
 ### TITLE ###
-While loop
+[F19] While loop
 ### INPUT ###
 while x:
     x=x-1
@@ -39,7 +39,7 @@ while x:
 while x:
     x = x - 1
 ### TITLE ###
-Nested blocks
+[F1][F17][F18] Nested blocks indent four spaces
 ### INPUT ###
 if a:
     for i in xs:

--- a/rts/radfmt/snapshots/misc.snap
+++ b/rts/radfmt/snapshots/misc.snap
@@ -1,0 +1,46 @@
+### TITLE ###
+[F16] Return and yield keyword spacing
+### INPUT ###
+return  1
+yield  2
+### STDOUT ###
+return 1
+yield 2
+### TITLE ###
+[F23] Parentheses are preserved, never added or removed
+### INPUT ###
+x = ( 1 + 2 ) * 3
+y = a and ( b or c )
+### STDOUT ###
+x = (1 + 2) * 3
+y = a and (b or c)
+### TITLE ###
+[F33] Number, bool, and null literals are preserved verbatim
+### INPUT ###
+a = 3.140
+b = 100
+c = true
+### STDOUT ###
+a = 3.140
+b = 100
+c = true
+### TITLE ###
+[F34] Shebang line is preserved
+### INPUT ###
+#!/usr/bin/env rad
+x=1
+### STDOUT ###
+#!/usr/bin/env rad
+x = 1
+### TITLE ###
+[F35] File header block is preserved verbatim
+### INPUT ###
+---
+A short description.
+---
+x = 1
+### STDOUT ###
+---
+A short description.
+---
+x = 1

--- a/rts/radfmt/snapshots/whitespace.snap
+++ b/rts/radfmt/snapshots/whitespace.snap
@@ -1,0 +1,24 @@
+### TITLE ###
+[F2][raw] CRLF and bare CR normalized to LF
+### INPUT ###
+"x = 1\r\ny = 2\r\n"
+### STDOUT ###
+"x = 1\ny = 2\n"
+### TITLE ###
+[F3][raw] Exactly one trailing newline at end of file
+### INPUT ###
+"x = 1"
+### STDOUT ###
+"x = 1\n"
+### TITLE ###
+[F3][raw] Multiple trailing newlines collapse to one
+### INPUT ###
+"x = 1\n\n\n"
+### STDOUT ###
+"x = 1\n"
+### TITLE ###
+[F4][raw] Trailing whitespace stripped from every line
+### INPUT ###
+"x = 1   \ny = 2\t\n"
+### STDOUT ###
+"x = 1\ny = 2\n"

--- a/rts/radfmt/structure_test.go
+++ b/rts/radfmt/structure_test.go
@@ -1,0 +1,125 @@
+package radfmt
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	gd "github.com/amterp/go-delta"
+	"github.com/amterp/rad/rts"
+)
+
+// dumpStructure parses src and returns its readable, position-free node-structure
+// dump. Used to assert the formatter never changes what the code parses to.
+func dumpStructure(t *testing.T, src string) string {
+	t.Helper()
+	parser, err := rts.NewRadParser()
+	if err != nil {
+		t.Fatalf("parser: %v", err)
+	}
+	defer parser.Close()
+	tree := parser.Parse(src)
+	return structuralDump(tree.Root())
+}
+
+// TestStructurePreserved is the explicit version of Format's runtime guard: for
+// every snapshot input, it formats the source (raw, BEFORE the structural
+// no-op) and asserts the CST node structure - kinds and field names, ignoring
+// whitespace, positions, quote characters, and comment placement - is identical
+// before and after. A formatter bug that reorders or drops nodes fails here with
+// a readable side-by-side diff, rather than silently degrading to a no-op.
+func TestStructurePreserved(t *testing.T) {
+	inputs := collectSnapshotInputs(t)
+	if len(inputs) == 0 {
+		t.Skip("no snapshot inputs yet")
+	}
+	for _, in := range inputs {
+		in := in
+		t.Run(in.name, func(t *testing.T) {
+			t.Parallel()
+			raw, _, _, ok := formatRaw(normalizeLineEndings(in.src))
+			if !ok {
+				t.Skipf("input has parse errors: %s", in.name)
+			}
+			before := dumpStructure(t, normalizeLineEndings(in.src))
+			after := dumpStructure(t, raw)
+			if before != after {
+				t.Errorf("formatting changed node structure for %s:\n%s",
+					in.name,
+					gd.DiffWith(before, after,
+						gd.WithColor(true),
+						gd.WithLayout(gd.LayoutPreferSideBySide),
+						gd.WithWidth(120)))
+			}
+		})
+	}
+}
+
+type snapshotInput struct {
+	name string
+	src  string
+}
+
+// collectSnapshotInputs reads the INPUT section of every .snap file under
+// snapshots/ by lightly parsing the snapshot format (### INPUT ### up to the
+// next ### delimiter). It avoids importing core/testing so this internal test
+// has no dependency cycle concerns.
+func collectSnapshotInputs(t *testing.T) []snapshotInput {
+	t.Helper()
+	var out []snapshotInput
+	dir := "snapshots"
+	if _, err := os.Stat(dir); os.IsNotExist(err) {
+		return nil
+	}
+	err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		if err != nil || info.IsDir() || !strings.HasSuffix(path, ".snap") {
+			return err
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		base := strings.TrimSuffix(filepath.Base(path), ".snap")
+		inputs := parseSnapInputs(string(data))
+		for i, in := range inputs {
+			name := base
+			if len(inputs) > 1 {
+				name = base + "#" + strconv.Itoa(i)
+			}
+			out = append(out, snapshotInput{name: name, src: in})
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk snapshots: %v", err)
+	}
+	return out
+}
+
+// parseSnapInputs extracts each ### INPUT ### block's contents from a snapshot
+// file body. This deliberately hand-rolls a minimal parser rather than reusing
+// core/testing.ParseSnapshotFile: this is a white-box (package radfmt) test that
+// needs internal access to formatRaw/structuralDump, and importing core/testing
+// here would form an import cycle (core/testing -> core -> rts/radfmt).
+func parseSnapInputs(body string) []string {
+	var inputs []string
+	lines := strings.Split(body, "\n")
+	i := 0
+	for i < len(lines) {
+		if strings.TrimSpace(lines[i]) == "### INPUT ###" {
+			i++
+			var b strings.Builder
+			for i < len(lines) && !strings.HasPrefix(strings.TrimSpace(lines[i]), "### ") {
+				b.WriteString(lines[i])
+				b.WriteByte('\n')
+				i++
+			}
+			inputs = append(inputs, strings.TrimSuffix(b.String(), "\n"))
+			continue
+		}
+		i++
+	}
+	return inputs
+}

--- a/rts/radfmt/structure_test.go
+++ b/rts/radfmt/structure_test.go
@@ -106,9 +106,16 @@ func collectSnapshotInputs(t *testing.T) []snapshotInput {
 func parseSnapInputs(body string) []string {
 	var inputs []string
 	lines := strings.Split(body, "\n")
+	title := ""
 	i := 0
 	for i < len(lines) {
-		if strings.TrimSpace(lines[i]) == "### INPUT ###" {
+		trimmed := strings.TrimSpace(lines[i])
+		if trimmed == "### TITLE ###" && i+1 < len(lines) {
+			title = lines[i+1]
+			i += 2
+			continue
+		}
+		if trimmed == "### INPUT ###" {
 			i++
 			var b strings.Builder
 			for i < len(lines) && !strings.HasPrefix(strings.TrimSpace(lines[i]), "### ") {
@@ -116,7 +123,16 @@ func parseSnapInputs(body string) []string {
 				b.WriteByte('\n')
 				i++
 			}
-			inputs = append(inputs, strings.TrimSuffix(b.String(), "\n"))
+			// Skip [raw] cases: their INPUT is a Go-quoted string (decoded only by
+			// the snapshot harness), and byte-level whitespace rules don't change
+			// node structure anyway, so there's nothing to assert here.
+			if !strings.Contains(title, "[raw]") {
+				inputs = append(inputs, strings.TrimSuffix(b.String(), "\n"))
+			}
+			// Each case carries its own title; clear it so an INPUT block missing
+			// its TITLE header can't silently inherit a prior [raw] title and be
+			// dropped from the structure check.
+			title = ""
 			continue
 		}
 		i++

--- a/rts/signatures.go
+++ b/rts/signatures.go
@@ -58,6 +58,7 @@ var internalSignatures = []FnSignature{
 	newInternalFnSignature(`_rad_get_stash_id(*_)`),
 	newInternalFnSignature(`_rad_delete_stash(*_)`),
 	newInternalFnSignature(`_rad_run_check(_script: str, _strict: bool) -> map`),
+	newInternalFnSignature(`_rad_fmt(_src: str) -> map`),
 	newInternalFnSignature(`_rad_check_from_logs(_duration: str, _verbose: bool, _strict: bool) -> void`),
 	newInternalFnSignature(`_rad_explain(_code: str) -> str?`),
 	newInternalFnSignature(`_rad_explain_list() -> str[]`),


### PR DESCRIPTION
Adds `rad fmt`, a gofmt-style canonical formatter for Rad scripts, and makes its formatting rules a numbered, documented, self-policing catalog.

- **Formatter** - Prettier-style Doc IR with a three-layer safety net (parse-error no-op, panic recovery, structural-equivalence guard) so it can never change a script's meaning.
- **Rule catalog** - `RULES.md` is the source of truth; each rule has a stable ID, a `// [Fn]` code tag, and a demonstrating snapshot, linked by a coverage test that fails the build on drift. `AGENTS.md` is the contributor playbook.

Two commits: the formatter itself, then the rule catalog plus the locked style decisions (width 120, spaced maps, typed assigns, tight named args).
