### PR TITLE
Fix two quick-win bugs; make snapshot -update targeted

### DIFF
--- a/.kan/boards/bugfixes/cards/a_sBPEpP4j.json
+++ b/.kan/boards/bugfixes/cards/a_sBPEpP4j.json
@@ -5,15 +5,16 @@
   "column": "todo-lo",
   "created_at_millis": 1775232007714,
   "creator": "Alexander Terp",
-  "description": "VERIFIED: This is documented behavior - the docs explicitly say _find is a regex pattern. However, there is no literal-string alternative for replace(), which is a real gap for the most common use case.\n\n**The problem:**\n- `\"a.b.c\".replace(\".\", \"-\")` produces `\"-----\"` because `.` is regex \"any char\"\n- `\"a.b.c\".split(\".\")` produces `[\"\", \"\", \"\", \"\", \"\", \"\"]` for same reason\n- Passing regex metacharacters like `(`, `+`, `*` crashes with \"Error compiling regex pattern\"\n- The replacement arg also uses regex semantics ($0, capture groups)\n\n**Why this matters despite being documented:**\nMost users expect literal string operations by default. The docs show `text.replace(\"hello\", \"hi\")` which looks like literal replacement. There is no `replace_literal()` or equivalent. Users must manually regex-escape their search strings.\n\n**Possible solutions:**\n1. Add `replace_literal()` / `split_literal()` functions\n2. Change replace/split to literal by default, add `replace_regex()` / `split_regex()`\n3. Add an `escape_regex()` utility function\n\n**Test files:** `bugs/strings/str_replace_regex_bug.rad`, `str_split_regex_check.rad`",
+  "description": "RE-VERIFIED 2026-06-14 (rad v0.10.1): still reproduces; no literal-string variant or `escape_regex()` exists yet. Documented behavior (the find arg is a regex pattern), but there is no literal alternative for the most common use case.\n\n**The problem:**\n- `\"a.b.c\".replace(\".\", \"-\")` -\u003e \"-----\"  (`.` is regex \"any char\")\n- `\"a.b.c\".split(\".\")` -\u003e [\"\", \"\", \"\", \"\", \"\", \"\"]\n- Regex metacharacters like `(` raise error[RAD20024] \"Error compiling regex pattern\"\n- The replacement arg also uses regex semantics ($0, capture groups)\n\n**Source:** `core/func_replace.go:20`, `core/func_split.go:32` - both `regexp.Compile` user input.\n\n**Why it matters:** most users expect literal string ops by default; docs show `text.replace(\"hello\", \"hi\")` which looks literal. Users must hand-escape regex metacharacters.\n\n**Possible solutions:**\n1. Add `replace_literal()` / `split_literal()`\n2. Make replace/split literal by default, add `replace_regex()` / `split_regex()`\n3. Add an `escape_regex()` utility",
+  "grammar": false,
   "id": "a_sBPEpP4j",
   "position": "6s",
-  "severity": "medium",
+  "severity": "high",
   "tags": [
     "design"
   ],
   "title": "replace() and split() treat first arg as regex, not literal string",
-  "updated_at_millis": 1775233443323,
+  "updated_at_millis": 1781449638859,
   "history": [
     {"field":"column","value":"todo-lo","at":1775232007714}
   ]

--- a/.kan/boards/bugfixes/cards/a_sBPpKYdk.json
+++ b/.kan/boards/bugfixes/cards/a_sBPpKYdk.json
@@ -5,7 +5,8 @@
   "column": "todo-lo",
   "created_at_millis": 1775232030347,
   "creator": "Alexander Terp",
-  "description": "VERIFIED: This is documented intended behavior - the basics guide explicitly states \"if you divide two ints, you will get back a float.\" However, the UX is poor.\n\n**The problem:**\n```\nitems = [\"a\", \"b\", \"c\", \"d\"]\nmid = 4 / 2     // 2.0 (float)\nitems[mid]       // Error: Expected int, got \"float\": 2\n```\n\nThe display hides the float nature (shows `2` not `2.0`), making the subsequent error confusing. There is no integer division operator (`//` is a comment in Rad).\n\n**Workaround:** `int(a / b)`\n\n**Design options:**\n1. Add `//` integer division operator (would need different comment syntax)\n2. Return int when division is exact (6/3 -\u003e 2, 7/3 -\u003e 2.333)\n3. Add `div()` or `idiv()` builtin function\n\n**Test files:** `bugs/operators/67_division_result_type.rad`, `76_int_int_division_result.rad`",
+  "description": "RE-VERIFIED 2026-06-14 (rad v0.10.1): still reproduces. This is documented intended behavior (the basics guide states \"if you divide two ints, you will get back a float\"), but the UX is poor.\n\n**The problem:**\nitems = [\"a\", \"b\", \"c\", \"d\"]\nmid = 4 / 2     // 2.0 (float)\nitems[mid]      // error[RAD30001]: Expected int, got float: 2\n\nThe display hides the float nature (shows `2` not `2.0`), making the subsequent error confusing. There is no integer-division operator (`//` is a comment in Rad).\n\n**Workaround:** `int(a / b)`\n\n**Design options:**\n1. Add a `//` integer-division operator (would need different comment syntax)\n2. Return int when division is exact (6/3 -\u003e 2, 7/3 -\u003e 2.333)\n3. Add a `div()` / `idiv()` builtin",
+  "grammar": false,
   "id": "a_sBPpKYdk",
   "position": "2w",
   "severity": "medium",
@@ -13,7 +14,7 @@
     "design"
   ],
   "title": "Division always returns float, unusable as list index",
-  "updated_at_millis": 1775233450471,
+  "updated_at_millis": 1781449638782,
   "history": [
     {"field":"column","value":"todo-lo","at":1775232030347}
   ]

--- a/.kan/boards/bugfixes/cards/a_sBPzQCcM.json
+++ b/.kan/boards/bugfixes/cards/a_sBPzQCcM.json
@@ -5,13 +5,16 @@
   "column": "todo-hi",
   "created_at_millis": 1775232036608,
   "creator": "Alexander Terp",
-  "description": "Writing a negative number literal as the fallback value for ?? or catch causes a parse error.\n\n**Repro:**\n```\nr = parse_int(\"x\") ?? -1\n// Error: Unexpected '-'\n\nr = risky() catch -1\n// Error: Unexpected '-'\n```\n\n**Workarounds:**\n- Use parentheses: `?? (-1)`\n- Use a variable: `fallback = -1; r = parse_int(\"x\") ?? fallback`\n- Use arithmetic: `?? (0 - 1)`\n\nThe parser does not recognize unary minus in this position. This is a natural thing to write - any user using ?? with negative defaults will hit it.\n\n**Test files:** `bugs/errors/17_neg_literal_fallback.rad`, `17b_neg_literal_catch.rad`, `bugs/functions/t76b_coalesce_negative.rad`, `t110_fn_catch_negative.rad`",
+  "description": "RE-VERIFIED 2026-06-14 (rad v0.10.1): still reproduces (both forms error RAD10009; the `?? (-1)` workaround works).\n\nWriting a negative number literal as the fallback value for ?? or catch causes a parse error.\n\n**Repro:**\nr = parse_int(\"x\") ?? -1      // error[RAD10009]: Unexpected '-'\nr = risky() catch -1          // error[RAD10009]: Unexpected '-'\n\n**Workarounds:**\n- Parentheses: `?? (-1)`  (confirmed working)\n- A variable: `fallback = -1; r = parse_int(\"x\") ?? fallback`\n- Arithmetic: `?? (0 - 1)`\n\nThe parser does not recognize unary minus in this position. Natural to write - any user using ?? / catch with negative defaults hits it.\n\n**Fix (slam dunk):** allow a unary-minus literal as the RHS of `??` / `catch` in the parser. The parens workaround proves it is purely a parsing gap.",
   "grammar": true,
   "id": "a_sBPzQCcM",
   "position": "m!",
-  "severity": "high",
+  "severity": "medium",
+  "tags": [
+    "quick-win"
+  ],
   "title": "?? and catch cannot parse negative literal on right side",
-  "updated_at_millis": 1775241425884,
+  "updated_at_millis": 1781449592005,
   "history": [
     {"field":"column","value":"todo-hi","at":1775232036608}
   ]

--- a/.kan/boards/bugfixes/cards/a_sBQ8LS6p.json
+++ b/.kan/boards/bugfixes/cards/a_sBQ8LS6p.json
@@ -5,13 +5,13 @@
   "column": "todo-hi",
   "created_at_millis": 1775232042140,
   "creator": "Alexander Terp",
-  "description": "Function calls, map lookups, and list indexing cannot be immediately called. The parser does not support chained call syntax.\n\n**Repro:**\n```\nfn make_adder(n):\n    return fn(x) x + n\n\nmake_adder(5)(3)          // Parse error - cannot call return value\n\nactions = {\"greet\": fn(name) \"Hello {name}\"}\nactions[\"greet\"](\"Alice\") // Parse error - cannot call map lookup result\n\nops = [fn(a, b) a + b]\nops[0](1, 2)              // Parse error - cannot call list index result\n```\n\n**Workaround:** Assign to a temporary variable first.\n\nThis blocks natural functional programming patterns and is especially painful combined with the broken escaping closures.\n\n**Test files:** `bugs/functions/t17b_immediate_call.rad`, `t29_fn_in_map.rad`, `t41_fn_list_call.rad`",
+  "description": "RE-VERIFIED 2026-06-14 (rad v0.10.1): still reproduces - all three forms are parse errors.\n\nFunction-call results, map lookups, and list indexing cannot be immediately called; the parser does not support chained call syntax.\n\n**Repro:**\nfn make_adder(n):\n    return fn(x) x + n\nmake_adder(5)(3)           // parse error - cannot call the returned function\n\nactions = {\"greet\": fn(name) \"Hello {name}\"}\nactions[\"greet\"](\"Alice\")  // parse error - cannot call a map-lookup result\n\nops = [fn(a, b) a + b]\nops[0](1, 2)               // parse error - cannot call a list-index result\n\n**Workaround:** assign to a temporary variable first.\n\nThis blocks natural functional-programming patterns (currying, dispatch tables). Requires a parser change to allow call/index expressions as the target of a further call/index (a refactor, not a one-liner - hence not a slam dunk despite being a clear grammar gap).",
   "grammar": true,
   "id": "a_sBQ8LS6p",
   "position": "t!",
   "severity": "high",
   "title": "Cannot immediately call result of an expression",
-  "updated_at_millis": 1775355523809,
+  "updated_at_millis": 1781449744346,
   "history": [
     {"field":"column","value":"todo-hi","at":1775232042140}
   ]

--- a/.kan/boards/bugfixes/cards/a_sBQgqO7u.json
+++ b/.kan/boards/bugfixes/cards/a_sBQgqO7u.json
@@ -5,15 +5,16 @@
   "column": "todo-hi",
   "created_at_millis": 1775232063525,
   "creator": "Alexander Terp",
-  "description": "VERIFIED: This is by design but counterintuitive. error() is a value constructor (not a panic thrower), so ?? and catch (which work by catching panics) do not intercept it.\n\n**The problem:**\n```\nr = error(\"test\") ?? \"fallback\"\nprint(r)  // \"test\" (NOT \"fallback\")\n\nfn fail():\n    return error(\"test\")\nr = fail() ?? \"fallback\"\nprint(r)  // \"fallback\" (this works because returning an error from a function triggers a panic)\n```\n\nThe distinction between `error(\"test\") ?? \"fallback\"` and `(fn() error(\"test\"))() ?? \"fallback\"` is deeply confusing.\n\n**Root cause:** Fallback checks `panicked || leftResult.Val.IsNull()` but not `leftResult.Val.IsError()`.\n\n**Design question:** Should ?? also check IsError()? Or should error() itself panic? Or should this asymmetry be explicitly documented?\n\n**Test files:** `bugs/errors/08_inline_error_coalesce.rad`, `73_error_inline_catch_block.rad`, `84_error_fn_coalesce.rad`",
+  "description": "RE-VERIFIED 2026-06-14 (rad v0.10.1): still reproduces. By design but counterintuitive: error() is a value constructor (not a panic thrower), so ?? and catch (which work by catching panics) do not intercept it inline.\n\n**The problem:**\nr = error(\"test\") ?? \"fallback\"\nprint(r)  // \"test\"     (NOT \"fallback\")\n\nfn fail():\n    return error(\"test\")\nr = fail() ?? \"fallback\"\nprint(r)  // \"fallback\" (returning an error from a function triggers a panic, which ?? catches)\n\nThe distinction between `error(\"test\") ?? \"fallback\"` and a function returning the error is deeply confusing.\n\n**Root cause:** the fallback checks `panicked || leftResult.Val.IsNull()` but not `leftResult.Val.IsError()`.\n\n**Design question:** should ?? also check IsError()? Should error() itself panic? Or should this asymmetry be documented?",
+  "grammar": false,
   "id": "a_sBQgqO7u",
   "position": "R!",
