### PR TITLE
fix: preserve for-loop with-clause in rad fmt

### DIFF
--- a/rts/radfmt/AGENTS.md
+++ b/rts/radfmt/AGENTS.md
@@ -100,16 +100,23 @@ Three layers guarantee `rad fmt` can never corrupt code:
 1. **Parse-error no-op** - a tree with invalid nodes is returned unchanged
    (`ok=false`).
 2. **Panic recovery** - a panic during formatting degrades to a safe no-op.
-3. **Structural-equivalence guard** - the output is re-parsed and its
-   named-node + comment structure compared to the input; a mismatch discards the
-   formatting and returns the original.
+3. **Structural-equivalence guard** - the output is re-parsed and its structure
+   (named-node kinds + field-bearing anonymous tokens + comment count) compared
+   to the input; a mismatch discards the formatting and returns the original.
 
 A construct with no dedicated formatter falls through to `verbatim`, which
 re-emits its exact source span - always safe, just not canonicalized. This is
 what lets us grow rules incrementally. **The structural guard compares node
-kinds, not text**, so a rule that rewrites token *content* (e.g. string quote
-normalization, F30) needs its own value-preservation check and tests - that's
-why F30 is deferred.
+kinds (and field-attached token kinds), not arbitrary text**, so a rule that
+rewrites token *content* (e.g. string quote normalization, F30) needs its own
+value-preservation check and tests - that's why F30 is deferred.
+
+The guard records a *field-bearing* anonymous token (`field=kind`) - the
+for-loop `with <ctx>` identifier, `?`/`*` markers, keyword choices like
+defer/errdefer, operators - so a formatter can no longer silently drop an
+optional clause realized as a bare token (that was issue #144). It still ignores
+*fieldless* punctuation (commas, colons, brackets), preserving the freedom to
+canonicalize a trailing comma.
 
 ## Layout
 

--- a/rts/radfmt/RULES.md
+++ b/rts/radfmt/RULES.md
@@ -142,6 +142,16 @@ Code: `print_stmt.go` `formatIf`
 `for i,x in items:` → `for i, x in items:`
 Code: `print_stmt.go` `formatFor`
 
+### F43 - For-loop with-context clause `implemented`
+The optional `with <ctx>` loop-context clause is preserved, single-spaced before
+`with` and after it. The clause names the variable a loop body reads (`ctx.idx`,
+`ctx.src`), so dropping it silently breaks the script - the bug behind #144. The
+context is a bare identifier token, invisible to the named-node structural guard,
+which is why it needs an explicit rule (and why the guard now records
+field-bearing tokens; see `AGENTS.md`).
+`for x in xs  with  loop:` → `for x in xs with loop:`
+Code: `print_stmt.go` `formatFor`
+
 ### F19 - While loop `implemented`
 `while <cond>:`, body indented.
 Code: `print_stmt.go` `formatWhile`

--- a/rts/radfmt/print_stmt.go
+++ b/rts/radfmt/print_stmt.go
@@ -144,9 +144,11 @@ func (p *printer) formatClause(prefix string, alt *ts.Node, leadingBreak bool) D
 	return clause
 }
 
-// formatFor formats `for x in expr:` (and `for i, x in expr:`).
+// formatFor formats `for x in expr:` (and `for i, x in expr:`), preserving the
+// optional `with <ctx>` loop-context clause.
 //
 // [F18] for loop: ", " between loop vars, " in ", header ends in `:`
+// [F43] for loop: keep the optional `with <ctx>` clause
 func (p *printer) formatFor(n *ts.Node) Doc {
 	lefts := childByField(n, rl.F_LEFTS)
 	right := childByField(n, rl.F_RIGHT)
@@ -154,6 +156,11 @@ func (p *printer) formatFor(n *ts.Node) Doc {
 		return p.verbatim(n)
 	}
 	header := concat(text("for "), p.formatForLefts(lefts), text(" in "), p.formatExpr(right))
+	// The context is a bare identifier token (not a named expr), so emit its
+	// source text directly - mirroring how formatForLefts handles loop vars.
+	if ctx := childByField(n, rl.F_CONTEXT); ctx != nil {
+		header = concat(header, text(" with "), text(p.nodeText(ctx)))
+	}
 	return concat(header, p.blockTail(n))
 }
 