-  "severity": "high",
+  "severity": "medium",
   "tags": [
     "design"
   ],
   "title": "error() inline not caught by ?? or catch operators",
-  "updated_at_millis": 1775233457061,
+  "updated_at_millis": 1781449711856,
   "history": [
     {"field":"column","value":"todo-hi","at":1775232063525}
   ]

--- a/.kan/boards/bugfixes/cards/a_sBQtDAsa.json
+++ b/.kan/boards/bugfixes/cards/a_sBQtDAsa.json
@@ -5,12 +5,16 @@
   "column": "todo-hi",
   "created_at_millis": 1775232071191,
   "creator": "Alexander Terp",
-  "description": "Deleting elements from a list or map during a for loop causes elements to be skipped, others to be visited twice, and in extreme cases, stale/phantom data to be read.\n\n**Repro (list):**\n```\nitems = [1, 2, 3, 4, 5]\nfor item in items:\n    if item == 2:\n        del items[1]\n    print(item)\n// Elements are skipped and duplicated; after deleting ALL\n// elements the loop still iterates and reads phantom values\n```\n\n**Repro (map):**\n```\nm = {\"a\": 1, \"b\": 2, \"c\": 3}\nfor k, v in m:\n    if k == \"b\":\n        del m[\"b\"]\n    print(k, v)\n// Keys skipped and others processed twice\n```\n\nThe iterator does not snapshot the collection, so structural mutations during iteration corrupt the traversal.\n\n**Test files:** `bugs/collections/09_list_del_during_iter.rad`, `46_iter_mutation_map_del.rad`, `83_del_during_for_with_context.rad`, `124_for_index_beyond_shrunk.rad`, `125_for_shrink_all.rad`, `bugs/control_flow/98_for_loop_with_del_list.rad`, `101_for_del_list_iteration.rad`",
+  "description": "RE-VERIFIED 2026-06-14 (rad v0.10.1): LIST iteration still corrupts; the MAP case does NOT corrupt in current rad (a change from the original report - the map repro now traverses cleanly). Re-verify the map path before fixing.\n\n**Repro (list - still broken):**\nitems = [1, 2, 3, 4, 5]\nfor item in items:\n    if item == 2:\n        del items[1]\n    print(item)\n// prints 1, 2, 4, 5, 5   (3 skipped, 5 duplicated)\n\n**Repro (map - now fine):**\nm = {\"a\": 1, \"b\": 2, \"c\": 3}\nfor k, v in m:\n    if k == \"b\":\n        del m[\"b\"]\n    print(k, v)\n// prints a 1 / b 2 / c 3   (all entries, no corruption)\n\nThe list iterator does not snapshot the collection, so structural mutation during iteration corrupts the traversal. The map path appears to snapshot keys.\n\n**Design:** snapshot iterators (safe, copy cost) vs live iterators with structural-mutation guards.",
+  "grammar": false,
   "id": "a_sBQtDAsa",
   "position": "6!",
   "severity": "high",
+  "tags": [
+    "design"
+  ],
   "title": "Mutating collections during iteration causes skipped/duplicated elements",
-  "updated_at_millis": 1775232071191,
+  "updated_at_millis": 1781449711688,
   "history": [
     {"field":"column","value":"todo-hi","at":1775232071191}
   ]

--- a/.kan/boards/bugfixes/cards/a_sBR0JLWj.json
+++ b/.kan/boards/bugfixes/cards/a_sBR0JLWj.json
@@ -5,12 +5,16 @@
   "column": "todo-hi",
   "created_at_millis": 1775232075591,
   "creator": "Alexander Terp",
-  "description": "When a nested for loop uses the same iteration variable name as the outer for loop, the inner loop overwrites the outer variable. After the inner loop completes, the outer variable has the last value from the inner loop.\n\n**Repro:**\n```\nfor i in range(3):\n    for i in range(2):\n        pass\n    print(i)\n// Expected: 0, 1, 2\n// Actual: 1, 1, 1 (inner loop's final value)\n```\n\nThe outer loop still iterates the correct number of times (internal index is separate), but any code referencing the variable after the inner loop sees the wrong value. This is a realistic scenario, especially with common variable names like i, x, item.\n\n**Test files:** `bugs/control_flow/121_nested_same_var_detailed.rad`",
+  "description": "RE-VERIFIED 2026-06-14 (rad v0.10.1): still reproduces.\n\nWhen a nested for loop reuses the outer loop's iteration variable name, the inner loop overwrites the outer variable. After the inner loop completes, the outer variable holds the inner loop's final value.\n\n**Repro:**\nfor i in range(3):\n    for i in range(2):\n        pass\n    print(i)\n// Expected: 0, 1, 2\n// Actual:   1, 1, 1   (inner loop's final value)\n\nThe outer loop still iterates the right number of times (its internal index is separate), but any code referencing the variable after the inner loop sees the wrong value. Realistic with common names like i, x, item.\n\n**Design:** shadow inner loop vars in a child scope, or save/restore the outer var (same save/restore family as the loop-context bug).",
+  "grammar": false,
   "id": "a_sBR0JLWj",
   "position": "D!",
   "severity": "high",
+  "tags": [
+    "design"
+  ],
   "title": "Nested loops with same variable name clobber outer loop variable",
-  "updated_at_millis": 1775232075591,
+  "updated_at_millis": 1781449711773,
   "history": [
     {"field":"column","value":"todo-hi","at":1775232075591}
   ]

--- a/.kan/boards/bugfixes/cards/a_sBRDpFgU.json
+++ b/.kan/boards/bugfixes/cards/a_sBRDpFgU.json
@@ -5,7 +5,8 @@
   "column": "todo-hi",
   "created_at_millis": 1775232083974,
   "creator": "Alexander Terp",
-  "description": "VERIFIED: The re-propagation behavior may be intentional, but there is a concrete sub-bug: the error attribution points to the ORIGINAL call site, not the re-propagation site.\n\n**The problem:**\n```\nfn fail():\n    return error(\"boom\")\n\nstored = fail() catch:\n    pass\n// stored is error-typed but \"defused\"\n\nfn relay(x):\n    return x\n\nresult = relay(stored)  // CRASHES - error re-propagates\n// Error points to line with fail(), NOT relay()\n```\n\n**Two issues:**\n1. **Design concern:** A user who wrote `catch: pass` reasonably expects they handled the error. Passing it through a transparent relay function re-fires it.\n2. **Confirmed sub-bug:** The error message points to the original fail() call site, not the relay() call. This makes debugging very difficult.\n\nNote: `relay(stored) ?? \"fallback\"` DOES catch the re-propagation, so it is recoverable.\n\n**Test files:** `bugs/errors/82_error_return_from_user_fn.rad`, `83_catch_repropagation.rad`",
+  "description": "RE-VERIFIED 2026-06-14 (rad v0.10.1): still reproduces, including the sub-bug - re-propagation crashes AND the error is attributed to the ORIGINAL call site, not the re-propagation site.\n\n**The problem:**\nfn fail():\n    return error(\"boom\")\n\nstored = fail() catch:\n    pass\n// stored is error-typed but \"defused\"\n\nfn relay(x):\n    return x\n\nresult = relay(stored)  // CRASHES - the error re-propagates\n// the error points to the fail() line, NOT relay()\n\n**Two issues:**\n1. Design concern: a user who wrote `catch: pass` reasonably believes they handled the error; passing it through a transparent relay re-fires it.\n2. Confirmed sub-bug: the error message points to the original fail() call site, not relay(), making debugging hard.\n\nNote: `relay(stored) ?? \"fallback\"` DOES catch the re-propagation, so it is recoverable.",
+  "grammar": false,
   "id": "a_sBRDpFgU",
   "position": "Y!",
   "severity": "high",
@@ -13,7 +14,7 @@
     "design"
   ],
   "title": "Caught errors re-propagate when returned from user-defined functions",
-  "updated_at_millis": 1775233464341,
+  "updated_at_millis": 1781449711943,
   "history": [
     {"field":"column","value":"todo-hi","at":1775232083974}
   ]

--- a/.kan/boards/bugfixes/cards/a_sBRVjVvW.json
+++ b/.kan/boards/bugfixes/cards/a_sBRVjVvW.json
@@ -5,15 +5,16 @@
   "column": "todo-hi",
   "created_at_millis": 1775232095072,
   "creator": "Alexander Terp",
-  "description": "The loop context variable specified with `with \u003cname\u003e` persists after the loop ends, retaining its final context object value. If a variable with the same name existed before the loop, it is permanently overwritten.\n\n**Repro:**\n```\nctx = \"important\"\nfor i in range(3) with ctx:\n    pass\nprint(ctx)  // {\"idx\": 2, \"src\": [0, 1, 2]} (NOT \"important\")\n```\n\n**Root cause:** `core/interpreter.go` line 1029: setLoopContext uses i.env.SetVar() which unconditionally sets the variable in the current scope. There is no save/restore of the previous value and no cleanup after the loop.\n\n**Test files:** `bugs/control_flow/112_context_var_leak.rad`",
+  "description": "RE-VERIFIED 2026-06-14 (rad v0.10.1): still reproduces.\n\nThe loop context variable specified with `with \u003cname\u003e` persists after the loop ends, retaining its final context object value. If a variable with the same name existed before the loop, it is permanently overwritten.\n\n**Repro:**\nctx = \"important\"\nfor i in range(3) with ctx:\n    pass\nprint(ctx)  // { \"idx\": 2, \"src\": [0, 1, 2] }  (NOT \"important\")\n\n**Root cause:** `setLoopContext` at `core/interpreter.go:1057-1064` (was cited as :1029) calls `i.env.SetVar()` unconditionally with no save/restore of the previous value and no cleanup after the loop.\n\n**Fix (slam dunk):** in `executeForLoop` (~:1069-1186) save the prior value of the context var before the loop and restore it afterwards (unset if it did not exist). Mechanical, contained, low risk.",
+  "grammar": false,
   "id": "a_sBRVjVvW",
   "position": "f!",
-  "severity": "medium",
+  "severity": "critical",
   "tags": [
-    "design"
+    "quick-win"
   ],
   "title": "Loop context variable (with) leaks after loop and overwrites existing vars",
-  "updated_at_millis": 1775233428322,
+  "updated_at_millis": 1781449591834,
   "history": [
     {"field":"column","value":"todo-hi","at":1775232095072}
   ]

--- a/.kan/boards/bugfixes/cards/a_sBRVjVvW.json
+++ b/.kan/boards/bugfixes/cards/a_sBRVjVvW.json
@@ -2,20 +2,30 @@
   "_v": 3,
   "alias": "loop-context",
   "alias_explicit": false,
-  "column": "todo-hi",
+  "column": "done",
+  "comments": [
+    {
+      "author": "Alexander Terp",
+      "body": "Closed as works-as-intended (decided 2026-06-14). This is documented, deliberate behavior, not an implementation bug:\n\n- docs/type_system.md:129-133 — 'For-loops, while-loops, and list comprehensions do NOT open scopes ... loop vars (and the optional with context) bind in the current scope.'\n- core/testing/snapshots/misc/scoping.snap — the 'Scoping ... in for block is remembered' cases explicitly assert that iteration vars, unpacked k/v vars, AND the with-loop context var all persist after the loop (authored 2026-02-02).\n- Both the interpreter (SetVar into enclosing env) and the static binder mirror this.\n\nThe context var 'leak' is the same mechanism/code path as the iteration var persisting; scoping only the context var would make the language inconsistent. Considered (A) scope context var only, (B) scope all loop vars, (C) warn on shadowing — all rejected in favor of keeping the coherent documented model. If the shadowing footgun resurfaces, a check-time shadow warning is the least-invasive future option.",
+      "created_at_millis": 1781452429272,
+      "id": "c_1YHQopYdX"
+    }
+  ],
   "created_at_millis": 1775232095072,
   "creator": "Alexander Terp",
   "description": "RE-VERIFIED 2026-06-14 (rad v0.10.1): still reproduces.\n\nThe loop context variable specified with `with \u003cname\u003e` persists after the loop ends, retaining its final context object value. If a variable with the same name existed before the loop, it is permanently overwritten.\n\n**Repro:**\nctx = \"important\"\nfor i in range(3) with ctx:\n    pass\nprint(ctx)  // { \"idx\": 2, \"src\": [0, 1, 2] }  (NOT \"important\")\n\n**Root cause:** `setLoopContext` at `core/interpreter.go:1057-1064` (was cited as :1029) calls `i.env.SetVar()` unconditionally with no save/restore of the previous value and no cleanup after the loop.\n\n**Fix (slam dunk):** in `executeForLoop` (~:1069-1186) save the prior value of the context var before the loop and restore it afterwards (unset if it did not exist). Mechanical, contained, low risk.",
   "grammar": false,
   "id": "a_sBRVjVvW",
-  "position": "f!",
+  "position": "u8U",
   "severity": "critical",
   "tags": [
     "quick-win"
   ],
   "title": "Loop context variable (with) leaks after loop and overwrites existing vars",
-  "updated_at_millis": 1781449591834,
+  "updated_at_millis": 1781452429356,
   "history": [
-    {"field":"column","value":"todo-hi","at":1775232095072}
+    {"field":"column","value":"todo-hi","at":1775232095072},
+    {"field":"column","value":"in-progress","at":1781451971487},
+    {"field":"column","value":"done","at":1781452429356}
   ]
 }

--- a/.kan/boards/bugfixes/cards/a_sBRwF6pf.json
+++ b/.kan/boards/bugfixes/cards/a_sBRwF6pf.json
@@ -2,20 +2,30 @@
   "_v": 3,
   "alias": "multi-line-string",
   "alias_explicit": false,
-  "column": "todo-hi",
+  "column": "done",
+  "comments": [
+    {
+      "author": "Alexander Terp",
+      "body": "Fixed (2026-06-14). The under-indented multi-line string case made tree-sitter emit an ERROR node parented directly by the 'string' node (between string_start and string_end); GenerateErrorMessage had no heuristic for it, so it fell through to the generic RAD10009 'Unexpected ...'.\n\nFix: added checkMultilineStringIndent to the rts/check/error_messages.go heuristic chain (after checkUnterminatedQuoteToken). It detects ERROR-under-string, computes the closing-delimiter indentation from the string_end text, and fires only when a content line is less-indented than the closing triple-quote. Reuses RAD10009 with a targeted message + suggestion (no new code), following the checkBareNullTypeAnnotation precedent.\n\nScope: only the common single-content-line shape is detected. The multi-content-line under-indent variant produces a messier CST (ERROR not parented by 'string') and still falls through to the generic message - documented in the heuristic comment.\n\nTest: snapshot 'StrLexing Multiline ContentLessIndentedThanClosing' in core/testing/snapshots/types/str_lexing.snap. Verified existing multi-line cases (valid + other error shapes like unterminated) are unaffected.",
+      "created_at_millis": 1781453393132,
+      "id": "c_1YHptRzmS"
+    }
+  ],
   "created_at_millis": 1775232111520,
   "creator": "Alexander Terp",
   "description": "RE-VERIFIED 2026-06-14 (rad v0.10.1): still reproduces. The indentation rule (content cannot have less indentation than the closing \"\"\") is documented and intentional - but the error message is unhelpful and gives no indication of the actual problem.\n\n**The problem:**\ns = \"\"\"\nhi\n    \"\"\"\n// error[RAD10009]: Unexpected ... (generic \"look for extra symbols\")\n\nThe generic RAD10009 gives zero indication this is about multi-line string indentation. The user cannot understand what went wrong without already knowing the rule.\n\n**Expected:** a specific message like \"Content line has less indentation than the closing triple-quote\", pointing at the relevant lines.\n\n**Fix (slam dunk):** detect the content-less-indented-than-closing-quote case and emit a targeted error. Error-message-only, no behavior change.",
   "grammar": false,
   "id": "a_sBRwF6pf",
-  "position": "K!",
+  "position": "u8UUU",
   "severity": "low",
   "tags": [
     "quick-win"
   ],
   "title": "Multi-line string indentation error has unhelpful error message",
-  "updated_at_millis": 1781449592094,
+  "updated_at_millis": 1781453393199,
   "history": [
-    {"field":"column","value":"todo-hi","at":1775232111520}
+    {"field":"column","value":"todo-hi","at":1775232111520},
+    {"field":"column","value":"in-progress","at":1781453040709},
+    {"field":"column","value":"done","at":1781453393199}
   ]
 }

--- a/.kan/boards/bugfixes/cards/a_sBRwF6pf.json
+++ b/.kan/boards/bugfixes/cards/a_sBRwF6pf.json
@@ -5,12 +5,16 @@
   "column": "todo-hi",
   "created_at_millis": 1775232111520,
   "creator": "Alexander Terp",
-  "description": "VERIFIED: The indentation rule is documented and intentional - content cannot have less indentation than the closing \"\"\". However, the error message is terrible and gives no indication of the actual problem.\n\n**The problem:**\n```\ns = \"\"\"\nhi\n    \"\"\"\n// error[RAD10009]: Unexpected 'hi'\n```\n\nThe error `RAD10009: Unexpected Token` with generic \"look for extra symbols\" explanation gives zero indication this is about multi-line string indentation. The user has no way to understand what went wrong without already knowing the indentation rule.\n\n**Expected:** A specific error message like \"Content line has less indentation than closing triple-quote\" pointing at the relevant lines.\n\n**Test files:** `bugs/strings/str_multiline_closing_more_indent.rad`, `str_multiline_indent_bug2.rad`",
+  "description": "RE-VERIFIED 2026-06-14 (rad v0.10.1): still reproduces. The indentation rule (content cannot have less indentation than the closing \"\"\") is documented and intentional - but the error message is unhelpful and gives no indication of the actual problem.\n\n**The problem:**\ns = \"\"\"\nhi\n    \"\"\"\n// error[RAD10009]: Unexpected ... (generic \"look for extra symbols\")\n\nThe generic RAD10009 gives zero indication this is about multi-line string indentation. The user cannot understand what went wrong without already knowing the rule.\n\n**Expected:** a specific message like \"Content line has less indentation than the closing triple-quote\", pointing at the relevant lines.\n\n**Fix (slam dunk):** detect the content-less-indented-than-closing-quote case and emit a targeted error. Error-message-only, no behavior change.",
+  "grammar": false,
   "id": "a_sBRwF6pf",
   "position": "K!",
-  "severity": "medium",
+  "severity": "low",
+  "tags": [
+    "quick-win"
+  ],
   "title": "Multi-line string indentation error has unhelpful error message",
-  "updated_at_millis": 1775233500610,
+  "updated_at_millis": 1781449592094,
   "history": [
     {"field":"column","value":"todo-hi","at":1775232111520}
   ]

--- a/.kan/boards/bugfixes/cards/a_sBSETejS.json
+++ b/.kan/boards/bugfixes/cards/a_sBSETejS.json
@@ -5,12 +5,16 @@
   "column": "todo-lo",
   "created_at_millis": 1775232122822,
   "creator": "Alexander Terp",
-  "description": "Writing an integer literal that exceeds int64 range causes an unrecoverable Go panic instead of a user-friendly error.\n\n**Repro:**\n```\nx = 9223372036854775808   // max int64 + 1\n// Go panic: converter: failed to parse int\n```\n\nAlso cannot express the minimum int64 value as a literal: -9223372036854775808 panics.\n\n**Source:** `rts/converter.go:1151`\n**Test files:** `bugs/operators/01_int_overflow.rad`, `59_min_int_literal.rad`",
+  "description": "RE-VERIFIED 2026-06-14 (rad v0.10.1): still a raw Go panic.\n\nWriting an integer literal that exceeds int64 range causes an unrecoverable Go panic instead of a user-friendly error.\n\n**Repro:**\nx = 9223372036854775808   // max int64 + 1\n// panic: converter: failed to parse int \"9223372036854775808\": strconv.ParseInt: ... value out of range\n\nAlso cannot express the minimum int64 value as a literal: -9223372036854775808 panics.\n\n**Source:** `rts/converter.go:1212` (was cited as :1151) - `convertInt()` calls `panic()` on parse failure.\n\n**Fix (slam dunk):** replace the `panic()` with a clean rad compile error; the converter already emits errors elsewhere, so callers handle it. Kills a raw Go panic.",
+  "grammar": false,
   "id": "a_sBSETejS",
   "position": "Ao",
-  "severity": "medium",
+  "severity": "high",
+  "tags": [
+    "quick-win"
+  ],
   "title": "Int literal overflow causes Go panic",
-  "updated_at_millis": 1775232122822,
+  "updated_at_millis": 1781449591916,
   "history": [
     {"field":"column","value":"todo-lo","at":1775232122822}
   ]

--- a/.kan/boards/bugfixes/cards/a_sBSETejS.json
+++ b/.kan/boards/bugfixes/cards/a_sBSETejS.json
@@ -2,20 +2,29 @@
   "_v": 3,
   "alias": "int-literal-overflow",
   "alias_explicit": false,
-  "column": "todo-lo",
+  "column": "done",
+  "comments": [
+    {
+      "author": "Alexander Terp",
+      "body": "Fixed (2026-06-14). Root cause: an out-of-range int literal reached rts.convertInt, which panics - and on the interpret path that conversion runs outside any recovery, so it surfaced as a raw Go panic.\n\nFix: added RAD40015 (ErrIntLiteralOutOfRange) + a CST-level checker pass (addIntLiteralOutOfRangeErrors in rts/check/check.go) that flags int literals failing ParseInt with strconv.ErrRange. validateSyntax surfaces it as a clean error before the panicking conversion. Left the convertInt panic in place as the converter's documented 'valid CST' invariant (now unreachable on the CLI path).\n\nNotes:\n- MinInt64 (-9223372036854775808) still can't be written as a literal (the magnitude overflows on its own before the unary minus); now a clean RAD40015 with a suggestion pointing at the '-...807 - 1' workaround, instead of a panic.\n- Collateral: core/error_docs/20017.md's example was itself relying on this bug (its literal would have panicked, and int() doesn't even raise RAD20017) - re-based it on round(x, -2), which genuinely demonstrates RAD20017.\n- Tests: snapshot core/testing/snapshots/errors/validation/int_literal_out_of_range.snap; error-doc 40015.md + tolerance.",
+      "created_at_millis": 1781453008586,
+      "id": "c_1YHftC4zq"
+    }
+  ],
   "created_at_millis": 1775232122822,
   "creator": "Alexander Terp",
   "description": "RE-VERIFIED 2026-06-14 (rad v0.10.1): still a raw Go panic.\n\nWriting an integer literal that exceeds int64 range causes an unrecoverable Go panic instead of a user-friendly error.\n\n**Repro:**\nx = 9223372036854775808   // max int64 + 1\n// panic: converter: failed to parse int \"9223372036854775808\": strconv.ParseInt: ... value out of range\n\nAlso cannot express the minimum int64 value as a literal: -9223372036854775808 panics.\n\n**Source:** `rts/converter.go:1212` (was cited as :1151) - `convertInt()` calls `panic()` on parse failure.\n\n**Fix (slam dunk):** replace the `panic()` with a clean rad compile error; the converter already emits errors elsewhere, so callers handle it. Kills a raw Go panic.",
   "grammar": false,
   "id": "a_sBSETejS",