--- a/rts/radfmt/roundtrip_test.go
+++ b/rts/radfmt/roundtrip_test.go
@@ -1,0 +1,80 @@
+package radfmt
+
+import (
+	"testing"
+
+	gd "github.com/amterp/go-delta"
+)
+
+// TestRoundTripOptionalClauses is a property test for the class of bug behind
+// issue #144: a formatter silently dropping an optional clause that the grammar
+// realizes as a bare (anonymous) token. For a spread of productions that carry
+// such tokens, it asserts the parse -> fmt -> parse round-trip preserves the
+// code structure - now including field-bearing anonymous tokens, since that is
+// the dimension the old structural guard was blind to (see safety.go).
+//
+// The for-loop `with <ctx>` clause is the live case: drop it and the dump loses
+// `context: identifier (token)`, failing here.
+//
+// Two kinds of case below. The "exercised" group feeds deliberately messy input
+// through an implemented formatter, so the formatter actually rewrites the source
+// and the round-trip proves the rewrite preserved structure (the real test). The
+// "verbatim lock" group covers constructs with no formatter yet (defer):
+// formatRaw returns them byte-for-byte, so they pass trivially today - they exist
+// to (a) assert the strengthened guard doesn't false-positive on these
+// field-bearing tokens and (b) fail loudly the day one graduates to a real
+// formatter that drops a clause. When that day comes, give the case messy input
+// so it joins the exercised group. Inputs are valid Rad drawn from the syntax
+// snapshot corpus (rts/test/st_snapshots).
+func TestRoundTripOptionalClauses(t *testing.T) {
+	cases := []struct {
+		name string
+		src  string
+	}{
+		// --- Exercised: messy input an implemented formatter must rewrite. ---
+		// For-loop context clause - the #144 bug and its keyed variant.
+		{"for_with_context", "for item in items  with  ctx:\n    print(ctx.idx, item)\n"},
+		{"keyed_for_with_context", "for k,v in m with ctx:\n    print(ctx.idx, k, v)\n"},
+		{"for_no_context", "for  item  in  items:\n    print(item)\n"},
+		// Operators and markers are all anonymous field-bearing tokens.
+		{"ternary", "y = a?b:c\n"},
+		{"binary_ops", "z = 1+2*3 and a or b\n"},
+		{"unary_ops", "z = not  a\nw = -  b\n"},
+		{"compound_and_incr", "x+=1\ni++\n"},
+		{"typed_assign", "x:int=1\n"},
+		// list_comprehension is verbatim, but the surrounding assign is formatted,
+		// so messy `=` spacing makes this a real round-trip over a verbatim subtree.
+		{"list_comprehension", "area=[width[i] * height[i] for i in range(width)]\n"},
+		// Optional `?` marker on an arg declaration - the args formatter tightens
+		// the spacing, so the round-trip proves the marker survives that rewrite.
+		{"args_optional_marker", "args:\n    count   int ?\n"},
+
+		// --- Verbatim locks: no formatter yet, so these are no-ops today. ---
+		// defer vs errdefer share the `defer_block` kind, distinguished only by the
+		// bare keyword token the strengthened guard now records.
+		{"defer_keyword", "defer print(1)\n"},
+		{"errdefer_keyword", "errdefer print(2)\n"},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			src := normalizeLineEndings(tc.src)
+			raw, _, _, ok := formatRaw(src)
+			if !ok {
+				t.Fatalf("input failed to parse cleanly: %s", tc.name)
+			}
+			before := dumpStructure(t, src)
+			after := dumpStructure(t, raw)
+			if before != after {
+				t.Errorf("parse -> fmt -> parse changed structure for %s:\n%s",
+					tc.name,
+					gd.DiffWith(before, after,
+						gd.WithColor(true),
+						gd.WithLayout(gd.LayoutPreferSideBySide),
+						gd.WithWidth(120)))
+			}
+		})
+	}
+}