-  "position": "Ao",
+  "position": "u8UU",
   "severity": "high",
   "tags": [
     "quick-win"
   ],
   "title": "Int literal overflow causes Go panic",
-  "updated_at_millis": 1781449591916,
+  "updated_at_millis": 1781453009532,
   "history": [
-    {"field":"column","value":"todo-lo","at":1775232122822}
+    {"field":"column","value":"todo-lo","at":1775232122822},
+    {"field":"column","value":"done","at":1781453009532}
   ]
 }

--- a/.kan/boards/bugfixes/cards/a_sBSMJTGV.json
+++ b/.kan/boards/bugfixes/cards/a_sBSMJTGV.json
@@ -5,12 +5,13 @@
   "column": "todo-lo",
   "created_at_millis": 1775232127674,
   "creator": "Alexander Terp",
-  "description": "Creating a circular reference (e.g. map containing itself) and then printing or comparing it causes a Go runtime stack overflow - a hard crash, not a recoverable error.\n\n**Repro:**\n```\nm = {}\nm[\"self\"] = m\nprint(m)   // fatal error: stack overflow\n\na = [1]\na[0] = a\nprint(a)   // fatal error: stack overflow\n```\n\nNo cycle detection exists in print or equality. Unlikely in normal usage but a hard crash is always bad.\n\n**Test files:** `bugs/operators/64_self_referential.rad`, `65c_circular_list.rad`, `bugs/collections/87_list_contains_self.rad`, `91_list_self_ref_crash.rad`",
+  "description": "RE-VERIFIED 2026-06-14 (rad v0.10.1): still a hard crash.\n\nCreating a circular reference (e.g. a map containing itself) and then printing or comparing it causes a Go runtime stack overflow - a hard crash, not a recoverable error.\n\n**Repro:**\nm = {}\nm[\"self\"] = m\nprint(m)   // fatal error: stack overflow\n\na = [1]\na[0] = a\nprint(a)   // fatal error: stack overflow\n\nNo cycle detection exists in print or equality (the value visitor in core/type_visitor.go / type_rad_value.go recurses without a visited-set). Unlikely in normal usage, but a hard crash is always bad.\n\n**Fix:** add a depth guard or cycle detection in print + equality. Pairs with the infinite-recursion crash (both are unbounded recursion crashing Go).",
+  "grammar": false,
   "id": "a_sBSMJTGV",
   "position": "Ek",
-  "severity": "medium",
+  "severity": "high",
   "title": "Circular data structures cause stack overflow crash",
-  "updated_at_millis": 1775232127674,
+  "updated_at_millis": 1781449744169,
   "history": [
     {"field":"column","value":"todo-lo","at":1775232127674}
   ]

--- a/.kan/boards/bugfixes/cards/a_sBSZN4IY.json
+++ b/.kan/boards/bugfixes/cards/a_sBSZN4IY.json
@@ -5,12 +5,16 @@
   "column": "todo-lo",
   "created_at_millis": 1775232135771,
   "creator": "Alexander Terp",
-  "description": "All integer arithmetic silently wraps on overflow. No error, no warning - just wrong results.\n\n**Repro:**\n```\nmax_int = 9223372036854775807\nprint(max_int + 1)    // -9223372036854775808 (wrapped)\nprint(max_int * 2)    // -2\nprint(-(-9223372036854775808) == -9223372036854775808)  // true\n```\n\nLow priority because most users will not work with numbers near int64 bounds, but when they do, the failure is silent.\n\n**Test files:** `bugs/operators/02_int_overflow_multiply.rad`, `77_int_overflow_addition.rad`, `89_int_overflow_unary.rad`, `109_int_overflow_subtraction.rad`",
+  "description": "RE-VERIFIED 2026-06-14 (rad v0.10.1): still reproduces. All integer arithmetic silently wraps on overflow (Go int64 semantics) - no error, no warning, just wrong results.\n\n**Repro:**\nmax_int = 9223372036854775807\nprint(max_int + 1)    // -9223372036854775808 (wrapped)\nprint(max_int * 2)    // -2\n\nLow priority because most users will not work near int64 bounds, but when they do, the failure is silent.\n\n**Design question:** error on overflow / promote to float / bigint / warn-and-wrap. Each has a performance or semantic cost.",
+  "grammar": false,
   "id": "a_sBSZN4IY",
   "position": "Ig",
   "severity": "medium",
+  "tags": [
+    "design"
+  ],
   "title": "Silent integer overflow wraparound with no error or warning",
-  "updated_at_millis": 1775232135771,
+  "updated_at_millis": 1781449638945,
   "history": [
     {"field":"column","value":"todo-lo","at":1775232135771}
   ]

--- a/.kan/boards/bugfixes/cards/a_sBSpTja4.json
+++ b/.kan/boards/bugfixes/cards/a_sBSpTja4.json
@@ -5,12 +5,16 @@
   "column": "todo-lo",
   "created_at_millis": 1775232145760,
   "creator": "Alexander Terp",
-  "description": "Sorting a list containing NaN values produces nonsensical results because NaN violates comparison transitivity.\n\n**Repro:**\n```\nitems = [5, 4, 0.0/0, 3, 0.0/0, 2, 1]\nprint(items.sort())\n// [4, 5, NaN, 3, NaN, 1, 2] (broken)\n```\n\nShould either error on NaN in sort or handle it explicitly (e.g. sort NaN to end).\n\n**Test files:** `bugs/operators/68_comparison_with_nan.rad`, `87_nan_sort_deeper.rad`",
+  "description": "RE-VERIFIED 2026-06-14 (rad v0.10.1): still reproduces. Sorting a list containing NaN produces a nonsensical order because NaN violates comparison transitivity.\n\n**Repro:**\nnan = pow(-1, 0.5)   // NaN  (note: 0.0/0 now raises RAD20036 divide-by-zero, so use pow)\nitems = [5, 4, nan, 3, nan, 2, 1]\nprint(items.sort())  // broken order - NaN not sorted to end, comparisons inconsistent\n\n**Design options:** error on NaN in sort, or define a NaN ordering (e.g. sort NaN to the end).",
+  "grammar": false,
   "id": "a_sBSpTja4",
   "position": "Mc",
-  "severity": "low",
+  "severity": "medium",
+  "tags": [
+    "design"
+  ],
   "title": "NaN poisons list sorting - produces completely broken order",
-  "updated_at_millis": 1775232145760,
+  "updated_at_millis": 1781449639038,
   "history": [
     {"field":"column","value":"todo-lo","at":1775232145760}
   ]

--- a/.kan/boards/bugfixes/cards/a_sBSvE2vJ.json
+++ b/.kan/boards/bugfixes/cards/a_sBSvE2vJ.json
@@ -5,12 +5,16 @@
   "column": "todo-lo",
   "created_at_millis": 1775232149323,
   "creator": "Alexander Terp",
-  "description": "Comparing large integers to their float representation gives incorrect results because the int is converted to float, losing precision.\n\n**Repro:**\n```\nx = 9223372036854775807\nprint(x == 9223372036854775807.0)  // true (WRONG)\n// The float is actually 9223372036854776000 (rounded up)\n```\n\nEdge case only relevant at int64 bounds.\n\n**Test files:** `bugs/operators/86_max_int_comparison_bug.rad`, `70_int_float_mixed_compare.rad`",
+  "description": "RE-VERIFIED 2026-06-14 (rad v0.10.1): still reproduces. Comparing a large int to its float representation gives a wrong result because the int is converted to float, losing precision.\n\n**Repro:**\nx = 9223372036854775807\nprint(x == 9223372036854775807.0)  // true (WRONG)\n// the float is actually 9223372036854776000 (rounded up)\n\nEdge case, only relevant at int64 bounds.\n\n**Design question:** stricter cross-type equality, arbitrary precision, or accept/document this IEEE-754 behavior.",
+  "grammar": false,
   "id": "a_sBSvE2vJ",
   "position": "QY",
-  "severity": "low",
+  "severity": "medium",
+  "tags": [
+    "design"
+  ],
   "title": "Large int vs float comparison gives wrong result due to precision loss",
-  "updated_at_millis": 1775232149323,
+  "updated_at_millis": 1781449639121,
   "history": [
     {"field":"column","value":"todo-lo","at":1775232149323}
   ]

--- a/.kan/boards/bugfixes/cards/a_sBT32BJP.json
+++ b/.kan/boards/bugfixes/cards/a_sBT32BJP.json
@@ -5,7 +5,8 @@
   "column": "todo-lo",
   "created_at_millis": 1775232154162,
   "creator": "Alexander Terp",
-  "description": "When a void function result is placed in a list or map literal, the entry is silently removed rather than producing an error.\n\n**Repro:**\n```\nfn do_nothing():\n    pass\n\nitems = [do_nothing(), 1, 2]\nprint(items)  // [1, 2] (void element silently dropped)\n\nm = {\"a\": do_nothing(), \"b\": 2}\nprint(m)  // {\"b\": 2} (void entry silently dropped)\n\nresult = [do_nothing() for x in [1, 2, 3]]\nprint(result)  // [] (all void results dropped)\n```\n\nThis can cause confusing bugs when a function was supposed to return a value but doesn't.\n\n**Test files:** `bugs/functions/t69_fn_void_in_list.rad`, `t98_fn_comprehension_void.rad`, `t101_fn_void_in_map.rad`",
+  "description": "RE-VERIFIED 2026-06-14 (rad v0.10.1): still reproduces in all three forms (list, map, comprehension).\n\nWhen a void function result is placed in a list or map literal, the entry is silently removed rather than producing an error.\n\n**Repro:**\nfn do_nothing():\n    pass\n\nitems = [do_nothing(), 1, 2]\nprint(items)   // [1, 2]   (void element silently dropped)\n\nm = {\"a\": do_nothing(), \"b\": 2}\nprint(m)       // {\"b\": 2}  (void entry silently dropped)\n\nresult = [do_nothing() for x in [1, 2, 3]]\nprint(result)  // []        (all void results dropped)\n\nThis can hide confusing bugs when a function was supposed to return a value but does not.\n\n**Design question:** error on void in a collection literal, or keep the silent-filter behavior.",
+  "grammar": false,
   "id": "a_sBT32BJP",
   "position": "UU",
   "severity": "medium",
@@ -13,7 +14,7 @@
     "design"
   ],
   "title": "Void values silently dropped from collections",
-  "updated_at_millis": 1775233427199,
+  "updated_at_millis": 1781449671663,
   "history": [
     {"field":"column","value":"todo-lo","at":1775232154162}
   ]

--- a/.kan/boards/bugfixes/cards/a_sBTDjj0k.json
+++ b/.kan/boards/bugfixes/cards/a_sBTDjj0k.json
@@ -5,7 +5,8 @@
   "column": "todo-lo",
   "created_at_millis": 1775232160794,
   "creator": "Alexander Terp",
-  "description": "`and` always returns a boolean, but `or` returns the actual operand value (short-circuit semantics). These should be consistent.\n\n**Repro:**\n```\nprint(1 and 2)   // true (boolean)\nprint(1 or 2)    // 1 (the operand value)\nprint(0 or 2)    // 2 (the operand value)\n```\n\nUsers coming from Python/JS expect both to return operand values (short-circuit), or both to return booleans.\n\n**Test files:** `bugs/operators/72_and_or_return_value.rad`, `78_and_return_inconsistency.rad`, `114_and_or_value_detail.rad`",
+  "description": "RE-VERIFIED 2026-06-14 (rad v0.10.1): still reproduces.\n\n`and` always returns a boolean, but `or` returns the actual operand value (short-circuit semantics). These are inconsistent.\n\n**Repro:**\nprint(1 and 2)   // true  (boolean)\nprint(1 or 2)    // 1     (the operand value)\nprint(0 or 2)    // 2     (the operand value)\n\n**Source:** `core/expr_ops.go:61-75` (and returns bool; or returns the operand).\n\nUsers from Python/JS expect both to return operand values (short-circuit), or both to return booleans.\n\n**Design question:** unify the two - and changing either is a potentially breaking semantic change.",
+  "grammar": false,
   "id": "a_sBTDjj0k",
   "position": "YQ",
   "severity": "medium",
@@ -13,7 +14,7 @@
     "design"
   ],
   "title": "and returns bool while or returns operand value - inconsistent",
-  "updated_at_millis": 1775233426117,
+  "updated_at_millis": 1781449671746,
   "history": [
     {"field":"column","value":"todo-lo","at":1775232160794}
   ]

--- a/.kan/boards/bugfixes/cards/a_sBTJUILR.json
+++ b/.kan/boards/bugfixes/cards/a_sBTJUILR.json
@@ -5,12 +5,16 @@
   "column": "todo-lo",
   "created_at_millis": 1775232164365,
   "creator": "Alexander Terp",
-  "description": "`\\{` correctly produces a literal `{` to prevent interpolation, but `\\}` does NOT produce a literal `}` - it produces the literal two characters `\\}`.\n\n**Repro:**\n```\nprint(\"\\{ and \\}\")\n// Expected: { and }\n// Actual:   { and \\}\n```\n\nMinor inconsistency but surprising when users discover it.\n\n**Test files:** `bugs/strings/str_escape_brace_closing.rad`",
+  "description": "RE-VERIFIED 2026-06-14 (rad v0.10.1): still reproduces.\n\n`\\{` correctly produces a literal `{` to prevent interpolation, but `\\}` does NOT produce a literal `}` - it produces the literal two characters `\\}`.\n\n**Repro:**\nprint(\"\\{ and \\}\")\n// Expected: { and }\n// Actual:   { and \\}   (the \\} stays as backslash-brace)\n\nMinor inconsistency but surprising when users discover it.\n\n**Fix (slam dunk):** add a `\\}` escape handler mirroring `\\{` (around rts/converter.go:1338). Pure symmetry, low risk.",
+  "grammar": true,
   "id": "a_sBTJUILR",
   "position": "cM",
   "severity": "low",
+  "tags": [
+    "quick-win"
+  ],
   "title": "Closing brace escape \\} does not work (asymmetry with \\{)",
-  "updated_at_millis": 1775232164365,
+  "updated_at_millis": 1781449558789,
   "history": [
     {"field":"column","value":"todo-lo","at":1775232164365}
   ]

--- a/.kan/boards/bugfixes/cards/a_sBTYIo6x.json
+++ b/.kan/boards/bugfixes/cards/a_sBTYIo6x.json
@@ -5,12 +5,16 @@
   "column": "todo-lo",
   "created_at_millis": 1775232173549,
   "creator": "Alexander Terp",
-  "description": "When calling zip() with fill=null, the result is truncated to the shortest list - same as calling zip() with no fill. But fill=0, fill=false, fill=\"\" all correctly pad to the longest.\n\n**Repro:**\n```\na = [1, 2, 3]\nb = [4, 5]\nprint(zip(a, b, fill=null))\n// Truncated: [[1, 4], [2, 5]] (same as no fill)\n// Expected: [[1, 4], [2, 5], [3, null]]\n```\n\n**Root cause:** `core/funcs.go` line 950: fill param default is null, and code checks IsNull() to decide truncate vs pad. Explicit fill=null is indistinguishable from \"not provided.\"\n\n**Test files:** `bugs/control_flow/92_zip_fill_null_detailed.rad`",
+  "description": "RE-VERIFIED 2026-06-14 (rad v0.10.1): still reproduces.\n\nCalling zip() with fill=null truncates to the shortest list - same as no fill. But fill=0, fill=false, fill=\"\" all correctly pad to the longest.\n\n**Repro:**\na = [1, 2, 3]\nb = [4, 5]\nprint(zip(a, b, fill=null))\n// Actual:   [[1, 4], [2, 5]]            (truncated, same as no fill)\n// Expected: [[1, 4], [2, 5], [3, null]]\n\n**Root cause:** `core/funcs.go:~966` (was cited as :950) - the fill default is null and the code checks IsNull() to decide truncate-vs-pad, so explicit fill=null is indistinguishable from \"not provided.\"\n\n**Design/impl:** track whether the fill arg was explicitly passed rather than using null as the sentinel.",
+  "grammar": false,
   "id": "a_sBTYIo6x",
   "position": "gI",
-  "severity": "low",
+  "severity": "medium",
+  "tags": [
+    "design"
+  ],
   "title": "zip(fill=null) behaves same as no fill argument",
-  "updated_at_millis": 1775232173549,
+  "updated_at_millis": 1781449671844,
   "history": [
     {"field":"column","value":"todo-lo","at":1775232173549}
   ]

--- a/.kan/boards/bugfixes/cards/a_sBTjzlaD.json
+++ b/.kan/boards/bugfixes/cards/a_sBTjzlaD.json
@@ -5,12 +5,16 @@
   "column": "todo-lo",
   "created_at_millis": 1775232180791,
   "creator": "Alexander Terp",
-  "description": "All case expressions in a switch are evaluated before matching, including those after the matching case. Functions with side effects in case expressions will execute for every case.\n\n**Repro:**\n```\nfn log(x):\n    print(\"evaluating: {x}\")\n    return x\n\nswitch 1:\n    case log(1):\n        print(\"matched 1\")\n    case log(2):\n        print(\"matched 2\")\n// Output includes \"evaluating: 1\" AND \"evaluating: 2\"\n// plus if multiple cases match, error RAD20035\n```\n\nMost switch implementations use lazy evaluation (stop after first match).\n\n**Test files:** `bugs/control_flow/54_switch_case_side_effects.rad`",
+  "description": "RE-VERIFIED 2026-06-14 (rad v0.10.1): still reproduces. (Note: real case syntax is single-line `case X -\u003e body`, not the `case X:` originally shown.)\n\nAll case expressions in a switch are evaluated before matching, including those after the matching case. Functions with side effects in case expressions execute for every case.\n\n**Repro:**\nfn log_(x):\n    print(\"evaluating: {x}\")\n    return x\n\nswitch 1:\n    case log_(1) -\u003e print(\"matched 1\")\n    case log_(2) -\u003e print(\"matched 2\")\n// prints \"evaluating: 1\" AND \"evaluating: 2\", then \"matched 1\"\n\n**Source:** `core/interpreter.go:451-459` loops through all cases and calls eval(key) on every case key before matching.\n\n**Design:** switch to lazy evaluation (stop after the first match) - a control-flow change.",
+  "grammar": false,
   "id": "a_sBTjzlaD",
   "position": "kE",
   "severity": "medium",
+  "tags": [
+    "design"
+  ],
   "title": "Switch evaluates ALL case expressions eagerly, even after match found",
-  "updated_at_millis": 1775232180791,
+  "updated_at_millis": 1781449671927,
   "history": [
     {"field":"column","value":"todo-lo","at":1775232180791}
   ]

--- a/.kan/boards/bugfixes/cards/a_sBTqWVMa.json
+++ b/.kan/boards/bugfixes/cards/a_sBTqWVMa.json
@@ -5,7 +5,8 @@
   "column": "todo-lo",
   "created_at_millis": 1775232184848,
   "creator": "Alexander Terp",
-  "description": "When the left and right sides of a multiple assignment have different counts, no error is raised. Extra values are silently dropped, missing values become null.\n\n**Repro:**\n```\na, b = 1, 2, 3\nprint(a, b)    // 1, 2 (3 silently dropped)\n\nc, d, e = 1, 2\nprint(c, d, e) // 1, 2, null (e silently set to null)\n```\n\nBoth should produce errors to catch typos and logic mistakes.\n\n**Test files:** `bugs/operators/31_multiple_assignment.rad`, `32_multi_assign_too_many.rad`",
+  "description": "RE-VERIFIED 2026-06-14 (rad v0.10.1): still reproduces.\n\nWhen the left and right sides of a multiple assignment have different counts, no error is raised: extra values are silently dropped, missing values become null.\n\n**Repro:**\na, b = 1, 2, 3\nprint(a, b)     // 1 2      (3 silently dropped)\n\nc, d, e = 1, 2\nprint(c, d, e)  // 1 2 null (e silently set to null)\n\n**Design question:** both should arguably error to catch typos and logic mistakes (vs the current asymmetric drop/null-fill).",
+  "grammar": false,
   "id": "a_sBTqWVMa",
   "position": "oA",
   "severity": "medium",
@@ -13,7 +14,7 @@
     "design"
   ],
   "title": "Multiple assignment silently handles count mismatches",
-  "updated_at_millis": 1775233427742,
+  "updated_at_millis": 1781449672010,
   "history": [
     {"field":"column","value":"todo-lo","at":1775232184848}
   ]

--- a/.kan/boards/bugfixes/cards/a_sBTwEeRL.json
+++ b/.kan/boards/bugfixes/cards/a_sBTwEeRL.json
@@ -5,12 +5,13 @@
   "column": "todo-lo",
   "created_at_millis": 1775232188385,
   "creator": "Alexander Terp",
-  "description": "A function that calls itself infinitely runs forever with no stack overflow detection or recursion depth limit.\n\n**Repro:**\n```\nfn infinite():\n    return infinite()\n\ninfinite()  // Hangs forever, must kill process\n```\n\nMost languages impose a recursion limit (e.g. Python's default 1000). Without one, accidental infinite recursion requires the user to manually kill the process.\n\n**Test files:** `bugs/functions/t124_fn_recursive_depth_limit.rad`",
+  "description": "RE-VERIFIED 2026-06-14 (rad v0.10.1): no recursion depth limit; deep self-recursion now hits a raw Go `fatal error: stack overflow` (exit code 2) rather than a clean rad error. (Originally reported as \"hangs forever\"; current behavior is a Go-level crash.)\n\n**Repro:**\nfn infinite():\n    return infinite()\n\ninfinite()   // -\u003e fatal error: stack overflow (Go runtime, ~1GB stack)\n\nMost languages impose a recursion limit (e.g. Python's ~1000) and raise a clean error.\n\n**Fix:** add a call-depth counter in the interpreter and emit a clean rad error past a limit. Pairs with the circular-data crash (both are unbounded recursion crashing Go).",
+  "grammar": false,
   "id": "a_sBTwEeRL",
   "position": "s6",
-  "severity": "low",
+  "severity": "high",
   "title": "Infinite recursion has no depth limit - must be killed externally",
-  "updated_at_millis": 1775232188385,
+  "updated_at_millis": 1781449744256,
   "history": [
     {"field":"column","value":"todo-lo","at":1775232188385}
   ]

--- a/.kan/boards/bugfixes/cards/a_sBUAtQm4.json
+++ b/.kan/boards/bugfixes/cards/a_sBUAtQm4.json
@@ -5,12 +5,16 @@
   "column": "todo-lo",
   "created_at_millis": 1775232197480,
   "creator": "Alexander Terp",
-  "description": "The `in` operator inconsistently coerces types when checking string containment. int is silently coerced to string, but float and bool are not.\n\n**Repro:**\n```\nprint(1 in \"hello123\")     // true (int coerced to \"1\")\nprint(3.14 in \"3.14159\")   // Error (float not coerced)\nprint(true in \"truefalse\")  // Error (bool not coerced)\n```\n\nEither all should coerce or none should.\n\n**Test files:** `bugs/operators/49_int_in_string.rad`, `51_in_coercion.rad`, `51b_in_coercion2.rad`",
+  "description": "RE-VERIFIED 2026-06-14 (rad v0.10.1): still reproduces.\n\nThe `in` operator inconsistently coerces types in string-containment checks: int is silently coerced to string, but float and bool are not.\n\n**Repro:**\nprint(1 in \"hello123\")      // true               (int coerced to \"1\")\nprint(3.14 in \"3.14159\")    // error[RAD30002]    (float not coerced)\nprint(true in \"truefalse\")  // error              (bool not coerced)\n\n**Source:** `core/expr_ops.go:~152` - the int+string case uses fmt.Sprintf coercion; there is no float+string or bool+string case.\n\n**Design question:** coerce all numeric/bool types consistently, or forbid coercion entirely (the latter is a breaking change for int).",
+  "grammar": false,
   "id": "a_sBUAtQm4",
   "position": "w2",