--- a/rts/radfmt/safety.go
+++ b/rts/radfmt/safety.go
@@ -8,12 +8,23 @@ import (
 )
 
 // structuralSig builds a fingerprint of a tree's *code* structure: the kinds and
-// field names of every named node, in pre-order. It deliberately ignores
-// anonymous punctuation tokens (so a canonical trailing comma is allowed),
-// string quote characters (a string node is a string node regardless of quote),
-// whitespace, and positions. Comments are excluded here and counted separately,
-// since formatting may legitimately move a comment but must never drop one or
-// change what the code parses to.
+// field names of every named node, plus every anonymous token that carries a
+// field name, in pre-order. It deliberately ignores *fieldless* anonymous
+// punctuation tokens (so a canonical trailing comma is allowed), string quote
+// characters (a string node is a string node regardless of quote), whitespace,
+// and positions. Comments are excluded here and counted separately, since
+// formatting may legitimately move a comment but must never drop one or change
+// what the code parses to.
+//
+// A field-bearing anonymous token is semantically load-bearing - the for-loop
+// `with <ctx>` identifier, `?`/`*` arg markers, keyword choices like
+// defer/errdefer or quiet/confirm, and operators - so its presence and kind are
+// recorded (`field=kind`). This is what stops a construct formatter from
+// silently dropping such a clause: doing so changes the signature and trips the
+// equivalence guard. Recording the kind (the literal, for keyword tokens) also
+// catches a swap where the choice rides on the token rather than the node kind:
+// `defer` and `errdefer` are one `defer_block` kind distinguished only by their
+// `keyword` token, so without this the named-node path alone can't tell them apart.
 func structuralSig(n *ts.Node) (sig string, comments int) {
 	var sb strings.Builder
 	var walk func(field string, n *ts.Node)
@@ -22,7 +33,13 @@ func structuralSig(n *ts.Node) (sig string, comments int) {
 			comments++
 			return
 		}
-		if n.IsNamed() {
+		// Record named nodes and field-bearing anonymous tokens alike, each
+		// opening a `(...)` group so its children nest under it (a flat encoding
+		// would let a child of an anonymous token masquerade as its sibling).
+		// Fieldless anonymous punctuation is skipped but still recursed through,
+		// keeping trailing-comma-style canonicalization invisible to the guard.
+		record := n.IsNamed() || field != ""
+		if record {
 			if field != "" {
 				sb.WriteString(field)
 				sb.WriteByte('=')
@@ -35,7 +52,7 @@ func structuralSig(n *ts.Node) (sig string, comments int) {
 		for i, ch := range n.Children(cursor) {
 			walk(n.FieldNameForChild(uint32(i)), &ch)
 		}
-		if n.IsNamed() {
+		if record {
 			sb.WriteByte(')')
 		}
 	}
@@ -44,10 +61,12 @@ func structuralSig(n *ts.Node) (sig string, comments int) {
 }
 
 // structuralDump renders a readable, position-free tree of named node kinds and
-// their field names (comments shown as a normalized marker). It's the
-// human-friendly twin of structuralSig: tests diff the dump of the input against
+// their field names, plus field-bearing anonymous tokens (comments shown as a
+// normalized marker). It's the human-friendly twin of structuralSig - it records
+// exactly what the signature does - so tests diff the dump of the input against
 // the dump of the formatted output to prove formatting never changed the code's
-// structure, with a clear side-by-side failure.
+// structure (including dropped optional clauses), with a clear side-by-side
+// failure.
 func structuralDump(n *ts.Node) string {
 	var sb strings.Builder
 	var walk func(depth int, field string, n *ts.Node)
@@ -57,13 +76,20 @@ func structuralDump(n *ts.Node) string {
 			sb.WriteString("<comment>\n")
 			return
 		}
-		if n.IsNamed() {
+		// Mirror structuralSig: named nodes and field-bearing anonymous tokens
+		// both print a line and indent their children; fieldless punctuation is
+		// skipped. Anonymous tokens get a `(token)` marker so the dump reads
+		// clearly.
+		if n.IsNamed() || field != "" {
 			sb.WriteString(strings.Repeat("  ", depth))
 			if field != "" {
 				sb.WriteString(field)
 				sb.WriteString(": ")
 			}
 			sb.WriteString(n.Kind())
+			if !n.IsNamed() {
+				sb.WriteString(" (token)")
+			}
 			sb.WriteByte('\n')
 			depth++
 		}

--- a/rts/radfmt/snapshots/control_flow.snap
+++ b/rts/radfmt/snapshots/control_flow.snap
@@ -31,6 +31,22 @@ for i,x in items:
 for i, x in items:
     print(x)
 ### TITLE ###
+[F43] For loop with context clause
+### INPUT ###
+for x in [1,2,3]  with  loop:
+    print(loop.idx)
+### STDOUT ###
+for x in [1, 2, 3] with loop:
+    print(loop.idx)
+### TITLE ###
+[F43] Keyed for loop with context clause
+### INPUT ###
+for k,v in m with loop:
+    print(loop.idx, k, v)
+### STDOUT ###
+for k, v in m with loop:
+    print(loop.idx, k, v)
+### TITLE ###
 [F19] While loop
 ### INPUT ###
 while x:


### PR DESCRIPTION
Closes #144.

## The bug

`rad fmt` silently rewrote `for x in xs with loop:` to `for x in xs:`, deleting the loop-context variable. The output stayed valid, well-formed Rad, so `--check`/CI never flagged it - the breakage only surfaced at runtime as `Undefined identifier 'loop'`. For a formatter, changing program behavior while reporting success is the worst failure mode. The reporter hit it on 2 of 23 real scripts.

## Root cause (two layers)

1. **The drop.** `formatFor` rebuilt the loop header from the `lefts`/`right` fields but never read the optional `context` field.
2. **Why the safety net missed it.** `Format`'s last line of defense re-parses the output and compares a structural signature (`structuralSig` in `safety.go`). It only recorded **named** nodes - but the `with` variable is an **anonymous** `identifier` token (`for_loop.context` is `"named": false` in the grammar), so it was invisible to the signature. Dropping it produced an identical fingerprint and the guard waved it through. This blind spot covered *every* field-attached anonymous token (the `with` context, `defer`/`errdefer`, shell `quiet`/`confirm`, arg `?`/`*` markers, operators); they were safe only because their constructs are still emitted verbatim.

## The fix

- **`print_stmt.go`** - `formatFor` now emits the optional `with <ctx>` clause (keyed and unkeyed forms). New rule **F43**.
- **`safety.go`** - the structural guard now also records **field-bearing anonymous tokens** (`field=kind`, properly nested), while still ignoring *fieldless* punctuation so trailing-comma canonicalization stays free. This closes the whole class at the runtime guard, not just the one instance - and even degrades a context-dropping format to a safe no-op on its own. Recording the kind also gives swap-detection (`defer` vs `errdefer`, which share one node kind).
- **Tests** - F43 regression snapshots (both loop forms) plus a new `roundtrip_test.go` property test asserting `parse -> fmt -> parse` preserves structure across optional-clause productions (the approach suggested in the issue).
- **Docs** - rule F43 in `RULES.md`; updated safety-model note in `AGENTS.md`.

## Verification

- `go test ./rts/...` green; rule-coverage lockstep accepts F43.
- Proved the strengthened guard works: reverting the `formatFor` fix makes the round-trip test fail with a clear `- context: identifier (token)` diff, and `Format` degrades to a safe no-op (`ok=false`, output unchanged) instead of corrupting.
- End-to-end: `rad fmt` on the issue's repro preserves `with loop` (keyed and unkeyed), and the formatted scripts run with no `RAD20028`.