-  "severity": "low",
+  "severity": "medium",
+  "tags": [
+    "design"
+  ],
   "title": "int in str coerces but float in str and bool in str do not",
-  "updated_at_millis": 1775232197480,
+  "updated_at_millis": 1781449711601,
   "history": [
     {"field":"column","value":"todo-lo","at":1775232197480}
   ]

--- a/.kan/boards/bugfixes/config.toml
+++ b/.kan/boards/bugfixes/config.toml
@@ -67,3 +67,8 @@ name = "bugfixes"
       color = "#8b5cf6"
       description = "Requires language design thinking"
       value = "design"
+
+    [[custom_fields.tags.options]]
+      color = "#22c55e"
+      description = "Clear, low-risk, contained fix with an obvious-correct answer"
+      value = "quick-win"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -264,6 +264,7 @@ make test         # Run tests in core/testing
 - Test resources in `core/testing/resources/`
 - Syntax tree snapshot tests in `rts/test/` - each case captures both CST and AST dumps side-by-side
 - Converter unit tests in `rts/converter_test.go`
+- Regenerate snapshots with a **targeted** `-update`, e.g. `go test ./core/testing/ -run TestSnapshots -update=types/str_lexing` (path-substring match; comma-separate multiple). A mismatch in a non-targeted file still fails, so regressions aren't silently absorbed. `-update-all` rewrites everything (avoid). Write the value with `=`; a bare `-update` errors.
 
 ### Key Dependencies
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,6 +65,33 @@ Or use the dev script for a more comprehensive validation (includes formatting, 
 ./dev --validate
 ```
 
+#### Updating Snapshots
+
+A lot of our tests are snapshot tests - they define some input and assert against
+captured output (`core/testing/snapshots/`, `rts/test/st_snapshots/`,
+`rts/check/snapshots/`, `rts/radfmt/snapshots/`, `radls/lstesting/snapshots/`).
+
+When you intentionally change behavior, regenerate the affected expected outputs
+with `-update` - but **scope it to the files you actually changed**:
+
+```shell
+# Rewrite only snapshot files whose path contains the substring(s):
+go test ./core/testing/ -run TestSnapshots -update=types/str_lexing
+go test ./core/testing/ -run TestSnapshots -update=errors/validation,control_flow
+
+# Rewrite every snapshot (use sparingly):
+go test ./core/testing/ -update-all
+```
+
+`-update` is deliberately targeted: a mismatch in a file you did **not** target
+still fails the test, so an unrelated regression can't be silently baked into a
+snapshot. Prefer it over `-update-all`, and always review `git diff` on the
+`.snap` files afterward.
+
+Write the value with `=` (`-update=foo`). A bare `-update` errors, and
+`-update -run X` would swallow `-run` as the update value (the test guards against
+this and tells you).
+
 #### Quick Platform Testing
 
 Rad supports Linux, macOS, and Windows. PR checks automatically run Go tests on all three platforms.

--- a/core/error_docs/20017.md
+++ b/core/error_docs/20017.md
@@ -1,15 +1,18 @@
 # RAD20017: Number Out of Range
 
-A numeric value is outside the valid range for the operation.
+A numeric value is outside the valid range accepted by an operation.
 
 ## Example
 
 ```rad
-// Integer overflow
-big = 99999999999999999999999
-x = int(big)  // Exceeds int64 range
+x = round(3.14159, -2)  // Error: precision must be non-negative
 ```
 
 ## How to Fix
 
-Check that values are within acceptable bounds before the operation. For integers, the valid range is roughly -9 quintillion to +9 quintillion (int64 limits).
+Check that values are within the bounds the operation accepts. For example,
+`round` requires a non-negative precision, `to_json` a non-negative indent, and
+`range` a non-zero step.
+
+(An integer *literal* that doesn't fit in an int64 is a separate, compile-time
+error - see RAD40015.)

--- a/core/error_docs/40015.md
+++ b/core/error_docs/40015.md
@@ -1,0 +1,29 @@
+# RAD40015: Integer Literal Out of Range
+
+An integer literal was written whose value does not fit in a signed 64-bit
+integer. Rad integers are 64-bit, so a literal must be in the range
+-9223372036854775808 to 9223372036854775807.
+
+## Example
+
+```rad
+x = 9223372036854775808   // Error: one past the maximum int64
+```
+
+These are fine:
+
+```rad
+biggest = 9223372036854775807   // the maximum int64
+million = 1_000_000             // underscores are allowed as digit separators
+print(biggest, million)
+```
+
+## What This Means
+
+The literal's magnitude exceeds what an `int` can hold. Note that the most
+negative value cannot be written directly as `-9223372036854775808`, because the
+literal `9223372036854775808` is parsed (and range-checked) on its own before the
+unary minus applies.
+
+Write the minimum value as `-9223372036854775807 - 1`, or use a `float` if you
+need to represent larger magnitudes (with reduced precision).

--- a/core/testing/docs_snippet_tolerances.go
+++ b/core/testing/docs_snippet_tolerances.go
@@ -167,6 +167,11 @@ var docSnippetTolerances = map[string]Tolerance{
 		Reason:        "demo: typo'd map key 'fjull_path' not in get_path's typed-map return shape.",
 	},
 
+	"core/error_docs/40015.md#94f07ed8": {
+		ExpectedCodes: []string{"RAD40015"},
+		Reason:        "demo: int literal one past the int64 max.",
+	},
+
 	"core/error_docs/20028.md#a34c5fb8": {
 		ExpectedCodes: []string{"RAD20028"},
 		Reason:        "demo: typo'd identifier ('usernme' vs 'username').",

--- a/core/testing/snapshot.go
+++ b/core/testing/snapshot.go
@@ -12,8 +12,68 @@ import (
 	gd "github.com/amterp/go-delta"
 )
 
-// UpdateSnapshots is set by the -update flag to regenerate expected outputs
-var UpdateSnapshots = flag.Bool("update", false, "update snapshot expected outputs")
+// Snapshot updating is opt-in and targeted by default, to stop a stray
+// `-update` from silently rewriting every snapshot to match current behavior
+// (which masks unrelated regressions). Pass `-update=<substr>[,<substr>...]` to
+// rewrite only the snapshot files whose path contains one of the substrings;
+// any mismatch in a non-targeted file still fails the test, so regressions
+// elsewhere surface loudly. Use `-update-all` for the rare blanket rewrite.
+//
+//	go test ./core/testing/ -run TestSnapshots -update=types/str_lexing
+//	go test ./core/testing/ -run TestSnapshots -update=errors/validation,types
+//	go test ./core/testing/ -run TestSnapshots -update-all
+var (
+	updateTargets = flag.String("update", "",
+		"comma-separated snapshot path substrings to rewrite (e.g. types/str_lexing); "+
+			"non-matching mismatches still fail. Use -update-all to rewrite everything.")
+	updateAll = flag.Bool("update-all", false,
+		"rewrite ALL snapshot expected outputs - prefer -update=<substr> to scope and avoid masking regressions")
+)
+
+// updateTargetList returns the trimmed, non-empty -update substrings.
+func updateTargetList() []string {
+	if strings.TrimSpace(*updateTargets) == "" {
+		return nil
+	}
+	var out []string
+	for _, t := range strings.Split(*updateTargets, ",") {
+		if t = strings.TrimSpace(t); t != "" {
+			out = append(out, t)
+		}
+	}
+	return out
+}
+
+// ShouldUpdateSnapshotFile reports whether the snapshot file at the given path
+// should be rewritten this run: true under -update-all, or when the path
+// contains any -update substring. Matching on the path means a target like
+// "types/str_lexing" or just "str_lexing" both work, and it's agnostic to each
+// caller's snapshot-directory layout.
+func ShouldUpdateSnapshotFile(path string) bool {
+	if *updateAll {
+		return true
+	}
+	for _, target := range updateTargetList() {
+		if strings.Contains(path, target) {
+			return true
+		}
+	}
+	return false
+}
+
+// CheckSnapshotUpdateFlags fails fast on common -update misuse. Call once at the
+// top of a snapshot test. The main trap is `-update -run X`: because -update now
+// takes a value, the flag parser swallows `-run` as that value. Catch the
+// flag-shaped target and point the user at the `=` form.
+func CheckSnapshotUpdateFlags(t *testing.T) {
+	t.Helper()
+	for _, target := range updateTargetList() {
+		if strings.HasPrefix(target, "-") {
+			t.Fatalf("-update value %q looks like a flag - write `-update=<path-substr>` "+
+				"(e.g. -update=types/str_lexing), or -update-all to rewrite everything", target)
+		}
+	}
+}
 
 const (
 	TitleDelimiter       = "### TITLE ###"
@@ -506,7 +566,12 @@ type SnapshotResult struct {
 // CompareSnapshotResult compares actual output against expected.
 // Returns true if the snapshot needs updating.
 // In update mode, it does not fail the test on mismatch.
-func CompareSnapshotResult(t *testing.T, tc *SnapshotCase, actual SnapshotResult) bool {
+// CompareSnapshotResult compares actual output against the expected case and
+// returns whether they differ (i.e. the snapshot needs rewriting). When
+// `updating` is true the diff is suppressed (the caller will rewrite this file);
+// otherwise a mismatch fails the test - so a scoped `-update` still catches
+// regressions in files it isn't rewriting.
+func CompareSnapshotResult(t *testing.T, tc *SnapshotCase, actual SnapshotResult, updating bool) bool {
 	t.Helper()
 
 	needsUpdate := false
@@ -514,7 +579,7 @@ func CompareSnapshotResult(t *testing.T, tc *SnapshotCase, actual SnapshotResult
 	// Compare stdout
 	if actual.Stdout != tc.Stdout {
 		needsUpdate = true
-		if !*UpdateSnapshots {
+		if !updating {
 			t.Errorf("Stdout mismatch:\n%s", gd.DiffWith(tc.Stdout, actual.Stdout, gd.WithColor(true), gd.WithLayout(gd.LayoutPreferSideBySide), gd.WithWidth(120)))
 		}
 	}
@@ -522,7 +587,7 @@ func CompareSnapshotResult(t *testing.T, tc *SnapshotCase, actual SnapshotResult
 	// Compare stderr
 	if actual.Stderr != tc.Stderr {
 		needsUpdate = true
-		if !*UpdateSnapshots {
+		if !updating {
 			t.Errorf("Stderr mismatch:\n%s", gd.DiffWith(tc.Stderr, actual.Stderr, gd.WithColor(true), gd.WithLayout(gd.LayoutPreferSideBySide), gd.WithWidth(120)))
 		}
 	}
@@ -530,7 +595,7 @@ func CompareSnapshotResult(t *testing.T, tc *SnapshotCase, actual SnapshotResult
 	// Compare interactive frames
 	if actual.Frames != tc.Frames {
 		needsUpdate = true
-		if !*UpdateSnapshots {
+		if !updating {
 			t.Errorf("Frames mismatch:\n%s", gd.DiffWith(tc.Frames, actual.Frames, gd.WithColor(true), gd.WithLayout(gd.LayoutPreferSideBySide), gd.WithWidth(120)))
 		}
 	}
@@ -538,7 +603,7 @@ func CompareSnapshotResult(t *testing.T, tc *SnapshotCase, actual SnapshotResult
 	// Compare exit code
 	if actual.ExitCode != tc.ExitCode {
 		needsUpdate = true
-		if !*UpdateSnapshots {
+		if !updating {
 			t.Errorf("Exit code mismatch\nExpected: %d\nActual: %d", tc.ExitCode, actual.ExitCode)
 		}
 	}

--- a/core/testing/snapshot_test.go
+++ b/core/testing/snapshot_test.go
@@ -44,6 +44,8 @@ func runSnapshotDirectory(t *testing.T, snapshotDir string) {
 		return
 	}
 
+	CheckSnapshotUpdateFlags(t)
+
 	// Track which files need updating (thread-safe for consistency,
 	// even though tests don't run in parallel due to shared global state)
 	var updateMu sync.Mutex
@@ -79,7 +81,8 @@ func runSnapshotDirectory(t *testing.T, snapshotDir string) {
 					ExitCode: getExitCode(),
 				}
 
-				if CompareSnapshotResult(t, tc, actual) {
+				updating := ShouldUpdateSnapshotFile(snapFile)
+				if CompareSnapshotResult(t, tc, actual, updating) && updating {
 					updateMu.Lock()
 					tc.Stdout = actual.Stdout
 					tc.Stderr = actual.Stderr
@@ -92,15 +95,14 @@ func runSnapshotDirectory(t *testing.T, snapshotDir string) {
 		}
 	}
 
-	// Write updates if in update mode
-	if *UpdateSnapshots {
-		for path, cases := range filesToUpdate {
-			err := WriteSnapshotFile(path, cases)
-			if err != nil {
-				t.Errorf("Failed to update snapshot file %s: %v", path, err)
-			} else {
-				t.Logf("Updated snapshot file: %s", path)
-			}
+	// Rewrite the snapshot files we targeted. filesToUpdate only holds files
+	// selected by -update / -update-all (it's empty otherwise), so there's no
+	// separate "are we updating?" guard here.
+	for path, cases := range filesToUpdate {
+		if err := WriteSnapshotFile(path, cases); err != nil {
+			t.Errorf("Failed to update snapshot file %s: %v", path, err)
+		} else {
+			t.Logf("Updated snapshot file: %s", path)
 		}
 	}
 }

--- a/core/testing/snapshots/errors/validation/int_literal_out_of_range.snap
+++ b/core/testing/snapshots/errors/validation/int_literal_out_of_range.snap
@@ -1,0 +1,39 @@
+### TITLE ###
+Int literal above max int64
+### DESCRIPTION ###
+An int literal past the int64 max is a clean RAD40015, not a raw Go panic.
+### INPUT ###
+x = 9223372036854775808
+### STDERR ###
+error[RAD40015]: Integer literal is out of range
+  --> <script>:1:5
+  |
+1 | x = 9223372036854775808
+  |     ^^^^^^^^^^^^^^^^^^^
+  |
+   = help: int values must fit in a signed 64-bit integer (max 9223372036854775807). Write the minimum as `-9223372036854775807 - 1`, or use a float for larger magnitudes.
+   = info: rad explain RAD40015
+
+
+### EXIT ###
+1
+### TITLE ###
+Min int64 literal cannot be written directly
+### DESCRIPTION ###
+-9223372036854775808 parses as unary minus over a literal that overflows on its
+own, so it is flagged; the suggestion points at the -...807 - 1 workaround.
+### INPUT ###
+x = -9223372036854775808
+### STDERR ###
+error[RAD40015]: Integer literal is out of range
+  --> <script>:1:6
+  |
+1 | x = -9223372036854775808
+  |      ^^^^^^^^^^^^^^^^^^^
+  |
+   = help: int values must fit in a signed 64-bit integer (max 9223372036854775807). Write the minimum as `-9223372036854775807 - 1`, or use a float for larger magnitudes.
+   = info: rad explain RAD40015
+
+
+### EXIT ###
+1

--- a/core/testing/snapshots/types/str_lexing.snap
+++ b/core/testing/snapshots/types/str_lexing.snap
@@ -481,3 +481,29 @@ error[RAD20028]: Undefined identifier 'text'
 
 ### EXIT ###
 1
+### TITLE ###
+StrLexing Multiline ContentLessIndentedThanClosing
+### DESCRIPTION ###
+A content line indented less than the closing triple-quote gets a targeted
+indentation message rather than the generic "Unexpected ...".
+### INPUT ###
+text = """
+hi
+    """
+print(text)
+### STDERR ###
+error[RAD10009]: Multi-line string content is indented less than its closing """
+  --> <script>:2:1
+  |
+1 | text = """
+2 | hi
+  | ^^
+3 |     """
+4 | print(text)
+  |
+   = help: indent every content line at least as much as the closing """ (or move the closing """ to column 0)
+   = info: rad explain RAD10009
+
+
+### EXIT ###
+1

--- a/dev
+++ b/dev
@@ -10,7 +10,7 @@ args:
     build b bool      # Enable to build.
     validate v bool   # Enable to build & test.
     test t bool       # Enable to run tests once.
-    update u bool     # Enable to update snapshot tests with current output.
+    update u bool     # Enable to update ALL snapshot tests with current output. For a scoped update, run `go test <pkg> -update=<path-substr>` directly.
     bump bool         # Enable to bump all dependency versions in go.mod.
 
     release range [1, 3]
@@ -30,7 +30,9 @@ if build:
     $`make build`
 
 if update:
-    $`go test ./core/testing/... ./rts/... ./radls/lstesting/... -args -update`
+    // Scoped to packages that own snapshot suites (and thus register the flag);
+    // ./rts/... would also pull in rts/rl & rts/test, which don't define it.
+    $`go test ./core/testing/... ./rts ./rts/check/... ./rts/radfmt/... ./radls/lstesting/... -args -update-all`
 else if test:
     $`make test`
 

--- a/docs-web/docs/reference/errors.md
+++ b/docs-web/docs/reference/errors.md
@@ -807,19 +807,22 @@ n = parse_int(raw) catch:
 
 ### RAD20017: Number Out of Range
 
-A numeric value is outside the valid range for the operation.
+A numeric value is outside the valid range accepted by an operation.
 
 #### Example
 
 ```rad
-// Integer overflow
-big = 99999999999999999999999
-x = int(big)  // Exceeds int64 range
+x = round(3.14159, -2)  // Error: precision must be non-negative
 ```
 
 #### How to Fix
 
-Check that values are within acceptable bounds before the operation. For integers, the valid range is roughly -9 quintillion to +9 quintillion (int64 limits).
+Check that values are within the bounds the operation accepts. For example,
+`round` requires a non-negative precision, `to_json` a non-negative indent, and
+`range` a non-zero step.
+
+(An integer *literal* that doesn't fit in an int64 is a separate, compile-time
+error - see RAD40015.)
 
 ### RAD20018: Empty List
 
@@ -2324,3 +2327,33 @@ left alone.
 Optional keys (declared with `?`, e.g. `get_path`'s `size_bytes?`)
 are considered valid keys: accessing one resolves its type and does
 not fire here, even though the key may be absent at runtime.
+
+### RAD40015: Integer Literal Out of Range
+
+An integer literal was written whose value does not fit in a signed 64-bit
+integer. Rad integers are 64-bit, so a literal must be in the range
+-9223372036854775808 to 9223372036854775807.
+
+#### Example
+
+```rad
+x = 9223372036854775808   // Error: one past the maximum int64
+```
+
+These are fine:
+
+```rad
+biggest = 9223372036854775807   // the maximum int64
+million = 1_000_000             // underscores are allowed as digit separators
+print(biggest, million)
+```
+
+#### What This Means
+
+The literal's magnitude exceeds what an `int` can hold. Note that the most
+negative value cannot be written directly as `-9223372036854775808`, because the
+literal `9223372036854775808` is parsed (and range-checked) on its own before the
+unary minus applies.
+
+Write the minimum value as `-9223372036854775807 - 1`, or use a `float` if you
+need to represent larger magnitudes (with reduced precision).

--- a/radls/lstesting/snapshot.go
+++ b/radls/lstesting/snapshot.go
@@ -7,11 +7,63 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"testing"
 
 	"github.com/amterp/rad/radls/lsp"
 )
 
-var UpdateSnapshots = flag.Bool("update", false, "update snapshot expected outputs")
+// Snapshot updating is opt-in and targeted by default so a stray `-update`
+// can't silently rewrite every snapshot (masking unrelated regressions). Pass
+// `-update=<substr>[,<substr>...]` to rewrite only matching files; mismatches
+// elsewhere still fail. Use `-update-all` for the rare blanket rewrite. This
+// mirrors core/testing's snapshot flags for a consistent contributor workflow.
+var (
+	updateTargets = flag.String("update", "",
+		"comma-separated snapshot path substrings to rewrite; "+
+			"non-matching mismatches still fail. Use -update-all to rewrite everything.")
+	updateAll = flag.Bool("update-all", false,
+		"rewrite ALL snapshot expected outputs - prefer -update=<substr> to scope and avoid masking regressions")
+)
+
+func updateTargetList() []string {
+	if strings.TrimSpace(*updateTargets) == "" {
+		return nil
+	}
+	var out []string
+	for _, t := range strings.Split(*updateTargets, ",") {
+		if t = strings.TrimSpace(t); t != "" {
+			out = append(out, t)
+		}
+	}
+	return out
+}
+
+// shouldUpdateSnapshotFile reports whether the snapshot file at path should be
+// rewritten this run: true under -update-all, or when the path contains any
+// -update substring.
+func shouldUpdateSnapshotFile(path string) bool {
+	if *updateAll {
+		return true
+	}
+	for _, target := range updateTargetList() {
+		if strings.Contains(path, target) {
+			return true
+		}
+	}
+	return false
+}
+
+// checkSnapshotUpdateFlags fails fast on the `-update -run X` trap, where the
+// flag parser swallows `-run` as -update's value. Call once per snapshot test.
+func checkSnapshotUpdateFlags(t *testing.T) {
+	t.Helper()
+	for _, target := range updateTargetList() {
+		if strings.HasPrefix(target, "-") {
+			t.Fatalf("-update value %q looks like a flag - write `-update=<path-substr>`, "+
+				"or -update-all to rewrite everything", target)
+		}
+	}
+}
 
 // Action delimiters. Each request-shaped action has its own header
 // because the LSP wire methods take different parameter shapes -

--- a/radls/lstesting/snapshot_test.go
+++ b/radls/lstesting/snapshot_test.go
@@ -48,6 +48,8 @@ func runSnapshotDirectory(t *testing.T, snapshotDir string) {
 		return
 	}
 
+	checkSnapshotUpdateFlags(t)
+
 	var updateMu sync.Mutex
 	filesToUpdate := make(map[string][]SnapshotCase)
 
@@ -72,7 +74,7 @@ func runSnapshotDirectory(t *testing.T, snapshotDir string) {
 				require.NoError(t, err, "Harness should run without error")
 
 				if actual != tc.Stdout {
-					if *UpdateSnapshots {
+					if shouldUpdateSnapshotFile(snapFile) {
 						updateMu.Lock()
 						tc.Stdout = actual
 						filesToUpdate[snapFile] = cases
@@ -89,17 +91,15 @@ func runSnapshotDirectory(t *testing.T, snapshotDir string) {
 		}
 	}
 
-	// Write updates after all subtests complete
-	if *UpdateSnapshots {
-		t.Cleanup(func() {
-			for path, cases := range filesToUpdate {
-				err := WriteSnapshotFile(path, cases)
-				if err != nil {
-					t.Errorf("Failed to update snapshot file %s: %v", path, err)
-				} else {
-					t.Logf("Updated snapshot file: %s", path)
-				}
+	// Write updates after all subtests complete. filesToUpdate only holds files
+	// selected by -update / -update-all.
+	t.Cleanup(func() {
+		for path, cases := range filesToUpdate {
+			if err := WriteSnapshotFile(path, cases); err != nil {
+				t.Errorf("Failed to update snapshot file %s: %v", path, err)
+			} else {
+				t.Logf("Updated snapshot file: %s", path)
 			}
-		})
-	}
+		}
+	})
 }

--- a/rts/check/check.go
+++ b/rts/check/check.go
@@ -1,6 +1,9 @@
 package check
 
 import (
+	"errors"
+	"strconv"
+
 	"github.com/amterp/rad/rts"
 	"github.com/amterp/rad/rts/rl"
 	ts "github.com/tree-sitter/go-tree-sitter"
@@ -75,6 +78,7 @@ func (c *RadCheckerImpl) SetStrict(strict bool) {
 func (c *RadCheckerImpl) Check() (Result, error) {
 	diagnostics := make([]Diagnostic, 0)
 	c.addInvalidNodes(&diagnostics)
+	c.addIntLiteralOutOfRangeErrors(&diagnostics)
 	c.addIntScientificNotationErrors(&diagnostics)
 	c.addFnParamScientificNotationErrors(&diagnostics)
 
@@ -257,6 +261,25 @@ func nodeSrc(n *ts.Node, src string) string {
 		return ""
 	}
 	return src[start:end]
+}
+
+// addIntLiteralOutOfRangeErrors flags integer literals whose value doesn't fit in
+// a signed 64-bit int. Left unchecked, these reach rts.convertInt, which panics -
+// and on the interpret path that conversion runs outside any recovery. We catch
+// them here at the CST level (so it works even when the failed conversion left
+// c.ast nil) and surface a clean diagnostic, which validateSyntax turns into a
+// normal error exit before the panicking conversion is ever reached.
+func (c *RadCheckerImpl) addIntLiteralOutOfRangeErrors(d *[]Diagnostic) {
+	for _, node := range c.tree.FindNodes(rl.K_INT) {
+		_, err := rts.ParseInt(nodeSrc(node, c.src))
+		if err == nil || !errors.Is(err, strconv.ErrRange) {
+			continue
+		}
+		suggestion := "int values must fit in a signed 64-bit integer (max 9223372036854775807). " +
+			"Write the minimum as `-9223372036854775807 - 1`, or use a float for larger magnitudes."
+		*d = append(*d, NewDiagnosticErrorWithSuggestion(
+			node, c.src, "Integer literal is out of range", rl.ErrIntLiteralOutOfRange, &suggestion))
+	}
 }
 
 func (c *RadCheckerImpl) addIntScientificNotationErrors(d *[]Diagnostic) {

--- a/rts/check/error_messages.go
+++ b/rts/check/error_messages.go
@@ -228,6 +228,13 @@ func generateErrorNodeMessage(node *ts.Node, src string) (string, rl.Error, *str
 		return msg, code, suggestion
 	}
 
+	// Heuristic: a multi-line string content line indented less than its
+	// closing `"""`. The indentation rule is intentional, but the bare
+	// "Unexpected ..." gives no hint; surface a targeted message instead.
+	if msg, code, suggestion := checkMultilineStringIndent(node, src); msg != "" {
+		return msg, code, suggestion
+	}
+
 	// Heuristic: `null` in a type union. Other-language users often
 	// reach for `int|null` (TypeScript / Pyright spelling); Rad has a
 	// single canonical form `int?`. Point them at it before they
@@ -708,6 +715,41 @@ func checkUnterminatedQuoteToken(node *ts.Node, src, trimmed string) (string, rl
 	msg := fmt.Sprintf("Unterminated string literal (missing closing %s quote)", quoteName)
 	suggestion := fmt.Sprintf("add closing %c before end of line", quote)
 	return msg, rl.ErrUnterminatedString, &suggestion
+}
+
+// checkMultilineStringIndent recognises a multi-line (triple-quoted) string whose
+// content is indented less than its closing `"""`. Rad strips the closing
+// delimiter's indentation from every content line, so a less-indented line can't
+// be dedented and tree-sitter bails with an ERROR node parented directly by the
+// `string`, wedged between `string_start` and `string_end`. The generic
+// "Unexpected ..." gives no hint about the actual (indentation) rule, so we surface
+// a targeted message. Only the common single-content-line shape is detected; the
+// multi-content-line variant produces a messier CST (the ERROR isn't parented by
+// `string`) and falls through to the generic message.
+func checkMultilineStringIndent(node *ts.Node, src string) (string, rl.Error, *string) {
+	parent := node.Parent()
+	if parent == nil || parent.Kind() != rl.K_STRING {
+		return "", "", nil
+	}
+	endNode := rl.GetChild(parent, rl.F_END)
+	if endNode == nil || endNode.EndByte() > uint(len(src)) {
+		return "", "", nil
+	}
+	// The closing delimiter of a multi-line string sits on its own line, so its
+	// source carries the newline + indentation that precede the `"""`.
+	endText := src[endNode.StartByte():endNode.EndByte()]
+	nl := strings.LastIndexByte(endText, '\n')
+	if nl < 0 {
+		return "", "", nil
+	}
+	closingLine := endText[nl+1:]
+	closingIndent := len(closingLine) - len(strings.TrimLeft(closingLine, " \t"))
+	if int(node.StartPosition().Column) >= closingIndent {
+		return "", "", nil
+	}
+	msg := `Multi-line string content is indented less than its closing """`
+	suggestion := `indent every content line at least as much as the closing """ (or move the closing """ to column 0)`
+	return msg, rl.ErrUnexpectedToken, &suggestion
 }
 
 func checkUnterminatedString(raw, trimmed string) (string, rl.Error, *string) {

--- a/rts/check/snapshot_test.go
+++ b/rts/check/snapshot_test.go
@@ -51,6 +51,8 @@ func TestCheckSnapshots(t *testing.T) {
 		return
 	}
 
+	radtesting.CheckSnapshotUpdateFlags(t)
+
 	var updateMu sync.Mutex
 	filesToUpdate := make(map[string][]radtesting.SnapshotCase)
 
@@ -110,7 +112,7 @@ func TestCheckSnapshots(t *testing.T) {
 				actual := check.DumpForSnapshot(file, result.Types, result.Resolved, result.Diagnostics)
 
 				if actual != tc.Stdout {
-					if *radtesting.UpdateSnapshots {
+					if radtesting.ShouldUpdateSnapshotFile(snapFile) {
 						updateMu.Lock()
 						tc.Stdout = actual
 						filesToUpdate[snapFile] = cases
@@ -129,14 +131,12 @@ func TestCheckSnapshots(t *testing.T) {
 	}
 
 	t.Cleanup(func() {
-		if *radtesting.UpdateSnapshots {
-			for path, cases := range filesToUpdate {
-				err := radtesting.WriteSnapshotFile(path, cases)
-				if err != nil {
-					t.Errorf("Failed to update snapshot file %s: %v", path, err)
-				} else {
-					t.Logf("Updated snapshot file: %s", path)
-				}
+		// filesToUpdate only holds files selected by -update / -update-all.
+		for path, cases := range filesToUpdate {
+			if err := radtesting.WriteSnapshotFile(path, cases); err != nil {
+				t.Errorf("Failed to update snapshot file %s: %v", path, err)
+			} else {
+				t.Logf("Updated snapshot file: %s", path)
 			}
 		}
 	})

--- a/rts/radfmt/snapshot_test.go
+++ b/rts/radfmt/snapshot_test.go
@@ -62,6 +62,8 @@ func TestFmtSnapshots(t *testing.T) {
 		return
 	}
 
+	radtesting.CheckSnapshotUpdateFlags(t)
+
 	var updateMu sync.Mutex
 	filesToUpdate := make(map[string][]radtesting.SnapshotCase)
 
@@ -102,7 +104,7 @@ func TestFmtSnapshots(t *testing.T) {
 				}
 
 				if actual != expected {
-					if *radtesting.UpdateSnapshots {
+					if radtesting.ShouldUpdateSnapshotFile(snapFile) {
 						updateMu.Lock()
 						if raw {
 							tc.Stdout = strconv.Quote(actual)
@@ -134,13 +136,12 @@ func TestFmtSnapshots(t *testing.T) {
 	}
 
 	t.Cleanup(func() {
-		if *radtesting.UpdateSnapshots {
-			for path, cases := range filesToUpdate {
-				if err := radtesting.WriteSnapshotFile(path, cases); err != nil {
-					t.Errorf("Failed to update snapshot file %s: %v", path, err)
-				} else {
-					t.Logf("Updated snapshot file: %s", path)
-				}
+		// filesToUpdate only holds files selected by -update / -update-all.
+		for path, cases := range filesToUpdate {
+			if err := radtesting.WriteSnapshotFile(path, cases); err != nil {
+				t.Errorf("Failed to update snapshot file %s: %v", path, err)
+			} else {
+				t.Logf("Updated snapshot file: %s", path)
 			}
 		}
 	})

--- a/rts/rl/errors.go
+++ b/rts/rl/errors.go
@@ -129,6 +129,7 @@ const (
 	ErrUnreachableCase                  Error = "40012"
 	ErrCaseKeyNotInDiscriminantType     Error = "40013"
 	ErrUnknownMapKey                    Error = "40014"
+	ErrIntLiteralOutOfRange             Error = "40015"
 )
 
 func (e Error) String() string {

--- a/rts/st_test.go
+++ b/rts/st_test.go
@@ -40,6 +40,8 @@ func TestSTSnapshots(t *testing.T) {
 		return
 	}
 
+	radtesting.CheckSnapshotUpdateFlags(t)
+
 	// Track which files need updating (thread-safe since tests run in parallel)
 	var updateMu sync.Mutex
 	filesToUpdate := make(map[string][]radtesting.SnapshotCase)
@@ -89,7 +91,8 @@ func TestSTSnapshots(t *testing.T) {
 					Stderr: astDump,
 				}
 
-				if radtesting.CompareSnapshotResult(t, tc, actual) {
+				updating := radtesting.ShouldUpdateSnapshotFile(snapFile)
+				if radtesting.CompareSnapshotResult(t, tc, actual, updating) && updating {
 					updateMu.Lock()
 					tc.Stdout = actual.Stdout
 					tc.Stderr = actual.Stderr
@@ -102,14 +105,12 @@ func TestSTSnapshots(t *testing.T) {
 
 	// Write updates after all subtests complete
 	t.Cleanup(func() {
-		if *radtesting.UpdateSnapshots {
-			for path, cases := range filesToUpdate {
-				err := radtesting.WriteSnapshotFile(path, cases)
-				if err != nil {
-					t.Errorf("Failed to update snapshot file %s: %v", path, err)
-				} else {
-					t.Logf("Updated snapshot file: %s", path)
-				}
+		// filesToUpdate only holds files selected by -update / -update-all.
+		for path, cases := range filesToUpdate {
+			if err := radtesting.WriteSnapshotFile(path, cases); err != nil {
+				t.Errorf("Failed to update snapshot file %s: %v", path, err)
+			} else {
+				t.Logf("Updated snapshot file: %s", path)
 			}
 		}
 	})


### PR DESCRIPTION
Three independent changes from the bugfixes board, one commit each.

### `fix:` out-of-range int literals no longer panic
An int literal beyond int64 (e.g. `9223372036854775808`) reached the converter and surfaced as a raw Go stack trace. Now flagged statically as **RAD40015** before the panicking conversion is reached. The most-negative int64 still can't be written directly, but errors cleanly with the `-9223372036854775807 - 1` workaround suggested. (Also re-bases the RAD20017 doc example, which leaned on this bug.)

### `fix:` clearer error for under-indented multi-line strings
A content line indented less than its closing `"""` gave the generic `RAD10009: Unexpected ...`. Now emits a targeted message + suggestion for the common case.

### `test:` targeted snapshot `-update`
A bare `-update` rewrote **every** snapshot to match current behavior, silently absorbing unrelated regressions. `-update` now takes path substrings (`-update=types/str_lexing`) and rewrites only matching files; mismatches elsewhere still fail. `-update-all` covers the rare blanket case. Applied across all five snapshot suites; `dev --update` and contributor docs updated.

All tests pass (`go test ./core/testing/... ./rts/... ./radls/lstesting/...`).

Note: `loop-context` (also on the board) was investigated and closed as works-as-intended — loops deliberately don't open scopes per `docs/type_system.md`, so the `with` context persisting is the documented model, not a bug.